### PR TITLE
🚧Support withSecretVault with more use cases

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -20,6 +20,7 @@ import co.elastic.mock.DockerMock
 import co.elastic.mock.GetVaultSecretMock
 import co.elastic.mock.PullRequestMock
 import co.elastic.mock.StepsMock
+import co.elastic.mock.WithSecretVaultMock
 import co.elastic.TestUtils
 
 import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
@@ -49,10 +50,11 @@ class ApmBasePipelineTest extends BasePipelineTest {
     registerSharedLibraryMethods()
 
     binding.setVariable('env', env)
-    binding.setProperty('getVaultSecret', new GetVaultSecretMock())
     binding.setProperty('docker', new DockerMock())
-    binding.setProperty('steps', new StepsMock())
+    binding.setProperty('getVaultSecret', new GetVaultSecretMock())
     binding.setProperty('pullRequest', new PullRequestMock())
+    binding.setProperty('steps', new StepsMock())
+    binding.setProperty('withSecretVault', new WithSecretVaultMock())
   }
 
   void registerDeclarativeMethods() {

--- a/src/test/groovy/co/elastic/mock/WithSecretVaultMock.groovy
+++ b/src/test/groovy/co/elastic/mock/WithSecretVaultMock.groovy
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package co.elastic.mock
+
+/**
+ * Mock withSecretVault step.
+ */
+class WithSecretVaultMock implements Serializable {
+  public void withSingleValue(Map params, Closure body) { body() }
+  public void withMultipleValues(Map params, Closure body) { body() }
+}

--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -17,31 +17,53 @@
 
 /**
   Grab a secret from the vault, define the environment variables which have been
-  passed as parammeters and mask the secrets
+  passed as parameters and mask the secrets
 
+  withSecretVault(secret: 'secret', data: [[var: 'myuser', env: 'my_user_env'],[var: 'mypass', env: 'my_password_env']]){
+    //block
+  }
+
+  // Deprecated
   withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: 'my_password_env'){
+    //block
+  }
+  // Replaced with
+  withSecretVault(secret: 'secret', data: [[var: 'user_var_name', env: 'my_user_env',[var: 'pass_var_name'. env: 'my_password_env']]){
     //block
   }
 */
 def call(Map params = [:], Closure body) {
-  def secret = params?.secret
-  def user_variable = params?.user_var_name
-  def pass_variable = params?.pass_var_name
-
-  if (!secret || !user_variable || !pass_variable) {
-    error "withSecretVault: Missing variables"
+  if (params.data) {
+    withMultipleValues(params) {
+      body()
+    }
+  } else {
+    withSingleValue(params) {
+      body()
+    }
   }
+}
+
+def withMultipleValues(Map params = [:], Closure body) {
+  def secret = params.containsKey('secret') ? params.secret : error('withSecretVault: secret is a mandatory parameter.')
+  body()
+}
+
+def withSingleValue(Map params = [:], Closure body) {
+  def secret = params.containsKey('secret') ? params.secret : error('withSecretVault: secret is a mandatory parameter.')
+  def user_variable = params.containsKey('user_var_name') ? params.user_var_name : error('withSecretVault: user_var_name is a mandatory parameter.')
+  def pass_variable = params.containsKey('pass_var_name') ? params.pass_var_name : error('withSecretVault: pass_var_name is a mandatory parameter.')
 
   def props = getVaultSecret(secret: secret)
   if(props?.errors){
-    error "withSecretVault: Unable to get credentials from the vault: " + props.errors.toString()
+    error 'withSecretVault: Unable to get credentials from the vault: ' + props.errors.toString()
   }
 
   def user = props?.data?.user
   def password = props?.data?.password
 
   if(user == null || password == null){
-    error "withSecretVault: was not possible to get authentication info"
+    error 'withSecretVault: was not possible to get authentication info'
   }
 
   wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [


### PR DESCRIPTION
## What does this PR do?

Enable more generic cases for the withSecretVault step

## Why is it important?

Simplify our pipeline.

## Related issues

Closes https://github.com/elastic/observability-dev/issues/39
