### PR TITLE
fix: PATH env variable is required in the inside method to be expanded

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -28,19 +28,6 @@ class PreCommitStepTests extends BasePipelineTest {
 
   Map env = [:]
 
-  def withEnvInterceptor = { list, closure ->
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], fields[1])
-    }
-    def res = closure.call()
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], null)
-    }
-    return res
-  }
-
   /**
    * Mock Docker class from docker-workflow plugin.
    */
@@ -74,7 +61,6 @@ class PreCommitStepTests extends BasePipelineTest {
     helper.registerAllowedMethod('preCommitToJunit', [Map.class], { 'OK' })
     helper.registerAllowedMethod('sh', [String.class], { 'OK' })
     helper.registerAllowedMethod('sshagent', [List.class, Closure.class], { m, body -> body() })
-    helper.registerAllowedMethod('withEnv', [List.class, Closure.class], withEnvInterceptor)
   }
 
   @Test
@@ -184,11 +170,6 @@ class PreCommitStepTests extends BasePipelineTest {
     printCallStack()
     assertNull(helper.callStack.find { call ->
       call.methodName == 'dockerLogin'
-    })
-    assertTrue(helper.callStack.findAll { call ->
-      call.methodName == 'withEnv'
-    }.any { call ->
-      callArgsToString(call).contains("[PATH=${env.PATH}:${env.WORKSPACE}/bin]")
     })
     assertJobStatusSuccess()
   }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -30,10 +30,8 @@
 def call(Map params = [:]) {
   def dockerImage = params.get('dockerImage')
   if (dockerImage?.trim()) {
-    docker.image(dockerImage).inside {
-      withEnv(["PATH=${env.PATH}:${env.WORKSPACE}/bin"]) {
-        preCommit(params)
-      }
+    docker.image(dockerImage).inside("-e PATH=${env.PATH}:${env.WORKSPACE}/bin") {
+      preCommit(params)
     }
   } else {
     preCommit(params)
@@ -64,7 +62,6 @@ def preCommit(Map params = [:]) {
       }
     }
     sh """
-      env | sort ## for debugging purposes
       curl https://pre-commit.com/install-local.py | python -
       git diff-tree --no-commit-id --name-only -r ${commit} | xargs pre-commit run --files | tee ${reportFileName}
     """


### PR DESCRIPTION
for some reason, the `withEnv` step is not expanded

```
10:48:43  PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

I'll use the same approach as stated in https://github.com/elastic/apm-agent-python/pull/557/files#diff-8db37e8fcea0f1a8f2f39667e94ebcc4L59