### PR TITLE
fix: we have to use the raw output of jq

### DIFF
--- a/resources/scripts/pushDockerImages.sh
+++ b/resources/scripts/pushDockerImages.sh
@@ -32,7 +32,7 @@ PREFIX=${2:-}
 PUSH_VERSION=${3:-"daily"}
 REGISTRY=${4:-"docker.elastic.co"}
 
-VERSION=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/latest"|jq .build.version)
+VERSION=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/latest"|jq -r .build.version)
 
 for image in elasticsearch/elasticsearch kibana/kibana apm/apm-server beats/auditbeat beats/filebeat beats/heartbeat beats/metricbeat beats/packetbeat
 do


### PR DESCRIPTION
the output of `jq` is like `"7.2.0"` but we need `7.2.0` so we have to add `-r` to `jq` to remove the `"`