### PR TITLE
Add MBP for Code's java-langserver

### DIFF
--- a/.ci/jobs/code-java-langserver.yml
+++ b/.ci/jobs/code-java-langserver.yml
@@ -1,0 +1,44 @@
+---
+- job:
+    name: code/code-java-langserver
+    display-name: Java Langserver Pipeline
+    description: Jenkins pipeline for the Java Langserver project
+    project-type: multibranch
+    script-path: .ci/Jenkinsfile
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: true
+          notification-context: 'apm-ci'
+          repo: java-langserver
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - tags:
+                ignore-tags-older-than: -1
+                ignore-tags-newer-than: -1
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: false
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true


### PR DESCRIPTION
## What does this PR do?
It adds a multi-branch pipeline for the `java-langserver` project.

## Why is it important?
This is needed to monitor PR, branches and tags in the github repository, so that Jenkins can execute the proper automation, which resides in that repository in the form of a Jenkinsfile.