### PR TITLE
[jjbb]: as long as https://github.com/elastic/infra/issues/16573 then it should be disabled

### DIFF
--- a/.ci/jobs/apm-ui-e2e-tests-mbp.yml
+++ b/.ci/jobs/apm-ui-e2e-tests-mbp.yml
@@ -5,6 +5,7 @@
     description: Jenkins pipeline to run the end2end tests for the APM UI
     project-type: multibranch
     script-path: .ci/end2end.groovy
+    disabled: true
     scm:
       - github:
           branch-discovery: no-pr


### PR DESCRIPTION
## What does this PR do?

Disable the pipeline as requested in the apm-ui channel

## Why is it important?

https://github.com/elastic/infra/issues/16573 is causing issues in the CI


## Related issues

Relates to https://github.com/elastic/infra/issues/16573