### PR TITLE
enable curl with timeout and connection timeout

### DIFF
--- a/vars/getBuildInfoJsonFiles.groovy
+++ b/vars/getBuildInfoJsonFiles.groovy
@@ -61,7 +61,7 @@ def call(jobURL, buildNumber){
 }
 
 def downloadJSONFile(url, file){
-  def ret = sh(label: "Get Build info ${file}", script: "curl -sfSL -o ${file} ${url}", returnStatus: true)
+  def ret = sh(label: "Get Build info ${file}", script: "curl -sfSL --max-time 60 --connect-timeout 10 -o ${file} ${url}", returnStatus: true)
 
   if(ret != 0){
     writeJSON(file: "${file}" , json: toJSON("{}"), pretty: 2)


### PR DESCRIPTION
## Highlights
- As a consequence of https://github.com/elastic/infra/issues/14936 let's ensure the Notify doesn't get stalled with a timeout after 60 seconds in total and connection timeout after 10 seconds.

![image](https://user-images.githubusercontent.com/2871786/65895655-b2c5e980-e3a3-11e9-8a1f-04b90d39cefb.png)
