### PR TITLE
Improve error reporting for Docker

### DIFF
--- a/local/Makefile
+++ b/local/Makefile
@@ -1,5 +1,5 @@
 VAULT_TOKEN ?= $(shell cat $${HOME}/.vault-token)
-LOG_LEVEL ?= CRITICAL
+LOG_LEVEL ?= WARNING
 .DEFAULT_GOAL := help
 
 .PHONY: build


### PR DESCRIPTION
## What does this PR do?

This improves our ability to see what's happening with Docker when there is a problem.

## Why is it important?

For example, if Docker isn't started on a workstation, `make` simply outputs `make: *** [status] Error 1` but no further information.

By setting the log level to something more informative, we can now easily see what the problem is:
```
WARNING: The VAULT_TOKEN variable is not set. Defaulting to a blank string.
WARNING: Some services (jenkins) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
ERROR: Couldn't connect to Docker daemon. You might need to start Docker for Mac.
make: *** [status] Error 1
```

## Related issues
No related issue.
