### PR TITLE
ci: disable SCM trigger for Observability test environments jobs

### DIFF
--- a/.ci/jobs/observability-test-environments-mbp.yml
+++ b/.ci/jobs/observability-test-environments-mbp.yml
@@ -20,13 +20,9 @@
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         clean:
           after: true
           before: true

--- a/.ci/jobs/observability-test-environments-update-mbp.yml
+++ b/.ci/jobs/observability-test-environments-update-mbp.yml
@@ -20,13 +20,9 @@
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         clean:
           after: true
           before: true


### PR DESCRIPTION
disable SCM trigger for Observability test environments jobs