### PR TITLE
feat: store https://artifacts-api.elastic.co/v1/versions output

### DIFF
--- a/.ci/dockerImagesESLatest.groovy
+++ b/.ci/dockerImagesESLatest.groovy
@@ -70,6 +70,11 @@ pipeline {
           sh(label: 'Get Docker images', script: "./resources/scripts/getDockerImages.sh ${params.elastic_stack}")
         }
       }
+      post {
+        always {
+          archiveArtifacts(allowEmptyArchive: true, artifacts: 'metadata.txt')
+        }
+      }
     }
     stage('Push Docker images'){
       steps {

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/
 .vagrant
 
 mail*.html
+metadata.txt


### PR DESCRIPTION
## What does this PR do?

Archive the output from the API query. Minor changes in the shell to avoid piping but using the redirect.

## Why is it important?

It will help to extend the use case of upgrading our K8s clusters when there are new changes as the output will be the one to compare with the new API queries.

## Related issues

Caused by https://github.com/elastic/observability-dev/issues/427