### PR TITLE
enable rebuild for the other main MPBs

### DIFF
--- a/vars/rebuildPipeline.groovy
+++ b/vars/rebuildPipeline.groovy
@@ -32,13 +32,72 @@ def call() {
 
   // Apply the rebuild only for the explicit pipelines.
   switch(env.JOB_NAME?.trim()) {
+    case ~/.*apm-agent-dotnet-mbp.*/:
+      apmAgentDotnet()
+      break
+    case ~/.*apm-agent-go-mbp.*/:
+      apmAgentGo()
+      break
+    case ~/.*apm-agent-java-mbp.*/:
+      apmAgentJava()
+      break
+    case ~/.*apm-agent-nodejs-mbp.*/:
+      apmAgentNodejs()
+      break
+    case ~/.*apm-agent-php-mbp.*/:
+      apmAgentPhp()
+      break
     case ~/.*apm-agent-python-mbp.*/:
       apmAgentPython()
+      break
+    case ~/.*apm-agent-ruby-mbp.*/:
+      apmAgentRuby()
+      break
+    case ~/.*apm-agent-rum-mbp.*/:
+      apmAgentRum()
+      break
+    case ~/.*apm-pipeline-library-mbp.*/:
+      apmPipelineLibrary()
+      break
+    case ~/.*apm-server-mbp.*/:
+      apmServer()
       break
     default:
       log(level: 'INFO', text: "rebuildPipeline: unsupported job '${env.JOB_NAME}'")
       break
   }
+}
+
+def apmAgentDotnet() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch)])
+}
+
+def apmAgentGo() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci),
+                     booleanParam(name: 'test_ci', value: params.test_ci),
+                     booleanParam(name: 'docker_test_ci', value: params.docker_test_ci),
+                     string(name: 'GO_VERSION', value: params.GO_VERSION)])
+}
+
+def apmAgentJava() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci),
+                     booleanParam(name: 'test_ci', value: params.test_ci),
+                     booleanParam(name: 'smoketests_ci', value: params.smoketests_ci),
+                     string(name: 'MAVEN_CONFIG', value: params.MAVEN_CONFIG)])
+}
+
+def apmAgentNodejs() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci),
+                     booleanParam(name: 'test_edge_ci', value: params.test_edge_ci),
+                     booleanParam(name: 'tests_ci', value: params.tests_ci),
+                     booleanParam(name: 'tav_ci', value: params.tav_ci)])
 }
 
 def apmAgentPython() {
@@ -47,4 +106,43 @@ def apmAgentPython() {
                      booleanParam(name: 'bench_ci', value: params.bench_ci),
                      booleanParam(name: 'tests_ci', value: params.tests_ci),
                      booleanParam(name: 'package_ci', value: params.package_ci)])
+}
+
+def apmAgentPhp() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false)
+}
+
+def apmAgentRuby() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci)])
+}
+
+def apmAgentRum() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'saucelab_test', value: params.saucelab_test),
+                     booleanParam(name: 'parallel_test', value: params.parallel_test),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci)])
+}
+
+def apmPipelineLibrary() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'make_release', value: params.make_release)])
+}
+
+def apmServer() {
+  build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
+        parameters: [booleanParam(name: 'Run_As_Master_Branch', value: params.Run_As_Master_Branch),
+                     booleanParam(name: 'linux_ci', value: params.linux_ci),
+                     booleanParam(name: 'test_ci', value: params.test_ci),
+                     booleanParam(name: 'windows_ci', value: params.windows_ci),
+                     booleanParam(name: 'intake_ci', value: params.intake_ci),
+                     booleanParam(name: 'test_sys_env_ci', value: params.test_sys_env_ci),
+                     booleanParam(name: 'bench_ci', value: params.bench_ci),
+                     booleanParam(name: 'release_ci', value: params.release_ci),
+                     booleanParam(name: 'kibana_update_ci', value: params.kibana_update_ci),
+                     booleanParam(name: 'its_ci', value: params.its_ci),
+                     string(name: 'DIAGNOSTIC_INTERVAL', value: params.DIAGNOSTIC_INTERVAL),
+                     string(name: 'ES_LOG_LEVEL', value: params.ES_LOG_LEVEL)])
 }


### PR DESCRIPTION
## What does this PR do?

Enable the rebuildPlugin for our main MBPs

## Why is it important?

As long as the networking issue is in place we do need to mitigate the build errors with some automation on the top

## Related issues
Closes #ISSUE