### PR TITLE
fix net.sf.json.JSONNull.trim()

### DIFF
--- a/resources/groovy-html-custom.template
+++ b/resources/groovy-html-custom.template
@@ -122,7 +122,7 @@
       <tr>
         <td colspan="5" style="vertical-align: middle; font-family: Helvetica; font-size: 24px; color: #343B49; letter-spacing: 1px; line-height: 30px;overflow: hidden;word-break: break-word;">
           ${jenkinsText}</br>
-          ${build?.description?.trim() && build?.description != 'null' ?: ''}
+          ${build?.description != null && build?.description != 'null' ? build?.description : ''}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Leave it as it used to be:
- https://github.com/elastic/apm-pipeline-library/pull/130#discussion_r303855266

Class: http://json-lib.sourceforge.net/apidocs/net/sf/json/JSONNull.html

```
04:34:51  groovy.lang.MissingMethodException: No signature of method: net.sf.json.JSONNull.trim() is applicable for argument types: () values: []
04:34:51  Possible solutions: wait(), grep(), wait(long), write(java.io.Writer), grep(java.lang.Object), print(java.io.PrintWriter)
04:34:51  Caused: groovy.text.TemplateExecutionException: Template execution error at line 125:
04:34:51         124:           ${jenkinsText}</br>
04:34:51     --> 125:           ${build?.description?.trim() && build?.description != 'null' ?: ''}
04:34:51         126:         </td>
```

## Tasks
- [ ] Need to be tested