### PR TITLE
feat: enable gherkin-lint pre-commit hook

### DIFF
--- a/.ci/scripts/gherkin-lint.sh
+++ b/.ci/scripts/gherkin-lint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+IMAGE="gherkin/lint"
+docker pull --quiet "${IMAGE}"
+
+## Iterate for each file without failing fast.
+set +e
+for file in "$@"; do
+  if ! docker run --rm -t -v "$(pwd)":/src -w /src "${IMAGE}" ${file} ; then
+    echo "ERROR: gherkin-lint failed for the file '${file}'"
+    exit_status=1
+  fi
+done
+
+exit $exit_status

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -60,3 +60,9 @@
     entry: .ci/scripts/validate-jjbb.sh
     language: script
     verbose: true
+-   id: check-gherkin-lint
+    name: Check gherkin lint
+    description: "Check Gherkin feature syntax corectness, requires docker."
+    language: script
+    entry: .ci/scripts/gherkin-lint.sh
+    files: \.feature$

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Add this to your `.pre-commit-config.yaml`
       -   id: remove-unicode-non-breaking-spaces
       -   id: check-en-dashes
       -   id: remove-en-dashes
+      -   id: check-gherkin-lint
 
 ### Available hooks
 
@@ -192,7 +193,7 @@ Add this to your `.pre-commit-config.yaml`
 - remove-unicode-non-breaking-spaces - Remove unicode non-breaking space character U+00A0 aka M-BM-
 - check-en-dashes - Detect the EXTREMELY confusing unicode character U+2013
 - remove-en-dashes - Remove the EXTREMELY confusing unicode character U+2013
-
+- check-gherkin-lint - Check Gherkin feature syntax corectness, requires docker.
 
 ## Resources
 


### PR DESCRIPTION
## Highlights
- Provide the gherkin-lint hooks which it's already in use in the project: https://github.com/elastic/metricbeat-tests-poc
- When merged then it should notify https://github.com/elastic/metricbeat-tests-poc/pull/9