### PR TITLE
feat: enable input parameters for the docker upload pipeline

### DIFF
--- a/.ci/jobs/apm-docker-images-es-pipeline.yml
+++ b/.ci/jobs/apm-docker-images-es-pipeline.yml
@@ -10,6 +10,21 @@
           name: branch_specifier
           default: master
           description: the Git branch specifier to build
+      - string:
+          name: registry
+          default: docker.elastic.co
+      - string:
+          name: tag_prefix
+          default: observability-ci
+      - string:
+          name: version
+          default: daily
+      - string:
+          name: elastic_stack
+          default: 8.0.0-SNAPSHOT
+      - string:
+          name: secret
+          default: secret/apm-team/ci/docker-registry/prod
     pipeline-scm:
       script-path: .ci/dockerImagesESLatest.groovy
       scm:


### PR DESCRIPTION
## What does this PR do?

JJBB in conjunction with Pipeline do not populate the input parameters in the UI

## Why is it important?

Being able to run manually different configurations

## Related issues
Caused by https://github.com/elastic/observability-dev/issues/427