### PR TITLE
fix: failed builds don't return a RunWrapper object

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -97,9 +97,11 @@ unclassified:
 jobs:
   - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/cancelPreviousRunningBuilds.dsl"
+  - file: "/var/pipeline-library/src/test/resources/jobs/downstream.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/gitCheckout.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/isTimerTrigger.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/isUserTrigger.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/log.dsl"
+  - file: "/var/pipeline-library/src/test/resources/jobs/parentstream.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/pipelineManager.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/rebuildPipeline.dsl"

--- a/src/test/groovy/BuildStepTests.groovy
+++ b/src/test/groovy/BuildStepTests.groovy
@@ -51,14 +51,14 @@ public class BuildStepTests extends ApmBasePipelineTest {
   @Test
   void testException() throws Exception {
     def script = loadScript(scriptName)
-    def result = script.getRedirectLink(new Exception('nested » foo #1'), 'nested/foo')
+    def result = script.getRedirectLink('nested » foo #1', 'nested/foo')
     assertTrue(result.contains("${env.JENKINS_URL}job/nested/job/foo/1/display/redirect"))
   }
 
   @Test
   void testExceptionWithoutTheFormat() throws Exception {
     def script = loadScript(scriptName)
-    def result = script.getRedirectLink(new Exception('nested » foo'), 'nested/foo')
+    def result = script.getRedirectLink('nested » foo', 'nested/foo')
     assertTrue(result.contains("Can not determine redirect link"))
   }
 

--- a/src/test/resources/jobs/downstream.dsl
+++ b/src/test/resources/jobs/downstream.dsl
@@ -1,0 +1,19 @@
+NAME = 'it/downstream'
+DSL = '''pipeline {
+  agent any
+  stages {
+    stage('error') {
+      steps {
+        error 'force a build error'
+      }
+    }
+  }
+}'''
+
+pipelineJob(NAME) {
+  definition {
+    cps {
+      script(DSL.stripIndent())
+    }
+  }
+}

--- a/src/test/resources/jobs/parentstream.dsl
+++ b/src/test/resources/jobs/parentstream.dsl
@@ -1,0 +1,19 @@
+NAME = 'it/parentstream'
+DSL = '''pipeline {
+  agent any
+  stages {
+    stage('trigger downstream') {
+      steps {
+        build job: 'downstream'
+      }
+    }
+  }
+}'''
+
+pipelineJob(NAME) {
+  definition {
+    cps {
+      script(DSL.stripIndent())
+    }
+  }
+}

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -33,20 +33,21 @@ def call(Map params = [:]){
 
   def buildInfo
   try {
-      buildInfo = steps.build(job: job, parameters: parameters, wait: wait, propagate: propagate, quietPeriod: quietPeriod)
+    buildInfo = steps.build(job: job, parameters: parameters, wait: wait, propagate: propagate, quietPeriod: quietPeriod)
   } catch (Exception e) {
-      log(level: 'INFO', text: "${getRedirectLink(e, job)}")
-      throw e
+    def buildLogOutput = currentBuild.rawBuild.getLog(2).find { it.contains('Starting building') }
+    log(level: 'INFO', text: "${getRedirectLink(buildLogOutput, job)}")
+    throw e
   }
   log(level: 'INFO', text: "${getRedirectLink(buildInfo, job)}")
   return buildInfo
 }
 
 def getRedirectLink(buildInfo, jobName) {
-  if(buildInfo instanceof Exception) {
+  if(buildInfo instanceof String) {
     def buildNumber = ''
-    buildInfo.toString().split(" ").each {
-      if(it.contains("#")) {
+    buildInfo.toString().split(' ').each {
+      if(it.contains('#')) {
         buildNumber = it.substring(1)
       }
     }


### PR DESCRIPTION
## What does this PR do?

If the build fails then the object doesn't provide the buildId. This is the way to get those details from the rawbuild

## Why is it important?

Help with the link to the broken downstreams

## Related issues

Closes https://github.com/elastic/apm-pipeline-library/issues/340

## How to test it

```bash
$ hub pr checkout 339
$ cd local
$ make restart
$ cd workers/linux
$ vagrant up --provision
$ open http://localhost:18080/job/it/job/parentstream/
```


![image](https://user-images.githubusercontent.com/2871786/72277312-9c2d6080-3629-11ea-9013-7f5b1c0eb2ba.png)
