### PR TITLE
feat: support cloneOptions by default

### DIFF
--- a/src/test/groovy/GitCheckoutStepTests.groovy
+++ b/src/test/groovy/GitCheckoutStepTests.groovy
@@ -96,6 +96,16 @@ class GitCheckoutStepTests extends BasePipelineTest {
     }.any { call ->
         callArgsToString(call).contains("Checkout master")
     })
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == 'log'
+    }.any { call ->
+        callArgsToString(call).contains('Reference repo disabled')
+    })
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == 'checkout'
+    }.any { call ->
+        callArgsToString(call).contains('reference=,')
+    })
     assertJobStatusSuccess()
   }
 
@@ -112,6 +122,16 @@ class GitCheckoutStepTests extends BasePipelineTest {
         call.methodName == "log"
     }.any { call ->
         callArgsToString(call).contains("Checkout master")
+    })
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == 'log'
+    }.any { call ->
+        callArgsToString(call).contains('Reference repo enabled')
+    })
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == 'checkout'
+    }.any { call ->
+        callArgsToString(call).contains('reference=repo')
     })
     assertJobStatusSuccess()
   }

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -42,10 +42,8 @@ def call(Map params = [:]){
   def githubCheckContext = 'CI-approved contributor'
   def extensions = []
 
-  if(reference != null){
-    extensions.add([$class: 'CloneOption', depth: 5, noTags: false, reference: "${reference}", shallow: true])
-    log(level: 'DEBUG', text: "gitCheckout: Reference repo enabled ${extensions.toString()}")
-  }
+  extensions.add([$class: 'CloneOption', depth: 5, noTags: false, reference: "${reference != null ? reference : '' }", shallow: true])
+  log(level: 'DEBUG', text: "gitCheckout: Reference repo ${reference != null ? 'enabled' : 'disabled' } ${extensions.toString()}")
 
   if(mergeTarget != null){
     extensions.add([$class: 'PreBuildMerge', options: [mergeTarget: "${mergeTarget}", mergeRemote: "${mergeRemote}"]])


### PR DESCRIPTION
## Highlights
- The current implementation doesn't support shallow cloning and some other git tweaks to speed up the cloning unless the reference repo is configured.
- This particular feature will enable to set up the default clone options even when the reference repo has been unset.
