### PR TITLE
fix: avoid NPE on inconsistent return objects

### DIFF
--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -36,7 +36,7 @@ def call(Map params = [:]){
 
   log(level: 'INFO', text: "githubPrCheckApproved: Title: ${pr?.title} - User: ${user} - Author Association: ${pr?.author_association}")
 
-  approved = user != null || isPrApproved(reviews) || hasWritePermission(token, repoName, user) || isAuthorizedBot(user, userType)
+  approved = user != null && (isPrApproved(reviews) || hasWritePermission(token, repoName, user) || isAuthorizedBot(user, userType))
 
   if(!approved){
     error("githubPrCheckApproved: The PR is not approved yet")


### PR DESCRIPTION
## What does this PR do?

it protects against NPE accessing to login field on the user object.

## Why is it important?

It should not happen but we detected that in some cases the object returned by GitHub is not the expected and the method throws an NPE
