### PR TITLE
ci: Cache Oracle Instant Client Docker Image

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -48,6 +48,7 @@ pipeline {
     string(name: 'secret', defaultValue: "secret/apm-team/ci/docker-registry/prod", description: "")
     booleanParam(name: 'python', defaultValue: "false", description: "")
     booleanParam(name: 'weblogic', defaultValue: "false", description: "")
+    booleanParam(name: 'oracle_instant_client', defaultValue: "false", description: "")
     booleanParam(name: 'apm_integration_testing', defaultValue: "false", description: "")
     booleanParam(name: 'helm_kubectl', defaultValue: "false", description: "")
     booleanParam(name: 'jruby', defaultValue: "false", description: "")
@@ -56,6 +57,7 @@ pipeline {
     stage('Cache Weblogic Docker Image'){
       agent { label 'immutable && docker' }
       environment {
+        IMAGE_TAG = "store/oracle/weblogic:12.2.1.3-dev"
         TAG_CACHE = "${params.registry}/${params.tag_prefix}/weblogic:12.2.1.3-dev"
         HOME = "${env.WORKSPACE}"
       }
@@ -64,18 +66,22 @@ pipeline {
         expression { return params.weblogic }
       }
       steps {
-        script{
-          dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-          sh(label: 'pull Docker image', script: "docker pull store/oracle/weblogic:12.2.1.3-dev")
-          sh "export"
-          sh "ls -la ${JENKINS_HOME}"
-          sh "cp /var/lib/jenkins/packer_cache* ."
-          archiveArtifacts 'packer_cache*'
-
-          dockerLoginElasticRegistry()
-          sh(label: 're-tag Docker image', script: "docker tag store/oracle/weblogic:12.2.1.3-dev ${TAG_CACHE}")
-          sh(label: "push Docker image to ${TAG_CACHE}", script: "docker push ${TAG_CACHE}")
-        }
+        pushDockerImageFromStore("${IMAGE_TAG}", "${TAG_CACHE}")
+      }
+    }
+    stage('Cache Oracle Instant Client Docker Image'){
+      agent { label 'immutable && docker' }
+      environment {
+        IMAGE_TAG = "store/oracle/database-instantclient:12.2.0.1"
+        TAG_CACHE = "${params.registry}/${params.tag_prefix}/database-instantclient:12.2.0.1"
+        HOME = "${env.WORKSPACE}"
+      }
+      when{
+        beforeAgent true
+        expression { return params.oracle_instant_client }
+      }
+      steps {
+        pushDockerImageFromStore("${IMAGE_TAG}", "${TAG_CACHE}")
       }
     }
     stage('Build agent Python images'){
@@ -215,4 +221,12 @@ def buildDockerImage(args){
       }
     }
   }
+}
+
+def pushDockerImageFromStore(imageTag, cacheTag){
+  dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
+  sh(label: 'pull Docker image', script: "docker pull ${imageTag}")
+  dockerLoginElasticRegistry()
+  sh(label: 're-tag Docker image', script: "docker tag ${imageTag} ${cacheTag}")
+  sh(label: "push Docker image to ${cacheTag}", script: "docker push ${cacheTag}")
 }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -52,6 +52,7 @@ pipeline {
             string(name: 'secret', value: 'secret/apm-team/ci/docker-registry/prod'),
             booleanParam(name: 'python', value: true),
             booleanParam(name: 'weblogic', value: true),
+            booleanParam(name: 'oracle_instant_client', value: true),
             booleanParam(name: 'apm_integration_testing', value: true),
             booleanParam(name: 'helm_kubectl', value: true),
             booleanParam(name: 'jruby', value: true),


### PR DESCRIPTION
put Oracle Instant Client Docker Image in the docker.elastic.co registry