### PR TITLE
feat: build opbot daily

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -22,7 +22,7 @@ import groovy.transform.Field
 @Field def results = [:]
 
 pipeline {
-  agent none
+  agent { label 'immutable && docker' }
   environment {
     BASE_DIR="src"
     NOTIFY_TO = credentials('notify-to')
@@ -55,7 +55,6 @@ pipeline {
   }
   stages {
     stage('Cache Weblogic Docker Image'){
-      agent { label 'immutable && docker' }
       environment {
         IMAGE_TAG = "store/oracle/weblogic:12.2.1.3-dev"
         TAG_CACHE = "${params.registry}/${params.tag_prefix}/weblogic:12.2.1.3-dev"
@@ -69,11 +68,11 @@ pipeline {
         expression { return params.weblogic }
       }
       steps {
+        deleteDir()
         pushDockerImageFromStore("${IMAGE_TAG}", "${TAG_CACHE}")
       }
     }
     stage('Cache Oracle Instant Client Docker Image'){
-      agent { label 'immutable && docker' }
       environment {
         IMAGE_TAG = "store/oracle/database-instantclient:12.2.0.1"
         TAG_CACHE = "${params.registry}/${params.tag_prefix}/database-instantclient:12.2.0.1"
@@ -87,11 +86,11 @@ pipeline {
         expression { return params.oracle_instant_client }
       }
       steps {
+        deleteDir()
         pushDockerImageFromStore("${IMAGE_TAG}", "${TAG_CACHE}")
       }
     }
     stage('Build agent Python images'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build agent Python images failed')
@@ -101,6 +100,7 @@ pipeline {
         expression { return params.python }
       }
       steps {
+        deleteDir()
         dir('apm-agent-python'){
           git 'https://github.com/elastic/apm-agent-python.git'
           script {
@@ -125,7 +125,6 @@ pipeline {
       }
     }
     stage('Build Curator image'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build Curator image failed')
@@ -135,6 +134,7 @@ pipeline {
         expression { return params.python }
       }
       steps {
+        deleteDir()
         dockerLoginElasticRegistry()
         buildDockerImage(
           repo: 'https://github.com/elastic/curator.git',
@@ -144,7 +144,6 @@ pipeline {
       }
     }
     stage('Build Integration test Docker images'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build Integration test Docker images failed')
@@ -154,6 +153,7 @@ pipeline {
         expression { return params.apm_integration_testing }
       }
       steps {
+        deleteDir()
         checkout scm
         dockerLoginElasticRegistry()
         buildDockerImage(
@@ -177,7 +177,6 @@ pipeline {
       }
     }
     stage('Build Apm Server test Docker images'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build Apm Server Docker images failed')
@@ -187,6 +186,7 @@ pipeline {
         expression { return params.apm_integration_testing }
       }
       steps {
+        deleteDir()
         checkout scm
         dockerLoginElasticRegistry()
         buildDockerImage(
@@ -210,7 +210,6 @@ pipeline {
       }
     }
     stage('Build helm-kubernetes Docker hub image'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build helm-kubernetes Docker hub image failed')
@@ -220,6 +219,7 @@ pipeline {
         expression { return params.helm_kubectl }
       }
       steps {
+        deleteDir()
         dockerLoginElasticRegistry()
         buildDockerImage(
           repo: 'https://github.com/dtzar/helm-kubectl.git',
@@ -229,7 +229,6 @@ pipeline {
       }
     }
     stage('Build JRuby-jdk Docker images'){
-      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Build JRuby-jdk Docker images failed')
@@ -242,12 +241,31 @@ pipeline {
         expression { return params.jruby }
       }
       steps {
+        deleteDir()
         git url: 'https://github.com/elastic/docker-jruby', branch: 'versions'
         sh(label: 'build docker images', script: "./run.sh --action build --registry ${TAG_CACHE} --exclude 1.7")
         sh(label: 'test docker images', script: "./run.sh --action test --registry ${TAG_CACHE} --exclude 1.7")
         dockerLoginElasticRegistry()
         sh(label: 'push docker images', script: "./run.sh --action push --registry ${TAG_CACHE} --exclude 1.7")
         archiveArtifacts '*.log'
+      }
+    }
+    stage('Build opbot'){
+      options {
+        skipDefaultCheckout()
+      }
+      when{
+        beforeAgent true
+        expression { return params.jruby }
+      }
+      steps {
+        deleteDir()
+        dockerLoginElasticRegistry()
+        buildDockerImage(
+          repo: 'https://github.com/elastic/opbot.git',
+          tag: "opbot",
+          version: "latest",
+          push: true)
       }
     }
   }
@@ -279,7 +297,7 @@ def buildDockerImage(args){
   }
   image += "/${tag}:${version}"
   dir("${tag}-${version}"){
-    git "${repo}"
+    git credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "${repo}"
     dir("${folder}"){
       withEnv(env){
         sh(label: "build docker image", script: "docker build ${options} -t ${image} .")


### PR DESCRIPTION
## What does this PR do?

It builds the OpBot Docker image daily, also change the pipeline to use only one agent.

## Why is it important?

It will build and deploy the OpBot automatically in the Docker registry. 

## Related issues
related to https://github.com/elastic/observability-dev/issues/594
