### PR TITLE
Use the new credentials for the benchmark ES stack

### DIFF
--- a/src/test/groovy/SendBenchmarksStepTests.groovy
+++ b/src/test/groovy/SendBenchmarksStepTests.groovy
@@ -56,7 +56,7 @@ class SendBenchmarksStepTests extends BasePipelineTest {
     })
     helper.registerAllowedMethod("getVaultSecret", [Map.class], { v ->
       def s = v.secret
-      if("secret".equals(s) || "secret/apm-team/ci/java-agent-benchmark-cloud".equals(s)){
+      if("secret".equals(s) || "secret/apm-team/ci/benchmark-cloud".equals(s)){
         return [data: [ user: 'user', password: 'password', url: "${URL}"]]
       }
       if("secretError".equals(s)){

--- a/vars/sendBenchmarks.groovy
+++ b/vars/sendBenchmarks.groovy
@@ -30,7 +30,7 @@ def call(Map params = [:]) {
   }
   def benchFile = params.containsKey('file') ? params.file : 'bench.out'
   def index = params.containsKey('index') ? params.index : 'benchmark-go'
-  def secret = params.containsKey('secret') ? params.secret : 'secret/apm-team/ci/java-agent-benchmark-cloud'
+  def secret = params.containsKey('secret') ? params.secret : 'secret/apm-team/ci/benchmark-cloud'
   def archive = params.containsKey('archive') ? params.archive : true
 
   if(archive){


### PR DESCRIPTION
Caused by https://github.com/elastic/observability-dev/issues/236

## Highlights
- Enable new credentials in vault to access the ES benchmarking project