### PR TITLE
ci: bring up to date the 'update clusters' job

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -43,127 +43,26 @@ pipeline {
           parallel {
             stage('8.0.0-SNAPSHOT'){
               steps {
-                build(job: 'apm-shared/apm-docker-es-pipeline',
-                  parameters: [
-                    string(name: 'registry', value: 'docker.elastic.co'),
-                    string(name: 'tag_prefix', value: 'observability-ci'),
-                    string(name: 'version', value: '8.0.0-SNAPSHOT'),
-                    string(name: 'elastic_stack', value: '8.0-SNAPSHOT'),
-                    string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
-                    string(name: 'branch_specifier', value: 'master')
-                  ],
-                  propagate: false,
-                  wait: true
-                )
+                grabDockerImages('8.0.0-SNAPSHOT','8.0-SNAPSHOT')
               }
             }
-            stage('7.4.0-SNAPSHOT'){
+            stage('7.5.0-SNAPSHOT'){
               steps {
-                build(job: 'apm-shared/apm-docker-es-pipeline',
-                  parameters: [
-                    string(name: 'registry', value: 'docker.elastic.co'),
-                    string(name: 'tag_prefix', value: 'observability-ci'),
-                    string(name: 'version', value: '7.4.0-SNAPSHOT'),
-                    string(name: 'elastic_stack', value: '7.4-SNAPSHOT'),
-                    string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
-                    string(name: 'branch_specifier', value: 'master')
-                  ],
-                  propagate: false,
-                  wait: true
-                )
+                grabDockerImages('7.5.0-SNAPSHOT','7.5.0-SNAPSHOT')
               }
             }
             stage('7.4.0'){
               steps {
-                build(job: 'apm-shared/apm-docker-es-pipeline',
-                  parameters: [
-                    string(name: 'registry', value: 'docker.elastic.co'),
-                    string(name: 'tag_prefix', value: 'observability-ci'),
-                    string(name: 'version', value: '7.4.0'),
-                    string(name: 'elastic_stack', value: '7.4'),
-                    string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
-                    string(name: 'branch_specifier', value: 'master')
-                  ],
-                  propagate: false,
-                  wait: true
-                )
-              }
-            }
-            stage('7.3.0-SNAPSHOT'){
-              steps {
-                build(job: 'apm-shared/apm-docker-es-pipeline',
-                  parameters: [
-                    string(name: 'registry', value: 'docker.elastic.co'),
-                    string(name: 'tag_prefix', value: 'observability-ci'),
-                    string(name: 'version', value: '7.3.0-SNAPSHOT'),
-                    string(name: 'elastic_stack', value: '7.3-SNAPSHOT'),
-                    string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
-                    string(name: 'branch_specifier', value: 'master')
-                  ],
-                  propagate: false,
-                  wait: true
-                )
-              }
-            }
-            stage('7.3.0'){
-              steps {
-                build(job: 'apm-shared/apm-docker-es-pipeline',
-                  parameters: [
-                    string(name: 'registry', value: 'docker.elastic.co'),
-                    string(name: 'tag_prefix', value: 'observability-ci'),
-                    string(name: 'version', value: '7.3.0'),
-                    string(name: 'elastic_stack', value: '7.3'),
-                    string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
-                    string(name: 'branch_specifier', value: 'master')
-                  ],
-                  propagate: false,
-                  wait: true
-                )
+                grabDockerImages('7.4.0','7.4')
               }
             }
           }
         }
         stage('Update k8s Clusters'){
           steps {
-            build(job: 'apm-shared/observability-test-environments-update-mbp/8.x.x-SNAPSHOT',
-              parameters: [
-                booleanParam(name: 'stop_services', value: true),
-                booleanParam(name: 'start_services', value: true)
-              ],
-              quietPeriod: 10,
-              propagate: false,
-              wait: false
-            )
-
-            build(job: 'apm-shared/observability-test-environments-update-mbp/7.x.x-SNAPSHOT',
-              parameters: [
-                booleanParam(name: 'stop_services', value: true),
-                booleanParam(name: 'start_services', value: true)
-              ],
-              quietPeriod: 10,
-              propagate: false,
-              wait: false
-            )
-
-            build(job: 'apm-shared/observability-test-environments-update-mbp/7.x.x',
-              parameters: [
-                booleanParam(name: 'stop_services', value: true),
-                booleanParam(name: 'start_services', value: true)
-              ],
-              quietPeriod: 10,
-              propagate: false,
-              wait: false
-            )
-
-            build(job: 'apm-shared/observability-test-environments-update-mbp/7.x.x-BC',
-              parameters: [
-                booleanParam(name: 'stop_services', value: true),
-                booleanParam(name: 'start_services', value: true)
-              ],
-              quietPeriod: 10,
-              propagate: false,
-              wait: false
-            )
+            updateCluster('8.x.x-SNAPSHOT')
+            updateCluster('7.x.x-SNAPSHOT')
+            updateCluster('7.x.x')
           }
         }
       }
@@ -174,4 +73,31 @@ pipeline {
       notifyBuildResult()
     }
   }
+}
+
+def grabDockerImages(versionToStore, versionToGet){
+  build(job: 'apm-shared/apm-docker-es-pipeline',
+    parameters: [
+      string(name: 'registry', value: 'docker.elastic.co'),
+      string(name: 'tag_prefix', value: 'observability-ci'),
+      string(name: 'version', value: versionToStore),
+      string(name: 'elastic_stack', value: versionToGet),
+      string(name: 'secret', value: "${DOCKERELASTIC_SECRET}"),
+      string(name: 'branch_specifier', value: 'master')
+    ],
+    propagate: false,
+    wait: true
+  )
+}
+
+def updateCluster(branch){
+  build(job: "apm-shared/observability-test-environments-update-mbp/${branch}",
+    parameters: [
+      booleanParam(name: 'stop_services', value: true),
+      booleanParam(name: 'start_services', value: true)
+    ],
+    quietPeriod: 10,
+    propagate: false,
+    wait: false
+  )
 }


### PR DESCRIPTION
## What does this PR do?

* Refactor the stages to update the clusters that are up
* Update the Elastic Stack versions
* Refactor code for reuse

## Why is it important?

We have to test the latest Release and SNAPSHOT 

## Related issues
Closes https://github.com/elastic/observability-dev/issues/373
