### PR TITLE
fix: replace only the first '-' with a ':'

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -108,7 +108,7 @@ pipeline {
             def pythonVersions = readYaml(file: '.ci/.jenkins_python.yml')['PYTHON_VERSION']
             def tasks = [:]
             pythonVersions.each { pythonIn ->
-              def pythonVersion = pythonIn.replace("-",":")
+              def pythonVersion = pythonIn.replaceFirst("-",":")
               tasks["${pythonVersion}"] = {
                 buildDockerImage(
                   repo: 'https://github.com/elastic/apm-agent-python.git',


### PR DESCRIPTION
replace only the first '-' with a ':'

This is required as the entries in the file https://github.com/elastic/apm-agent-python/blob/dbb14af8a94f7366aaac71c3cfcda3b68f82a011/.ci/.jenkins_python.yml#L7 might contain several `-` and we only care for the first one which contains the term `python`