### PR TITLE
ci(jenkins): enable tag args and force the tag creation

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
             ''')
           }
           gitPush()
-          gitCreateTag(tag: 'current', pushArgs: '--force')
+          gitCreateTag(tag: 'current', tagArgs: '--force', pushArgs: '--force')
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -221,4 +221,12 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>debug</id>
+      <properties>
+        <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/src/test/groovy/GitCreateTagStepTests.groovy
+++ b/src/test/groovy/GitCreateTagStepTests.groovy
@@ -56,4 +56,13 @@ class GitCreateTagStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('gitPush', 'args=--tags -f'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testTagArgs() throws Exception {
+    def script = loadScript(scriptName)
+    script.call(tag: 'my_tag', tagArgs: '-f')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "git tag -a -m 'chore: Create tag my_tag' 'my_tag' -f"))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/gitCreateTag.groovy
+++ b/vars/gitCreateTag.groovy
@@ -24,8 +24,9 @@
 
 def call(Map params = [:]) {
   def tag =  params.get('tag', "${BUILD_TAG}")
+  def tagArgs =  params.get('tagArgs', '')
   def pushArgs = params.get('pushArgs', '')
   def credentialsId = params.get('credentialsId', '')
-  sh(label: "create tag", script: "git tag -a -m 'chore: Create tag ${tag}' '${tag}'")
+  sh(label: "create tag", script: "git tag -a -m 'chore: Create tag ${tag}' '${tag}' ${tagArgs}")
   gitPush(credentialsId: credentialsId, args: "--tags ${pushArgs}")
 }

--- a/vars/gitCreateTag.txt
+++ b/vars/gitCreateTag.txt
@@ -10,5 +10,6 @@ gitCreateTag(tag: 'tagName', credentialsId: 'my_credentials')
 ```
 
 * tag: name of the new tag.
+* tagArgs: what arguments are passed to the tag command
 * credentialsId: the credentials to access the repo.
 * pushArgs: what arguments are passed to the push command


### PR DESCRIPTION
## What does this PR do?

Enable to add tag arguments to force the tag creation in the current release process. Add the debug maven profile to get verbose output in the terminal if required

## Why is it important?

Fixes the release process and help with the local development when running `mvn clean test -P debug`

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/347 and https://github.com/elastic/apm-pipeline-library/pull/339