### PR TITLE
[APM-CI] Implement a withSecretVault step

### DIFF
--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -1,27 +1,40 @@
 #!/usr/bin/env groovy
 
 /**
-  Grab a secret from the vault, define some environment variables with the
-  secrets and mask the secrets
+  Grab a secret from the vault, define the environment variables which have been
+  passed as parammeters and mask the secrets
 
-  withSecretVault(secret: 'secret', data: [APP_USER: 'my_variable', APP_PASSWORD: 'my_password']){
+  withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: 'my_password_env'){
     //block
   }
 */
 def call(Map params = [:], Closure body) {
-  def secret = params.get('secret')
-  def user_variable = params.get('data').get('APP_USER')
-  def pass_variable = params.get('data').get('APP_PASSWORD')
+  def secret = params?.secret
+  def user_variable = params?.user_var_name
+  def pass_variable = params?.pass_var_name
 
-  def jsonValue = getVaultSecret(secret: "${secret}")
+  if (!secret || !user_variable || !pass_variable) {
+    error "withSecretVault: Missing variables"
+  }
+
+  def props = getVaultSecret(secret)
+  if(props?.errors){
+    error "withSecretVault: Unable to get credentials from the vault: " + props.errors.toString()
+  }
+
+  def user = props?.data?.user
+  def password = props?.data?.password
+
+  if(user == null || password == null){
+    error "withSecretVault: was not possible to get authentication info"
+  }
+
   wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [
-        [var: "${user_variable}", password: jsonValue.data.user],
-        [var: "${pass_variable}", password: jsonValue.data.password],
+        [var: "${user_variable}", password: user],
+        [var: "${pass_variable}", password: password],
   ]]) {
-    withEnv([
-      "${user_variable}=${jsonValue.data.user}",
-      "APP_PASSWORD=${jsonValue.data.password}"]) {
-        body()
+    withEnv(["${user_variable}=${user}", "${pass_variable}=${password}"]) {
+      body()
     }
   }
 }

--- a/vars/withSecretVault.txt
+++ b/vars/withSecretVault.txt
@@ -1,5 +1,5 @@
-Grab a secret from the vault, define some environment variables with the
-secrets and mask the secrets
+Grab a secret from the vault, define the environment variables which have been
+passed as parameters and mask the secrets
 
 the secret must have this format
 `{ data: { user: 'username', password: 'user_password'} }``
@@ -7,7 +7,7 @@ the secret must have this format
 The passed data variables will be exported and masked on logs
 
 ```
-withSecretVault(secret: 'secret', data: [APP_USER: 'my_variable', APP_PASSWORD: 'my_password']){
+withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: 'my_password_env'){
   //block
 }
 ```


### PR DESCRIPTION
Closes https://github.com/elastic/apm-dev/issues/532

## Highlights
- Support withSecretVault step to encapsulate the mask wrapper and the env variable generation
- UTs

## Tasks 
- [x] Test shared library locally
- [x] Test shared library within apm-ci. See [here](https://apm-ci.elastic.co/job/apm-shared/job/apm-apm-pipeline-library-mbp/job/test%252Fapm-dev-532/4/console)
- [x] Remove branch: [test/apm-dev-532](https://github.com/elastic/apm-pipeline-library/tree/test/apm-dev-532) which was created for testing purposes.

## Test Cases
### APM-ci
- Snippet
```
stage('withSecretVault') {
  steps {
    sh 'echo "${USER_VAR} IS UNSET"'
    sh 'echo "${PASS_VAR} IS UNSET"'
    withSecretVault(secret: 'apm-agent-python-twine', user_var_name: 'USER_VAR', pass_var_name: 'PASS_VAR'){
      sh 'echo "${USER_VAR} HAS BEEN CREATED"'
      sh 'echo "${PASS_VAR} HAS BEEN CREATED"'
    }
  }
}
```
- Log output
![image](https://user-images.githubusercontent.com/2871786/57388975-3131ad00-71b1-11e9-9f31-509fbd189608.png)

### Locally
- Code
```
node {
    ansiColor('xterm') {
        sh 'echo "${USER_VAR} IS UNSET"'
        sh 'echo "${PASS_VAR} IS UNSET"'
        withSecretVault(secret: 'test', user_var_name: 'USER_VAR', pass_var_name: 'PASS_VAR') {
            sh 'echo "${USER_VAR} HAS BEEN CREATED"'
            sh 'echo "${PASS_VAR} HAS BEEN CREATED"'
        }
    }
}
```
- Output
```
[Pipeline] sh
+ echo  IS UNSET
 IS UNSET
[Pipeline] sh
+ echo  IS UNSET
 IS UNSET
[Pipeline] wrap
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] sh
+ echo ******** HAS BEEN CREATED
******** HAS BEEN CREATED
[Pipeline] sh
+ echo ******** HAS BEEN CREATED
******** HAS BEEN CREATED
[Pipeline] }
```

![image](https://user-images.githubusercontent.com/2871786/57383705-27a34780-71a7-11e9-9103-035960cd2660.png)

