### PR TITLE
force shallow to False if mergeTarget is enabled

### DIFF
--- a/src/test/groovy/GitCheckoutStepTests.groovy
+++ b/src/test/groovy/GitCheckoutStepTests.groovy
@@ -416,25 +416,26 @@ class GitCheckoutStepTests extends BasePipelineTest {
   }
 
   @Test
-  void testErrorWithShallowAndMergeTarget() throws Exception {
+  void testWithShallowAndMergeTarget() throws Exception {
     def script = loadScript(scriptName)
     script.scm = "SCM"
-    try {
-      script.call(basedir: 'sub-folder', branch: 'master',
+    script.call(basedir: 'sub-folder', branch: 'master',
         repo: 'git@github.com:elastic/apm-pipeline-library.git',
         credentialsId: 'credentials-id',
         mergeTarget: "master",
         shallow: true)
-    } catch(e){
-      //NOOP
-    }
     printCallStack()
     assertTrue(helper.callStack.findAll { call ->
-        call.methodName == 'error'
+        call.methodName == 'log'
     }.any { call ->
-        callArgsToString(call).contains('It might cause refusing to merge unrelated histories')
+        callArgsToString(call).contains('refusing to merge unrelated histories')
     })
-    assertJobStatusFailure()
+    assertTrue(helper.callStack.findAll { call ->
+        call.methodName == 'checkout'
+    }.any { call ->
+        callArgsToString(call).contains('CloneOption, depth=0, noTags=false, reference=, shallow=false')
+    })
+    assertJobStatusSuccess()
   }
 
   @Test

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -46,7 +46,8 @@ def call(Map params = [:]){
 
   if (shallowValue && mergeTarget != null) {
     // https://issues.jenkins-ci.org/browse/JENKINS-45771
-    error 'It might cause refusing to merge unrelated histories'
+    log(level: 'INFO', text: "'shallow' is forced to be disabled when using mergeTarget to avoid refusing to merge unrelated histories")
+    shallowValue = false
   }
 
   extensions.add([$class: 'CloneOption', depth: shallowValue ? depthValue : 0, noTags: false, reference: "${reference != null ? reference : '' }", shallow: shallowValue])


### PR DESCRIPTION
## Highlights
- This will help with backward compatibility
- As discussed offline this particular behavior is a restriction rather than a failure. Let's ensure even when misconfigured the step does self-configured accordingly.

