### PR TITLE
ci(jenkins): validate pipelines

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     PIPELINE_LOG_LEVEL = 'DEBUG'
-    PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.WORKSPACE}/bin:${env.PATH}"
+    PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.PATH}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

Run the validateDeclarativePipeline step in the BASE_DIR folder. Some cosmetic changes.

## Why is it important?

It was not validated.

```
11:10:53  [Pipeline] validateDeclarativePipeline
11:10:53  Declarative Pipeline file '.ci/Jenkinsfile' does not exist.
```

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/325