### PR TITLE
enable HOME/PATH env variables for the preCommit's step context

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -63,6 +63,7 @@ class PreCommitStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'bar | xargs pre-commit run --files'))
     assertTrue(assertMethodCallContainsPattern('withEnv', "HOME=${env.HOME}"))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "PATH=${env.HOME}/bin"))
     assertJobStatusSuccess()
   }
 
@@ -111,6 +112,7 @@ class PreCommitStepTests extends ApmBasePipelineTest {
     script.call(commit: 'foo')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withEnv', "HOME=${env.WORKSPACE}"))
+    assertTrue(assertMethodCallContainsPattern('withEnv', "PATH=${env.WORKSPACE}/bin"))
     assertJobStatusSuccess()
   }
 }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -47,7 +47,7 @@ def call(Map params = [:]) {
     }
 
     def newHome = env.HOME ?: env.WORKSPACE
-    withEnv(["HOME=${newHome}"]) {
+    withEnv(["HOME=${newHome}", "PATH=${newHome}/bin:${env.PATH}"]) {
       sh """
         curl https://pre-commit.com/install-local.py | python -
         git diff-tree --no-commit-id --name-only -r ${commit} | xargs pre-commit run --files | tee ${reportFileName}


### PR DESCRIPTION
## What does this PR do?

Configure the required environment variables

## Why is it important?

Avoid to be explicit in the pipelines that use this particular step

## Related issues

Relates to https://github.com/elastic/ecs-logging-php/pull/6