### PR TITLE
fix: change deprecated call to getVaultSecrets to the current

### DIFF
--- a/src/test/groovy/WithSecretVaultStepTests.groovy
+++ b/src/test/groovy/WithSecretVaultStepTests.groovy
@@ -75,7 +75,8 @@ class WithSecretVaultStepTests extends BasePipelineTest {
       updateBuildStatus('FAILURE')
       throw new Exception(s)
     })
-    helper.registerAllowedMethod("getVaultSecret", [String.class], { s ->
+    helper.registerAllowedMethod("getVaultSecret", [Map.class], { m ->
+      def s = m.secret
       if("secret".equals(s)){
         return [data: [ user: 'username', password: 'user_password']]
       }

--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -32,7 +32,7 @@ def call(Map params = [:], Closure body) {
     error "withSecretVault: Missing variables"
   }
 
-  def props = getVaultSecret(secret)
+  def props = getVaultSecret(secret: secret)
   if(props?.errors){
     error "withSecretVault: Unable to get credentials from the vault: " + props.errors.toString()
   }


### PR DESCRIPTION
the call `getVaultSecret(secret)` is deprecated and only works with APM Vault secrets, so I changed it to the good one. This probably needs an update in the pipelines that use withSecretVault step.