### PR TITLE
fix: force git push

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,18 +81,8 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh '''
-              curl https://pre-commit.com/install-local.py | python -
-              git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files | tee pre-commit.out
-            '''
+            preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
           }
-        }
-      }
-      post {
-        always {
-          preCommitToJunit(input: "${BASE_DIR}/pre-commit.out", output: "${BASE_DIR}/pre-commit-junit.xml")
-          archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
-          junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
         }
       }
     }

--- a/.ci/docker/Makefile
+++ b/.ci/docker/Makefile
@@ -1,19 +1,41 @@
 .PHONY: help
 .DEFAULT_GOAL := help
-BATS_VERSION = "v1.1.0"
+BATS_VERSION = c706d1470dd1376687776bbe985ac22d09780327 #v1.1.0
+BATS_ASSERT = 9f88b4207da750093baabc4e3f41bf68f0dd3630 #v0.3.0
+BATS_SUPPORT = 004e707638eedd62e0481e8cdc9223ad471f12ee #v0.3.0
 LTS_ALPINE ?= 12-alpine
 
 help: ## Display this help text
 	@grep -E '^[a-zA-Z_-]+[%]?:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 bats: ## Install bats in the project itself
-	@test -e "bats-core" && (cd bats-core ; git checkout ${BATS_VERSION}) || git clone https://github.com/bats-core/bats-core.git --depth=1 --branch ${BATS_VERSION}
+	@echo "Cloning bats-core"
+	@[ -d $(CURDIR)/bats-core ] \
+		|| git clone -n https://github.com/bats-core/bats-core.git $(CURDIR)/bats-core
+	@cd $(CURDIR)/bats-core \
+		&& git fetch --all \
+		&& git checkout -B v1.1.0 ${BATS_VERSION}
 
-prepare-test: bats ## Prepare the bats dependencies
+bats-assert: ##Install bats-assert in the project itself
+	@echo "Clonning bats-assert"
+	@[ -d $(CURDIR)/tests/test_helper/bats-assert ] \
+		|| git clone -n https://github.com/ztombol/bats-assert $(CURDIR)/tests/test_helper/bats-assert
+	@cd $(CURDIR)/tests/test_helper/bats-assert \
+		&& git fetch --all \
+		&& git checkout -B v0.3.0 ${BATS_ASSERT}
+
+bats-support: ##Install bats-support in the project itself
+	@echo "Clonning bats-support"
+	@[ -d $(CURDIR)/tests/test_helper/bats-support ] \
+		|| git clone -n https://github.com/ztombol/bats-support $(CURDIR)/tests/test_helper/bats-support
+	@cd $(CURDIR)/tests/test_helper/bats-support \
+		&& git fetch --all \
+		&& git checkout -B v0.3.0 ${BATS_SUPPORT}
+
+prepare-test: bats bats-assert bats-support## Prepare the bats dependencies
+	@echo "Pulling Alpine image"
 	@docker pull node:${LTS_ALPINE}
 	@mkdir -p target
-	@git submodule sync
-	@git submodule update --init --recursive
 
 convert-tests-results: ## convert TAP test results to JUnit
 	@APP=$*; docker run --rm -e APP=$${APP} -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:${LTS_ALPINE} \

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ jenkins-cli.jar
 # For the BATS testing
 bats-core/
 target/
+.ci/docker/tests/test_helper/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule ".ci/docker/tests/test_helper/bats-assert"]
-	path = .ci/docker/tests/test_helper/bats-assert
-	url = https://github.com/ztombol/bats-assert
-[submodule ".ci/docker/tests/test_helper/bats-support"]
-	path = .ci/docker/tests/test_helper/bats-support
-	url = https://github.com/ztombol/bats-support

--- a/resources/JenkinsfileTemplate.groovy
+++ b/resources/JenkinsfileTemplate.groovy
@@ -280,16 +280,8 @@ pipeline {
           bat returnStatus: true, script: 'docker -v'
         }
       }
-      stage('windows 2016 check'){
-        agent { label 'windows-2016' }
-        options { skipDefaultCheckout() }
-        steps {
-          bat returnStatus: true, script: 'msbuild'
-          bat returnStatus: true, script: 'docker -v'
-        }
-      }
-      stage('windows 2016 immutable check'){
-        agent { label 'windows-2016 && immutable' }
+      stage('windows 2019 immutable check'){
+        agent { label 'windows-2019-immutable' }
         options { skipDefaultCheckout() }
         steps {
           bat returnStatus: true, script: 'msbuild'
@@ -299,9 +291,23 @@ pipeline {
           bat returnStatus: true, script: 'docker -v'
         }
       }
-      stage('windows 2019 immutable check'){
-        agent { label 'windows-2019 && immutable' }
+      stage('windows 2012 immutable check'){
+        agent { label 'windows-2012-r2-immutable' }
         options { skipDefaultCheckout() }
+        steps {
+          bat returnStatus: true, script: 'msbuild'
+          bat returnStatus: true, script: 'dotnet --info'
+          bat returnStatus: true, script: 'nuget --help'
+          bat returnStatus: true, script: 'vswhere'
+          bat returnStatus: true, script: 'docker -v'
+        }
+      }
+       stage('windows 2019 docker immutable check'){
+        agent { label 'windows-2019-docker-immutable' }
+        options { skipDefaultCheckout() }
+        when {
+          expression { return false }
+        }
         steps {
           bat returnStatus: true, script: 'msbuild'
           bat returnStatus: true, script: 'dotnet --info'


### PR DESCRIPTION
```
15:45:04  [Pipeline] }
15:45:04  [Pipeline] // withCredentials
15:45:04  [Pipeline] sh (create tag)
15:45:04  + git tag -a -m chore: Create tag current current
15:45:04  [Pipeline] isUnix
15:45:04  [Pipeline] withCredentials
15:45:04  Masking supported pattern matches of $GIT_USERNAME or $GIT_PASSWORD
15:45:04  [Pipeline] {
15:45:04  [Pipeline] sh (Git push)
15:45:05  + git push https://****:****@github.com/elastic/apm-pipeline-library.git --tags
15:45:07  To https://****:****@github.com/elastic/apm-pipeline-library.git
15:45:07   ! [rejected]        current -> current (already exists)
15:45:07  error: failed to push some refs to 'https://****:****@github.com/elastic/apm-pipeline-library.git'
15:45:07  hint: Updates were rejected because the tag already exists in the remote.
15:45:07  [Pipeline] }
```