### PR TITLE
enable jjbb validation locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Some hooks might require some extra tools such as:
 - Detect the EXTREMELY confusing unicode character U+2013
 - Remove the EXTREMELY confusing unicode character U+2013
 
+
+### Validate JJBB files
+
+If the local jenkins instance has been enabled then it's possible to validate whether the JJBB
+files are healthy enough.
+
+```bash
+  sh local/test-jjbb.sh .ci/jobs/apm-docker-images-pipeline.yml
+```
+
+Then open http://localhost:18080
+
 ## pre-commit-hooks
 
 Observability robots hooks for http://pre-commit.com/

--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -14,3 +14,20 @@ unclassified:
   location:
     adminAddress: robots@elastic.co
     url: http://jenkins-lint.localhost/
+
+## TODO: vault should be in place.
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - string:
+              description: GitHub user @${github_username} Personal Access Token
+              id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7
+              scope: GLOBAL
+              secret: ${github_personal_access_token}
+          - usernamePassword:
+              description: GitHub user @${github_username} User + Personal Access Token
+              id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+              password: ${github_personal_access_token}
+              scope: GLOBAL
+              username: ${github_username}

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -28,6 +28,12 @@ services:
         reservations:
           cpus: '0.25'
           memory: 100M
+    networks:
+      apm-pipeline-library:
 
 volumes:
   jenkins_home:
+
+networks:
+  apm-pipeline-library:
+    driver: bridge

--- a/local/jenkins_jobs.ini
+++ b/local/jenkins_jobs.ini
@@ -1,0 +1,5 @@
+[job_builder]
+allow_duplicates=True
+
+[jenkins]
+url=http://jenkins:8080

--- a/local/test-jjbb.sh
+++ b/local/test-jjbb.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+FILENAME=$1
+BASENAME=$(basename "${FILENAME}")
+## Further details: https://github.com/elastic/infra/blob/master/flavortown/jjbb/README.md#how-do-i-test-changes-locally
+
+TMPFOLDER=$(mktemp -q -d /tmp/pre-commit.XXXXXX)
+
+function finish {
+  rm -rf "${TMPFOLDER}"
+}
+trap finish EXIT
+
+IMAGE="docker.elastic.co/infra/jjbb"
+docker pull "${IMAGE}" > /dev/null
+
+echo 'Transform JJBB to JJB'
+docker run -t --rm --user "$(id -u):$(id -g)" \
+        -v "${TMPFOLDER}:/tmp" \
+        -v "$(pwd):/jjbb" -w /jjbb "${IMAGE}" --write-yaml --yaml-output-dir=/tmp
+printf '\tpassed\n'
+
+echo 'Validate JJB'
+JJB_REPORT="${TMPFOLDER}/jjb.xml"
+set +e
+docker run -t --rm --user "$(id -u):$(id -g)" \
+        -v "${TMPFOLDER}:/jjbb" \
+        -w '/jjbb' \
+        -e HOME=/tmp \
+        widerplan/jenkins-job-builder -l error test "${BASENAME}" > "${JJB_REPORT}"
+
+# shellcheck disable=SC2181
+if [ $? -gt 0 ] ; then
+  cat "${JJB_REPORT}"
+  exit 1
+else
+  printf '\tpassed\n'
+fi
+
+echo 'Create JJB locally'
+set -e
+docker run -t --rm --user "$(id -u):$(id -g)" \
+        -v "${TMPFOLDER}:/jjbb" \
+        -e HOME=/tmp \
+        -w '/jjbb' \
+        -v "$(pwd)/local/jenkins_jobs.ini":/etc/jenkins_jobs/jenkins_jobs.ini \
+        --network local_apm-pipeline-library \
+        widerplan/jenkins-job-builder -l error update "${BASENAME}"
+printf '\tpassed\n'


### PR DESCRIPTION
Closes https://github.com/elastic/apm-pipeline-library/issues/214

## Highlights
- Wrapper to enable the JJBB validation in the local jenkins instance.
-  `local/test-jjbb.sh` similar to `.ci/scripts/validate-jjbb.sh` but adding a new step.

## Test cases

```bash
sh local/test-jjbb.sh .ci/jobs/apm-docker-images-pipeline.yml
Transform JJBB to JJB
2019-09-04 10:13:23,051 [jjbb.main] [INFO] No templates found in .ci/templates, continuing without them.
2019-09-04 10:13:23,192 [jjbb.main] [INFO] No views found at .ci/views/views.yml, continuing without them.
	passed
Validate JJB
	passed
Create JJB locally
	passed
```

## Follow up
- Enable credentials with Vault. For such it's required https://github.com/elastic/apm-pipeline-library/pull/204. So there will be another PR to enhance it.