### PR TITLE
sleep in the first checkout since it is the best worst scenario

### DIFF
--- a/vars/checkout.groovy
+++ b/vars/checkout.groovy
@@ -34,13 +34,11 @@ def call(params) {
 }
 
 def retryWithSleep(int i, body) {
+  def factor = 0
   retry(i) {
-    log(level: 'DEBUG', text: "Let's checkout (${i} tries).")
-    try {
-      body()
-    } catch(e) {
-      sleep(20)
-      throw e
-    }
+    factor++
+    log(level: 'DEBUG', text: "Let's checkout (${factor} of ${i} tries).")
+    sleep(10 * factor)
+    body()
   }
 }


### PR DESCRIPTION
## What does this PR do?

Force the sleep at the beginning with certain factor. 

## Why is it important?

It seems the previous configuration was good but in the worst case scenario is behaving bad:

```
16:41:51  Cloning repository git@github.com:elastic/apm-agent-dotnet.git
16:41:51   > git init /var/lib/jenkins/workspace/tnet_apm-agent-dotnet-mbp_PR-689 # timeout=10
16:41:51  Fetching upstream changes from git@github.com:elastic/apm-agent-dotnet.git
16:41:51   > git --version # timeout=10
16:41:51  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
16:41:51   > git fetch --no-tags --progress -- git@github.com:elastic/apm-agent-dotnet.git +refs/heads/*:refs/remotes/origin/* # timeout=15
16:42:22  ERROR: Error cloning remote repo 'origin'
16:42:22  hudson.plugins.git.GitException: Command "git fetch --no-tags --progress -- git@github.com:elastic/apm-agent-dotnet.git +refs/heads/*:refs/remotes/origin/*" returned status code 128:
16:42:22  stdout: 
16:42:22  stderr: ssh: connect to host github.com port 22: Connection timed out
16:42:22  fatal: Could not read from remote repository.
16:42:22  
16:42:22  Please make sure you have the correct access rights
16:42:22  and the repository exists.

...
16:42:22  [Pipeline] sleep
16:42:22  Sleeping for 20 sec
16:42:42  [Pipeline] }
16:42:42  ERROR: Error cloning remote repo 'origin'
16:42:42  Retrying
...
```

What do I mean?

In the above console output, there was a timeout after 30 seconds, then 20 seconds of sleeping before trying again.
 
 
## Related issues
Closes #ISSUE