### PR TITLE
fix the deploy as it was done previously

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,16 +101,12 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-    <pluginManagement>
-       <plugins>
-           <plugin>
-               <artifactId>maven-deploy-plugin</artifactId>
-               <configuration>
-                   <skip>true</skip>
-               </configuration>
-           </plugin>
-       </plugins>
-   </pluginManagement>
 </project>


### PR DESCRIPTION
https://github.com/elastic/apm-pipeline-library/commit/7351f980e43f31788494ad970f3360bc56e02fc8

I thought I managed to test it out with the PR: https://github.com/elastic/apm-pipeline-library/pull/90 when running `mvn release:prepare` but I missed the `mvn release:perform` :(