### PR TITLE
withEnv in the checkLicenses step

### DIFF
--- a/src/test/groovy/CheckLicensesStepTests.groovy
+++ b/src/test/groovy/CheckLicensesStepTests.groovy
@@ -25,6 +25,19 @@ class CheckLicensesStepTests extends BasePipelineTest {
   static final String scriptName = 'vars/checkLicenses.groovy'
   Map env = [:]
 
+  def withEnvInterceptor = { list, closure ->
+    list.forEach {
+      def fields = it.split("=")
+      binding.setVariable(fields[0], fields[1])
+    }
+    def res = closure.call()
+    list.forEach {
+      def fields = it.split("=")
+      binding.setVariable(fields[0], null)
+    }
+    return res
+  }
+
   /**
    * Mock Docker class from docker-workflow plugin.
    */
@@ -61,6 +74,7 @@ class CheckLicensesStepTests extends BasePipelineTest {
     helper.registerAllowedMethod('junit', [Map.class], { 'OK' })
     helper.registerAllowedMethod('readFile', [Map.class], { '' })
     helper.registerAllowedMethod('sh', [Map.class], { 'OK' })
+    helper.registerAllowedMethod('withEnv', [List.class, Closure.class], withEnvInterceptor)
     helper.registerAllowedMethod('writeFile', [Map.class], { 'OK' })
   }
 
@@ -82,6 +96,33 @@ class CheckLicensesStepTests extends BasePipelineTest {
       call.methodName == 'sh'
     }.any { call ->
       callArgsToString(call).contains('-ext .foo')
+    })
+  }
+
+  @Test
+  void testWithEnvAndAllTheEnvironmentVariables() throws Exception {
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+    assertJobStatusSuccess()
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'withEnv'
+    }.any { call ->
+      callArgsToString(call).contains("[HOME=${env.WORKSPACE}/${env.BASE_DIR}]")
+    })
+  }
+
+  @Test
+  void testWithEnvAndNoBaseDirVariable() throws Exception {
+    env.BASE_DIR = ''
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+    assertJobStatusSuccess()
+    assertTrue(helper.callStack.findAll { call ->
+      call.methodName == 'withEnv'
+    }.any { call ->
+      callArgsToString(call).contains("[HOME=${env.WORKSPACE}/]")
     })
   }
 

--- a/vars/checkLicenses.groovy
+++ b/vars/checkLicenses.groovy
@@ -45,11 +45,13 @@ def call(Map params = [:]) {
     error('checkLicenses: skip should be enabled when using the junit flag.')
   }
 
-  docker.image('golang:1.12').inside("-e HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"){
+  docker.image('golang:1.12').inside {
     catchError {
-      sh(label: 'Check Licenses', script: """
-      go get -u github.com/elastic/go-licenser
-      go-licenser ${skipFlag} ${excludeFlag} ${fileExtFlag} ${licenseFlag} ${licensorFlag} | tee ${testOutput}""")
+      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
+        sh(label: 'Check Licenses', script: """
+        go get -u github.com/elastic/go-licenser
+        go-licenser ${skipFlag} ${excludeFlag} ${fileExtFlag} ${licenseFlag} ${licensorFlag} | tee ${testOutput}""")
+      }
     }
 
     // Potentially supported with https://github.com/elastic/go-licenser/issues/23


### PR DESCRIPTION
## Highlights
- docker step set the environment variables once the docker container is up, therefore it's required to use the`withEnv` step rather than the parameters approach as they will be overridden.

## Test Cases
- Locally using the below snippet
```
@Library('apm') _

pipeline {
  agent { label 'linux && immutable' }
  environment {
    BASE_DIR="src/github.com/elastic/apm-pipeline-library"
  }
  stages {
    stage('Checkout') {
      steps {
        dir(BASE_DIR) {
            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'v1v-pat', url: 'https://github.com/v1v/apm-pipeline-library.git']]]

            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE', message: 'Some files does not contain license') {
              checkLicenses(skip: true, junit:true, ext: '.groovy')
            }
        }
      }
    }
  }
}
```
Used this particular PR:
```
> git fetch --no-tags --force --progress https://github.com/v1v/apm-pipeline-library.git +refs/heads/issue/188:refs/remotes/origin/issue/188 --depth=1
Checking out Revision 762bbb1e9bdba14aea307f8c3eee9e934e8ee227 (issue/188)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 762bbb1e9bdba14aea307f8c3eee9e934e8ee227
Commit message: "withEnv in the checkLicenses step"
```

![image](https://user-images.githubusercontent.com/2871786/62695485-5a3f2500-b9ce-11e9-94a9-2f8d2fde9168.png)
