### PR TITLE
enable labels when connecting the swarm linux agent

### DIFF
--- a/local/workers/linux/Vagrantfile
+++ b/local/workers/linux/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
 
   $script = <<-SCRIPT
   su - vagrant -c 'curl -s https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.9/swarm-client-3.9.jar > swarm-client.jar'
-  su - vagrant -c 'nohup java -jar swarm-client.jar -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1 &'
+  su - vagrant -c 'nohup java -jar swarm-client.jar -labels "linux docker immutable" -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1 &'
   SCRIPT
 
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
## Highlights
- Enable labels in the linux agent 

## Test Case

```
$ cd local/workers/linux
$ vagrant up --provision
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'elastic/ubuntu-16.04-x86_64' version '20190319.1.0' is up to date...
==> default: A newer version of the box 'elastic/ubuntu-16.04-x86_64' for provider 'virtualbox' is
==> default: available! You currently have version '20190319.1.0'. The latest is version
==> default: '20190915.0.0'. Run `vagrant box update` to update.
==> default: Clearing any previously set forwarded ports...
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 5.0.18_Ubuntu r106667
    default: VirtualBox Version: 6.0
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /vagrant => /Users/vmartinez/work/src/github.com/elastic/apm-pipeline-library/local/workers/linux
==> default: Running provisioner: shell...
    default: Running: inline script

```

![image](https://user-images.githubusercontent.com/2871786/65234623-d4ce8a80-dacc-11e9-9e48-ecbc5629bb16.png)
