### PR TITLE
feat: retry in case vault is not reachable

### DIFF
--- a/src/test/groovy/GetVaultSecretStepTests.groovy
+++ b/src/test/groovy/GetVaultSecretStepTests.groovy
@@ -80,6 +80,11 @@ class GetVaultSecretStepTests extends BasePipelineTest {
       def script = loadScript("vars/toJSON.groovy")
       return script.call(s)
       })
+    helper.registerAllowedMethod("retry", [Integer.class, Closure.class], { i, c ->
+      c.call()
+    })
+    helper.registerAllowedMethod("randomNumber", [Map.class], { m -> return m.min })
+    helper.registerAllowedMethod("sleep", [Integer.class], { 'OK' })
   }
 
   @Test

--- a/vars/getVaultSecret.groovy
+++ b/vars/getVaultSecret.groovy
@@ -49,8 +49,11 @@ def readSecret(secret){
     string(credentialsId: 'vault-addr', variable: 'VAULT_ADDR'),
     string(credentialsId: 'vault-role-id', variable: 'VAULT_ROLE_ID'),
     string(credentialsId: 'vault-secret-id', variable: 'VAULT_SECRET_ID')]) {
-    def token = getVaultToken(env.VAULT_ADDR, env.VAULT_ROLE_ID, env.VAULT_SECRET_ID)
-    props = getVaultSecretObject(env.VAULT_ADDR, secret, token)
+    retry(2) {
+      sleep randomNumber(min: 5, max: 10)
+      def token = getVaultToken(env.VAULT_ADDR, env.VAULT_ROLE_ID, env.VAULT_SECRET_ID)
+      props = getVaultSecretObject(env.VAULT_ADDR, secret, token)
+    }
     //we do not have permissions to revoke a token.
     //revokeToken(env.VAULT_ADDR, token)
   }


### PR DESCRIPTION
I've just seen an issue when the vault service is not accessible

```
12:08:05  [INFO] getVaultSecret: Getting secrets
12:08:05  [Pipeline] withCredentials
12:08:05  Masking supported pattern matches of $VAULT_ADDR or $VAULT_ROLE_ID or $VAULT_SECRET_ID
12:08:05  [Pipeline] {
12:16:16  [Pipeline] }
12:16:16  [Pipeline] // withCredentials
12:16:16  [Pipeline] }
12:16:16  [Pipeline] // stage
12:16:16  [Pipeline] }
12:16:16  [Pipeline] // node
12:16:16  [Pipeline] }
12:16:16  [Pipeline] // script
12:16:16  Error when executing always post condition:
12:16:16  java.lang.Exception: httpRequest: Failure connecting to the service https://secrets.elastic.co:8200/v1/auth/approle/login : Connection timed out (Connection timed out)
12:16:16  	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
12:16:16  	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
12:16:16  	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
12:16:16  	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
12:16:16  	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:83)
12:16:16  	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:77)
12:16:16  	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:84)
12:16:16  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
12:16:16  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
12:16:16  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:247)
12:16:16  	at httpRequest.call(httpRequest.groovy:75)
12:16:16  	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
12:16:16  	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
12:16:16  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:16:16  	at java.lang.reflect.Method.invoke(Method.java:498)
12:16:16  	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
12:16:16  	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
12:16:16  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213)
12:16:16  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
12:16:16  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:810)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:114)
12:16:16  	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
12:16:16  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
12:16:16  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
12:16:16  	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
12:16:16  	at getVaultSecret.getVaultToken(getVaultSecret.groovy:61)
12:16:16  	at getVaultSecret.readSecret(getVaultSecret.groovy:52)
12:16:16  	at ___cps.transform___(Native Method)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:57)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:109)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:82)
12:16:16  	at sun.reflect.GeneratedMethodAccessor845.invoke(Unknown Source)
12:16:16  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:16:16  	at java.lang.reflect.Method.invoke(Method.java:498)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
12:16:16  	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55)
12:16:16  	at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45)
12:16:16  	at sun.reflect.GeneratedMethodAccessor848.invoke(Unknown Source)
12:16:16  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:16:16  	at java.lang.reflect.Method.invoke(Method.java:498)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:103)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:82)
12:16:16  	at sun.reflect.GeneratedMethodAccessor845.invoke(Unknown Source)
12:16:16  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:16:16  	at java.lang.reflect.Method.invoke(Method.java:498)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:60)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:109)
12:16:16  	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:82)
12:16:16  	at sun.reflect.GeneratedMethodAccessor845.invoke(Unknown Source)
12:16:16  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:16:16  	at java.lang.reflect.Method.invoke(Method.java:498)
12:16:16  	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
12:16:16  	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
12:16:16  	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
12:16:16  	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
12:16:16  	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
12:16:16  	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129)
12:16:16  	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268)
12:16:16  	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:186)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:370)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$200(CpsThreadGroup.java:93)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:282)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:270)
12:16:16  	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:64)
12:16:16  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
12:16:16  	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:131)
12:16:16  	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
12:16:16  	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
12:16:16  	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
12:16:16  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
12:16:16  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
12:16:16  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
12:16:16  	at java.lang.Thread.run(Thread.java:748)
```

So this is a proposal to make the pipeline more resilience in case the service is temporarily down for whatever reason

## Highlights
- Sleep between 5 to 10 seconds
- Retry twice

## Questions
- Not sure how to implement that particular test case scenario where the first time failed and second one was ok. 