### PR TITLE
enforce: maven dependencies and validation within the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,28 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <!-- force upper bound dependencies -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-al</artifactId>
+        <version>2.4.12</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <scriptSourceDirectory>vars</scriptSourceDirectory>
     <testSourceDirectory>src</testSourceDirectory>
@@ -140,6 +162,38 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.5.4,)</version>
+                  <message>3.5.4 required to at least look at .mvn/ if it exists.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8.0,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Highlights
- This is the very first step to enable the ITs when running them using the JenkinsRule as if those dependencies are not solved correctly then the classloader might cause some issues and the jenkins instance might fail.
- Potentially we could rollback https://github.com/elastic/apm-pipeline-library/pull/90 to reuse the parent-pom which already provides those maven goals. although I do rather prefer to control those dependencies and so on explicitly.