### PR TITLE
ci(jenkins): workaround the timeout with a sleep

### DIFF
--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -50,6 +50,9 @@ def call(Map params = [:]){
   def githubCheckContext = 'CI-approved contributor'
   def extensions = []
 
+  // Force the sleep to avoid the timeout when reusing CI Workers.
+  sleep(20)
+
   if (shallowValue && mergeTarget != null) {
     // https://issues.jenkins-ci.org/browse/JENKINS-45771
     log(level: 'INFO', text: "'shallow' is forced to be disabled when using mergeTarget to avoid refusing to merge unrelated histories")


### PR DESCRIPTION
## What does this PR do?

Add a 20 seconds sleep to help with the assigining of CI workers

## Why is it important?

Mitigate the tiemout when accessing to the GitHub repo, it might be related to the current issue when reusing Workers

## Related issues

https://github.com/elastic/infra/issues/16001