### PR TITLE
fix: githubNotify when success should not happen when notify is disabled

### DIFF
--- a/src/test/groovy/GitCheckoutStepTests.groovy
+++ b/src/test/groovy/GitCheckoutStepTests.groovy
@@ -280,4 +280,17 @@ class GitCheckoutStepTests extends BasePipelineTest {
     })
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testWithFirstTimeContributorWithoutNotify() throws Exception {
+    def script = loadScript(scriptName)
+    env.BRANCH_NAME = "BRANCH"
+    script.scm = "SCM"
+    script.call(basedir: 'sub-folder', githubNotifyFirstTimeContributor: false)
+    printCallStack()
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == "githubNotify"
+    }.size() == 0 )
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -74,7 +74,9 @@ def call(Map params = [:]){
     if(!isUserTrigger() && !isCommentTrigger()){
       try {
         githubPrCheckApproved()
-        githubNotify(context: 'First time contributor', status: 'SUCCESS', targetUrl: ' ')
+        if (notify) {
+          githubNotify(context: 'First time contributor', status: 'SUCCESS', targetUrl: ' ')
+        }
       } catch(err) {
         if (notify) {
           githubNotify(context: 'First time contributor', description: 'It requires manual inspection', status: 'FAILURE', targetUrl: ' ')


### PR DESCRIPTION
### Highlights
- Minor change to avoid notifying when the parameter is false. 
- A cosmetic change as it does only report when it's a success and it should not.