### PR TITLE
Adds Probot Paths-Labeller descriptor to the library

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -12,8 +12,6 @@
   - ".github/*"
   - ".mvn/*"
   - "local/*"
-- "jenkins":
-  - "local/**/*"
 - "master":
   - "local/Dockerfile"
   - "local/docker-compose.yml"


### PR DESCRIPTION
## What does this PR do?
This PR adds the descriptor in YAML format for the bot we created to add labels based on paths.

## Why is it important?
It will allow Elastic's Infra's probot (`botelastic`) to manage PRs in this repository, adding labels when a modified path matches the globs defined in the descriptor.

## Related issues
Once merged, we have to contact Infra to subscribe this repository to the `botelastic` probot, which I guess it's done using Github's UI 🤔 

## Follow-ups
The format only supports globs, but @v1v proposed using both globs and regexs, which would simplify the descriptor. There is an open issue in the probot: https://github.com/mdelapenya/probot-paths-labeller/issues/8
