### PR TITLE
Add "flags" param to codecov

### DIFF
--- a/vars/codecov.groovy
+++ b/vars/codecov.groovy
@@ -5,6 +5,7 @@ https://github.com/docker/jenkins-pipeline-scripts/blob/master/vars/codecov.groo
 def call(Map params = [:]){
   def repo = params?.repo
   def basedir = params.containsKey('basedir') ? params.basedir : "."
+  def flags = params.containsKey("flags") ? params.flags : ""
   
   if(!repo){
     log(level: 'WARN', text: "Codecov: No repository specified.")
@@ -32,11 +33,11 @@ def call(Map params = [:]){
         "ghprbPullId=${env.CHANGE_ID}",
         "GIT_BRANCH=${branchName}",
         "CODECOV_TOKEN=${token}"]) {
-        sh '''#!/bin/bash
+        sh """#!/bin/bash
         set -x
         curl -s -o codecov.sh https://codecov.io/bash
-        bash codecov.sh || echo "codecov exited with $?"
-        '''
+        bash codecov.sh ${flags} || echo "codecov exited with \$?"
+        """
       }
     }
   }

--- a/vars/codecov.txt
+++ b/vars/codecov.txt
@@ -5,6 +5,7 @@ codecov(basedir: "${WORKSPACE}", repo: 'apm-agent-go')
 ```
 *repo*: The repository name (for example apm-agent-go), it is needed
 *basedir*: the folder to search into (the default value is '.').
+*flags*: a string holding arbitrary flags to pass to the codecov bash script
 
 It requires to initialise the pipeline with github_enterprise_constructor() first.
 


### PR DESCRIPTION
Add a flags param which will be passed to the codecov bash
script command line. This enables specifying the report files,
for example.