### PR TITLE
fix: build version might differ when using aliases

### DIFF
--- a/resources/scripts/getDockerImages.sh
+++ b/resources/scripts/getDockerImages.sh
@@ -30,19 +30,19 @@ VERSION_ID=${1}
 #BUILD_ID=$(echo ${JSON}|jq -r .build_id)
 #VERSION_ID=$(echo ${JSON}|jq -r .version)
 #MANIFEST_URL=$(echo ${JSON}|jq -r .manifest_url)
-MANIFEST_JSON=$(curl -sSf https://artifacts-api.elastic.co/v1/versions/${VERSION_ID}/builds/latest/)
-#VERSION_ID=$(echo ${MANIFEST_JSON}|jq -r .version)
+MANIFEST_JSON=$(curl -sSf https://artifacts-api.elastic.co/v1/versions/"${VERSION_ID}"/builds/latest/)
+BUILD_VERSION=$(echo "${MANIFEST_JSON}"|jq -r ".build.version")
 
 for product in elasticsearch kibana apm-server
 do
-  URL=$(echo ${MANIFEST_JSON}|jq -r ".build.projects.\"${product}\".packages[]|select(.type==\"docker\" and (.classifier==\"docker-image\" or .classifier==null) ).url"|grep "${product}-${VERSION_ID}")
+  URL=$(echo "${MANIFEST_JSON}"|jq -r ".build.projects.\"${product}\".packages[]|select(.type==\"docker\" and (.classifier==\"docker-image\" or .classifier==null) ).url"|grep "${product}-${BUILD_VERSION}")
   echo "Downloading ${product} - ${URL}"
-  curl ${URL}|docker load
+  curl "${URL}"|docker load
 done
 
 for product in auditbeat filebeat heartbeat metricbeat packetbeat
 do
-  URL=$(echo ${MANIFEST_JSON}|jq -r ".build.projects.beats.packages[]|select(.type==\"docker\" and (.classifier==\"docker-image\" or .classifier==null) ).url"|grep "${product}-${VERSION_ID}")
+  URL=$(echo "${MANIFEST_JSON}"|jq -r ".build.projects.beats.packages[]|select(.type==\"docker\" and (.classifier==\"docker-image\" or .classifier==null) ).url"|grep "${product}-${BUILD_VERSION}")
   echo "Downloading ${product} - ${URL}"
-  curl ${URL}|docker load
+  curl "${URL}"|docker load
 done


### PR DESCRIPTION
## Highlights
- When using alias the version need to be collected. 

## Test Cases
- Used to be
```
> sh resources/scripts/getDockerImages.sh 7.4-SNAPSHOT

> echo $?
1

```
- Now
```
> sh resources/scripts/getDockerImages.sh 7.4-SNAPSHOT
Downloading elasticsearch - https://snapshots.elastic.co/7.4.0-809769f8/downloads/elasticsearch/elasticsearch-7.4.0-SNAPSHOT-docker-image.tar.gz
Downloading kibana - https://snapshots.elastic.co/7.4.0-809769f8/downloads/kibana/kibana-7.4.0-SNAPSHOT-docker-image.tar.gz
Downloading apm-server - https://snapshots.elastic.co/7.4.0-809769f8/downloads/apm-server/apm-server-7.4.0-SNAPSHOT-docker-image.tar.gz
Downloading auditbeat - https://snapshots.elastic.co/7.4.0-809769f8/downloads/beats/auditbeat/auditbeat-7.4.0-SNAPSHOT-docker-image-linux-amd64.tar.gz
Downloading filebeat - https://snapshots.elastic.co/7.4.0-809769f8/downloads/beats/filebeat/filebeat-7.4.0-SNAPSHOT-docker-image-linux-amd64.tar.gz
Downloading heartbeat - https://snapshots.elastic.co/7.4.0-809769f8/downloads/beats/heartbeat/heartbeat-7.4.0-SNAPSHOT-docker-image-linux-amd64.tar.gz
Downloading metricbeat - https://snapshots.elastic.co/7.4.0-809769f8/downloads/beats/metricbeat/metricbeat-7.4.0-SNAPSHOT-docker-image-linux-amd64.tar.gz
Downloading packetbeat - https://snapshots.elastic.co/7.4.0-809769f8/downloads/beats/packetbeat/packetbeat-7.4.0-SNAPSHOT-docker-image-linux-amd64.tar.gz

> echo $?
0

```