### PR TITLE
support upstreamTrigger validation in the 1st time contributors

### DIFF
--- a/src/test/groovy/IsUpstreamTriggerStepTests.groovy
+++ b/src/test/groovy/IsUpstreamTriggerStepTests.groovy
@@ -1,0 +1,91 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import net.sf.json.JSONNull
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsUpstreamTriggerStepTests extends ApmBasePipelineTest {
+  String scriptName = 'vars/isUpstreamTrigger.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+  }
+
+  @Test
+  void test_with_upstream_cause() throws Exception {
+    binding.getVariable('currentBuild').getBuildCauses = {
+      return [
+        [
+          _class: 'hudson.model.Cause$UpstreamCause',
+          shortDescription: 'Started by upstream project "apm-integration-tests/PR-695" build number 5',
+          upstreamBuild: 5,
+          upstreamProject: 'apm-integration-tests/PR-695',
+          upstreamUrl: 'job/apm-integration-tests/job/PR-695/'
+        ]
+      ]
+    }
+
+    def script = loadScript(scriptName)
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('log', 'isUpstreamTrigger: apm-integration-tests/PR-695'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_trigger_cause() throws Exception {
+    binding.getVariable('currentBuild').getBuildCauses = {
+      return [
+        [
+          _class: 'hudson.triggers.TimerTrigger$TimerTriggerCause',
+          shortDescription: 'Started by a timmer',
+        ]
+      ]
+    }
+
+    def script = loadScript(scriptName)
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_upstream_cause_without_upstreamProject() throws Exception {
+    binding.getVariable('currentBuild').getBuildCauses = {
+      return [
+        [
+          _class: 'hudson.model.Cause$UpstreamCause',
+          shortDescription: 'Started by upstream project "apm-integration-tests/PR-695" build number 5',
+          upstreamBuild: 5
+        ]
+      ]
+    }
+
+    def script = loadScript(scriptName)
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -495,6 +495,13 @@ Check it the build was triggered by a timer (scheduled job).
 def timmerTrigger = isTimerTrigger()
 ```
 
+## isUpstreamTrigger
+Check if the build was triggered by an upstream job.
+
+```
+def upstreamTrigger = isUpstreamTrigger()
+```
+
 ## isUserTrigger
 Check it the build was triggered by a user.
 it stores the username in the BUILD_CAUSE_USER environment variable.

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -103,7 +103,7 @@ def call(Map params = [:]){
       error "${message}"
     }
     githubEnv()
-    if(isUserTrigger() || isCommentTrigger()){
+    if(isUserTrigger() || isCommentTrigger() || isUpstreamTrigger()){
       // Ensure the GH check gets reset as there is a cornercase where a specific commit got relaunched and this check failed.
       if (notify) {
         githubNotify(context: githubCheckContext, status: 'SUCCESS', targetUrl: ' ')

--- a/vars/isUpstreamTrigger.groovy
+++ b/vars/isUpstreamTrigger.groovy
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Check it the build was triggered by an upstream job.
+
+  def upstreamTrigger = isUpstreamTrigger()
+*/
+def call(){
+  def buildCause = currentBuild.getBuildCauses()?.find{ it._class == 'hudson.model.Cause$UpstreamCause'}
+  if (buildCause?.upstreamProject?.trim()) {
+    log(level: 'DEBUG', text: "isUpstreamTrigger: ${buildCause?.upstreamProject?.toString()}")
+    return true
+  }
+  return false
+}

--- a/vars/isUpstreamTrigger.txt
+++ b/vars/isUpstreamTrigger.txt
@@ -1,0 +1,5 @@
+Check if the build was triggered by an upstream job.
+
+```
+def upstreamTrigger = isUpstreamTrigger()
+```


### PR DESCRIPTION
## What does this PR do?

Enable isUpstreamTrigger to validate when checking out the repo as this is a valid use case to be excluded from the first time contributors check

## Why is it important?

To support the downstream jobs.

## Related issues

Closes https://github.com/elastic/apm-pipeline-library/issues/313