### PR TITLE
fix: build all the PRs and all the branches without any PRs

### DIFF
--- a/.ci/jobs/apm-nodejs-http-client-mbp.yml
+++ b/.ci/jobs/apm-nodejs-http-client-mbp.yml
@@ -10,7 +10,7 @@
     script-path: .ci/Jenkinsfile
     scm:
       - github:
-          branch-discovery: all
+          branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/apm-pipeline-library-mbp.yml
+++ b/.ci/jobs/apm-pipeline-library-mbp.yml
@@ -8,7 +8,7 @@
     script-path: .ci/Jenkinsfile
     scm:
       - github:
-          branch-discovery: all
+          branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/observability-test-environments-mbp.yml
+++ b/.ci/jobs/observability-test-environments-mbp.yml
@@ -8,7 +8,7 @@
     script-path: .ci/Jenkinsfile
     scm:
       - github:
-          branch-discovery: all
+          branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/observability-test-environments-update-mbp.yml
+++ b/.ci/jobs/observability-test-environments-update-mbp.yml
@@ -8,7 +8,7 @@
     script-path: .ci/update-cluster.groovy
     scm:
       - github:
-          branch-discovery: all
+          branch-discovery: no-pr
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current


### PR DESCRIPTION
Depends on: https://github.com/elastic/apm-pipeline-library/pull/182 as the docker JJB image cannot be reached if no dockerLogin. This dependency is only for the build and validation nothing about the implementation itself.