### PR TITLE
ci(jenkins): support rebuild for the toplevel apm-integration-tests pipeline

### DIFF
--- a/vars/rebuildPipeline.groovy
+++ b/vars/rebuildPipeline.groovy
@@ -56,8 +56,8 @@ def call() {
     case ~/.*apm-agent-rum-mbp.*/:
       apmAgentRum()
       break
-    case ~/.*apm-integration-tests\/PR-.*/:
-      apmIntegrationsLibrary()
+    case ~/.*apm-integration-tests\/.*/:
+      apmIntegrationTests()
       break
     case ~/.*apm-pipeline-library-mbp.*/:
       apmPipelineLibrary()
@@ -129,7 +129,7 @@ def apmAgentRum() {
                      booleanParam(name: 'bench_ci', value: params.bench_ci)])
 }
 
-def apmIntegrationsLibrary() {
+def apmIntegrationTests() {
   build(job: env.JOB_NAME, propagate: false, quietPeriod: 1, wait: false,
         parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
                      string(name: 'BUILD_OPTS', value: params.BUILD_OPTS),


### PR DESCRIPTION
## What does this PR do?

Rebuild the apm-integration-testing pipeline

## Why is it important?

Workaround the enviromental issues with the GitHub checkout

See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-tests/detail/PR-707/2/pipeline/)

## Related issues

Closes #ISSUE