### PR TITLE
fix: support docker.inside with the precommit step

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -63,7 +63,7 @@ class PreCommitStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'bar | xargs pre-commit run --files'))
     assertTrue(assertMethodCallContainsPattern('withEnv', "HOME=${env.HOME}"))
-    assertTrue(assertMethodCallContainsPattern('withEnv', "PATH=${env.HOME}/bin"))
+    assertTrue(assertMethodCallContainsPattern('sh', "PATH=${env.HOME}/bin"))
     assertJobStatusSuccess()
   }
 
@@ -112,7 +112,7 @@ class PreCommitStepTests extends ApmBasePipelineTest {
     script.call(commit: 'foo')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withEnv', "HOME=${env.WORKSPACE}"))
-    assertTrue(assertMethodCallContainsPattern('withEnv', "PATH=${env.WORKSPACE}/bin"))
+    assertTrue(assertMethodCallContainsPattern('sh', "PATH=${env.WORKSPACE}/bin"))
     assertJobStatusSuccess()
   }
 }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -47,8 +47,9 @@ def call(Map params = [:]) {
     }
 
     def newHome = env.HOME ?: env.WORKSPACE
-    withEnv(["HOME=${newHome}", "PATH=${newHome}/bin:${env.PATH}"]) {
+    withEnv(["HOME=${newHome}"]) {
       sh """
+        export PATH=${newHome}/bin:${env.PATH}
         curl https://pre-commit.com/install-local.py | python -
         git diff-tree --no-commit-id --name-only -r ${commit} | xargs pre-commit run --files | tee ${reportFileName}
       """


### PR DESCRIPTION
## What does this PR do?

Fixes the issue when using withEnv and PATH env variable. 

## Why is it important?

To simplify how to trigger the pre-commit withn a docker container.

## Related issues

Related to https://github.com/elastic/apm-agent-python/pull/684