### PR TITLE
Add ssh-agent explicitly

### DIFF
--- a/local/configs/plugins.txt
+++ b/local/configs/plugins.txt
@@ -1,2 +1,3 @@
 filesystem_scm
 job-dsl
+ssh-agent


### PR DESCRIPTION
## What does this PR do?

Add the required plugin

## Why is it important?

Waiting for the upcoming release for the docker local instance from instance so that plugin is not in the installed plugins yet.

This can be reverted after the next release.

## Related issues

Relates to https://github.com/elastic/infra/pull/17138