### PR TITLE
CRUMB issues when running the validate.sh

### DIFF
--- a/.ci/scripts/validate.sh
+++ b/.ci/scripts/validate.sh
@@ -5,7 +5,8 @@ if [ -z "${JENKINS_URL}" ] ; then
   JENKINS_URL=http://0.0.0.0:18080
 else
   # See https://jenkins.io/doc/book/pipeline/development/#linter
-  JENKINS_CRUMB=$(curl --silent "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
+  JENKINS_URL=${JENKINS_URL%%/}  ## Remove last / if it's defined
+  JENKINS_CRUMB=$(curl --silent "${JENKINS_URL}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)")
 fi
 
 ## Validate whether the URL is reachable before running anything else


### PR DESCRIPTION
See https://github.com/elastic/observability-dev/issues/353

## Highlights
- Crumb validation fails when using `https://apm-ci.elastic.co//pipeline-model-converter/validate`