### PR TITLE
fix: avoid showing 'null' on the email subject when BRANCH_NAME is not defined

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -81,7 +81,7 @@ def notifyEmail(Map params = [:]) {
       ]);
 
       mail(to: emailRecipients.join(","),
-        subject: "${icon} ${buildStatus} ${env.JOB_NAME}#${env.BRANCH_NAME} ${env.BUILD_NUMBER}",
+        subject: "${icon} ${buildStatus} ${env.JOB_NAME}#${env.BRANCH_NAME ? env.BRANCH_NAME : ''} ${env.BUILD_NUMBER}",
         body: body,
         mimeType: 'text/html'
       );


### PR DESCRIPTION
avoid showing 'null' on the email subject when BRANCH_NAME is not defined