### PR TITLE
ci(jjbb): only PRs for the e2e Kibana UI

### DIFF
--- a/.ci/jobs/apm-ui-e2e-tests-mbp.yml
+++ b/.ci/jobs/apm-ui-e2e-tests-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-origin: merge-current
           discover-tags: false
           filter-by-name-wildcard:
-            includes: 'PR-48109'
+            includes: 'PR-*'
           notification-context: 'apm-ci/end2end'
           repo: kibana
           repo-owner: elastic
@@ -22,7 +22,7 @@
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:
-            - regular-branches: true
+            - regular-branches: false
             - change-request:
                 ignore-target-only-changes: false
           clean:


### PR DESCRIPTION
## What does this PR do?

Configure the `JJBB` for the end to end tests of the Kibana UI to be caring only for Pull Requests.

## Why is it important?

Branches are not required in this particular phase yet.

## Related issues

Relates to https://github.com/elastic/observability-dev/issues/361