### PR TITLE
disable opbeans-dotnet build images generation

### DIFF
--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -58,6 +58,10 @@ pipeline {
         stage('Opbeans-dotnet') {
           agent { label 'docker' }
           options { skipDefaultCheckout() }
+          /** FIXME disable until 7.4 is not released */
+          when {
+            expression { return false }
+          }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-dotnet.git',
               tag: "opbeans-dotnet",


### PR DESCRIPTION
opbeans-dotnet docker images are broken as long as no release is out. Let's disable the generation from the pipeline for the sake of our mind