### PR TITLE
fix: use fork to build the images

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -242,7 +242,7 @@ pipeline {
         expression { return params.jruby }
       }
       steps {
-        git url: 'https://github.com/elastic/docker-jruby', branch: 'versions'
+        git url: 'https://github.com/kuisathaverat/docker-jruby', branch: 'versions'
         sh(label: 'build docker images', script: "./run.sh --action build --registry ${TAG_CACHE} --exclude 1.7")
         sh(label: 'test docker images', script: "./run.sh --action test --registry ${TAG_CACHE} --exclude 1.7")
         dockerLoginElasticRegistry()


### PR DESCRIPTION
## What does this PR do?

meanwhile, we have permission to merge https://github.com/elastic/docker-jruby/pull/1 we need to build the images with the proper packages. This PR changes the build to pull the code from my personal fork.

## Why is it important?

without this change, the Docker images will have a bug, then the Ruby build will fail.
