### PR TITLE
feat: notify to the distribution list with the filter

### DIFF
--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -181,4 +181,40 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
 
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testCustomisedEmailWithEmptyOrNull() throws Exception {
+    def script = loadScript(scriptName)
+    assertTrue(script.customisedEmail('').equals(''))
+    assertTrue(script.customisedEmail(null).equals(''))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testCustomisedEmailWithoutJOB_NAME() throws Exception {
+    def script = loadScript(scriptName)
+    env.REPO = 'foo'
+    env.remove('JOB_NAME')
+    def result = script.customisedEmail('build-apm@example.com')
+    assertTrue(result.equals('build-apm+foo@example.com'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testCustomisedEmailWithJOB_NAME() throws Exception {
+    def script = loadScript(scriptName)
+    env.REPO = 'foo'
+    env.JOB_NAME = 'folder1/folder2/foo'
+    assertTrue(script.customisedEmail('build-apm@example.com').equals('build-apm+folder1@example.com'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testCustomisedEmailWithEmptyEnv() throws Exception {
+    def script = loadScript(scriptName)
+    env.REPO = ''
+    env.JOB_NAME = ''
+    assertTrue(script.customisedEmail('build-apm@example.com').equals('build-apm@example.com'))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -505,7 +505,7 @@ notifyBuildResult(es: 'http://elastisearch.example.com:9200', secret: 'secret/te
 ```
 * es: Elasticserach URL to send the report.
 * secret: vault secret used to access to Elasticsearch, it should have `user` and `password` fields.
-* to: Array of emails to notify.
+* to: Array of emails to notify. Optional. Default value uses `env.NOTIFY_TO` which will add a suffix to the distribution list with the folder name or env.REPO
 * statsURL: Kibana URL where you can check the stats sent to Elastic search.
 * shouldNotify: boolean value to decide to send or not the email notifications, by default it send
 emails on Failed builds that are not pull request.

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -31,7 +31,7 @@ def call(Map params = [:]) {
     stage('Reporting build status'){
       def secret = params.containsKey('secret') ? params.secret : 'secret/apm-team/ci/jenkins-stats-cloud'
       def es = params.containsKey('es') ? params.es : getVaultSecret(secret: secret)?.data.url
-      def to = params.containsKey('to') ? params.to : ["${env.NOTIFY_TO}"]
+      def to = params.containsKey('to') ? params.to : [ customisedEmail(env.NOTIFY_TO)]
       def statsURL = params.containsKey('statsURL') ? params.statsURL : "ela.st/observabtl-ci-stats"
       def shouldNotify = params.containsKey('shouldNotify') ? params.shouldNotify : !env.CHANGE_ID && currentBuild.currentResult != "SUCCESS"
 
@@ -60,4 +60,25 @@ def call(Map params = [:]) {
       }
     }
   }
+}
+
+def customisedEmail(String email) {
+  if (email) {
+    // default name should be the REPO env variable.
+    def suffix = env.REPO
+
+    // If JOB_NAME then let's get its parent folder name
+    if (env.JOB_NAME) {
+      def folders = env.JOB_NAME.split("/")
+      if (folders?.length > 0) {
+        suffix = folders[0]
+      }
+    }
+    if (suffix?.trim()) {
+      return email.replace('@', "+${suffix}@")
+    } else {
+      return email
+    }
+  }
+  return ''
 }

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -10,7 +10,7 @@ notifyBuildResult(es: 'http://elastisearch.example.com:9200', secret: 'secret/te
 ```
 * es: Elasticserach URL to send the report.
 * secret: vault secret used to access to Elasticsearch, it should have `user` and `password` fields.
-* to: Array of emails to notify.
+* to: Array of emails to notify. Optional. Default value uses `env.NOTIFY_TO` which will add a suffix to the distribution list with the folder name or env.REPO
 * statsURL: Kibana URL where you can check the stats sent to Elastic search.
 * shouldNotify: boolean value to decide to send or not the email notifications, by default it send
 emails on Failed builds that are not pull request.


### PR DESCRIPTION
## What does this PR do?

Filter notifications using the parent folder name or the REPO name.

Top-level folder names are defined in the main dashboard:
- https://apm-ci.elastic.co/

## Why is it important?

Easy to filter emails for the build status using the +<filter>@elastic.co format

## Related issues

Closes https://github.com/elastic/observability-dev/issues/276