### PR TITLE
HOME is required to be declared when using the preCommit

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -60,6 +60,7 @@ class PreCommitStepTests extends BasePipelineTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
+    env.BASE_DIR='src'
     env.PATH='/foo'
     env.WORKSPACE='/bar'
     binding.setProperty('docker', new Docker())
@@ -188,7 +189,7 @@ class PreCommitStepTests extends BasePipelineTest {
     assertTrue(helper.callStack.findAll { call ->
       call.methodName == 'withEnv'
     }.any { call ->
-      callArgsToString(call).contains("[HOME=${env.WORKSPACE}]")
+      callArgsToString(call).contains("[HOME=${env.WORKSPACE}/${env.BASE_DIR}]")
     })
     assertJobStatusSuccess()
   }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -31,7 +31,7 @@ def call(Map params = [:]) {
   def dockerImage = params.get('dockerImage')
   if (dockerImage?.trim()) {
     docker.image(dockerImage).inside("-e PATH=${env.PATH}:${env.WORKSPACE}/bin") {
-      withEnv(["HOME=${env.WORKSPACE}"]) {
+      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
         preCommit(params)
       }
     }


### PR DESCRIPTION
## Highlights
- Let's override the HOME to be WORKSPACE/BASE_DIR as that's where the docker container does run.

```
08:46:05  Running in /var/lib/jenkins/workspace/hon_apm-agent-python-mbp0_master/src/github.com/elastic/apm-agent-python
...
08:46:18  PermissionError: [Errno 13] Permission denied: '/var/lib/jenkins/workspace/hon_apm-agent-python-mbp0_master/.pre-commit-venv'
```

A bit more of context for the future if required, the current approach in the CI pipelines is:
- to checkout the source code under the folder BASE_DIR. See https://github.com/elastic/apm-agent-python/blob/b4fc4469fa172c2d3d2ee56b5c1bbdf115c65140/Jenkinsfile#L57
- the HOME will point out to the WORKSPACE path. https://github.com/elastic/apm-agent-python/blob/b4fc4469fa172c2d3d2ee56b5c1bbdf115c65140/Jenkinsfile#L46

Then, in this case when the docker container runs under the folder BASE_DIR, which it's where the source code is stored, but the HOME path is not accessible as the docker container is mounted under the folder BASE_DIR, there are two possible options:
- To delegate that setup in the pipeline.
- As done in this PR.

I believe any implementation details should be addressed within the library to simplify how to use this step in the pipeline itself.