### PR TITLE
Revert "HOME is required to be declared when using the preCommit"

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -28,19 +28,6 @@ class PreCommitStepTests extends BasePipelineTest {
 
   Map env = [:]
 
-  def withEnvInterceptor = { list, closure ->
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], fields[1])
-    }
-    def res = closure.call()
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], null)
-    }
-    return res
-  }
-
   /**
    * Mock Docker class from docker-workflow plugin.
    */
@@ -60,7 +47,6 @@ class PreCommitStepTests extends BasePipelineTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
-    env.BASE_DIR='src'
     env.PATH='/foo'
     env.WORKSPACE='/bar'
     binding.setProperty('docker', new Docker())
@@ -75,7 +61,6 @@ class PreCommitStepTests extends BasePipelineTest {
     helper.registerAllowedMethod('preCommitToJunit', [Map.class], { 'OK' })
     helper.registerAllowedMethod('sh', [String.class], { 'OK' })
     helper.registerAllowedMethod('sshagent', [List.class, Closure.class], { m, body -> body() })
-    helper.registerAllowedMethod('withEnv', [List.class, Closure.class], withEnvInterceptor)
   }
 
   @Test
@@ -185,11 +170,6 @@ class PreCommitStepTests extends BasePipelineTest {
     printCallStack()
     assertNull(helper.callStack.find { call ->
       call.methodName == 'dockerLogin'
-    })
-    assertTrue(helper.callStack.findAll { call ->
-      call.methodName == 'withEnv'
-    }.any { call ->
-      callArgsToString(call).contains("[HOME=${env.WORKSPACE}/${env.BASE_DIR}]")
     })
     assertJobStatusSuccess()
   }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -31,9 +31,7 @@ def call(Map params = [:]) {
   def dockerImage = params.get('dockerImage')
   if (dockerImage?.trim()) {
     docker.image(dockerImage).inside("-e PATH=${env.PATH}:${env.WORKSPACE}/bin") {
-      withEnv(["HOME=${env.WORKSPACE}/${env.BASE_DIR ?: ''}"]) {
-        preCommit(params)
-      }
+      preCommit(params)
     }
   } else {
     preCommit(params)


### PR DESCRIPTION
Reverts elastic/apm-pipeline-library#193

I'm afraid there are some issues when running in the docker container context that I cannot warranty we will be able to fix them.

So I'd revert this PR to leave the dockerImage definition within the Pipeline, not ideal, but it did work as expected.