### PR TITLE
fix: grab the real version name from artifactory before push

### DIFF
--- a/resources/scripts/pushDockerImages.sh
+++ b/resources/scripts/pushDockerImages.sh
@@ -32,6 +32,8 @@ PREFIX=${2:-}
 PUSH_VERSION=${3:-"daily"}
 REGISTRY=${4:-"docker.elastic.co"}
 
+VERSION=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/latest"|jq .build.version)
+
 for image in elasticsearch/elasticsearch kibana/kibana apm/apm-server beats/auditbeat beats/filebeat beats/heartbeat beats/metricbeat beats/packetbeat
 do
   IMAGE_SHORT=${image#*/}


### PR DESCRIPTION
it is not possible to push images with the alias, the script needs the 3 coordinates, so we get them from the Artifact.