### PR TITLE
POST ability for GitHub API

### DIFF
--- a/src/test/groovy/GithubApiCallStepTests.groovy
+++ b/src/test/groovy/GithubApiCallStepTests.groovy
@@ -18,6 +18,7 @@
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
 
 class GithubApiCallStepTests extends ApmBasePipelineTest {
   String scriptName = 'vars/githubApiCall.groovy'
@@ -54,6 +55,32 @@ class GithubApiCallStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(ret[0].user.login == "githubusername")
     assertJobStatusSuccess()
+  }
+
+  @Test
+  void testData() throws Exception {
+    helper.registerAllowedMethod("httpRequest", [Map.class], shInterceptor)
+    def script = loadScript(scriptName)
+    try {
+      script.call(url: "dummy", token: "dummy", data: ["foo": "bar"])
+    } catch(e) {
+      // NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern("log", "gitHubApiCall: found data param. Switching to POST"))
+  }
+
+  @Test
+  void testNoData() throws Exception {
+    helper.registerAllowedMethod("httpRequest", [Map.class], shInterceptor)
+    def script = loadScript(scriptName)
+    try {
+      script.call(url: "dummy", token: "dummy")
+    } catch(e) {
+      // NOOP
+    }
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern("log", "gitHubApiCall: found data param. Switching to POST"))
   }
 
   @Test

--- a/vars/githubApiCall.txt
+++ b/vars/githubApiCall.txt
@@ -7,6 +7,7 @@ Make a REST API call to Github. It manage to hide the call and the token in the 
 
 * token: String to use as authentication token.
 * url: URL of the Github API call.
-* allowEmptyResponse: whether to allow empty responses. Default false
+* allowEmptyResponse: whether to allow empty responses. Default false.
+* data: Data to post to the API. Pass as a Map.
 
 [Github REST API](https://developer.github.com/v3/)


### PR DESCRIPTION
## What does this PR do?

This gives our interface to the GitHub API the ability to send a JSON-encoded data structure in a POST.

## Why is it important?

This unblocks follow-up work which will give us the ability to interact with some of GitHub's more sophisticated APIs, such as [the API to manage releases](https://developer.github.com/v3/repos/releases/#create-a-release).

## Testing

Testing can be a bit labor intensive, but below are my instructions which can be re-purposed for reviewers.

1. Pull down this PR

1. Set up a pipeline similar to this:

```
pipeline {
   agent any
   
    environment {
    REPO = 'apm-pipeline-library'
    BASE_DIR = "src/github.com/elastic/${env.REPO}"
    PIPELINE_LOG_LEVEL = "DEBUG"
  }

   stages {
      stage('Hello') {
         steps {
            gitCheckout(basedir: 'sub-folder', branch: 'master',
                repo: 'https://github.com/cachedout/apm-pipeline-library',
                credentialsId: <REPLACE_WITH_CORRECT_JENKINS_CREDS)
            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
            dir("/home/vagrant/workspace/test-gh/sub-folder"){
                sh("chmod -R u+w .git")
            }
            unstash 'source'
            dir("/home/vagrant/workspace/test-gh/sub-folder"){
                sh("ls -larth")
                
                githubEnv()
                githubApiCall(token: getGithubToken(),
                url: "http://10.0.2.20/",
                data: ['foo': 'bar'])
                
            }
         }
      }
   }
}
```

3. Bind an interface on your machine to the 10.0.2.0 network so that your local Jenkins instance can see it.

3. Listen on the interface you create: `sudo  nc -kdl 10.0.2.20 80`

3. Run the pipeline

3. Verify that you get a correctly formatted response on your `nc` process. Mine looks like this:

```
POST / HTTP/1.1
Host: 10.0.2.20:80
User-Agent: Elastic-Jenkins-APM
Content-Length: 13
Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
Authorization: token <REPLACE_WITH_REAL_TOKEN>
Cache-Control: no-cache
Content-Type: application/json
Pragma: no-cache
Accept-Encoding: gzip

{"foo":"bar"}
``` 
## Related issues
Refs https://github.com/elastic/apm-agent-java/issues/991
