### PR TITLE
bump version from 2.x support to 3.x support in order to use the filter-branch

### DIFF
--- a/local/test-jjbb.sh
+++ b/local/test-jjbb.sh
@@ -46,5 +46,5 @@ docker run -t --rm --user "$(id -u):$(id -g)" \
         -w '/jjbb' \
         -v "$(pwd)/local/jenkins_jobs.ini":/etc/jenkins_jobs/jenkins_jobs.ini \
         --network local_apm-pipeline-library \
-        widerplan/jenkins-job-builder -l error update "${BASENAME}"
+        osmman/jenkins-job-builder:3.0.2 -l error update "${BASENAME}"
 printf '\tpassed\n'


### PR DESCRIPTION
## What does this PR do?

Current JJB docker image uses JJB version 2.x and that's not what we have already in production.

## Why is it important?

Align versions

## Related issues
Closes #ISSUE