### PR TITLE
Add information on Docker creds

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -41,7 +41,6 @@ order to utilize the local Jenkins master:
   You may also need to authenticate to the Elastic Docker repo. You can do so by visiting
   the [registry authentication page](https://github.com/elastic/infra/blob/master/docs/vault/README.md#github-auth).
 
-
 ### APM Pipeline shared library
 
 This particular Jenkins instance got the shared library loaded by default.


### PR DESCRIPTION
## What does this PR do?

Minor documentation update

## Why is it important?

Provides information to new users on how to auth to the Docker registry.

## Related issues
No issue filed. Discovered during onboarding process.
