### PR TITLE
PoC: serverspec to validate CI Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ metadata.txt
 
 out.html
 .vscode
+rspec.xml

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,6 @@
+--color
+--format documentation
+--format html
+--out rspec.html
+--format RspecJunitFormatter
+--out rspec.xml

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+require 'rake'
+require 'rspec/core/rake_task'
+require 'rspec_junit_formatter'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+    end
+  end
+end

--- a/spec/localhost/sample_spec.rb
+++ b/spec/localhost/sample_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe command('docker --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('docker-compose --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('go version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('gvm --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('git version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('java -version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('jq --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('mvn --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('node --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('npm --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('python --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('python3 --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end
+
+describe command('vault --version'), :if => ['debian', 'darwin', 'ubuntu'].include?(os[:family]) do
+  its(:exit_status) { should eq 0 }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
## What does this PR do?

Uses serverspec to validate the expected configuration in the CI workers and generate a junit output file

## Tasks
- [ ] Enable in the CI
- [ ] Enable the setup (Gemfile, and so on)

## Why is it important?

Standardise the CI validations with some JUnit reporting.

## Related issues
Closes #ISSUE

## How to use it

```
gem install serverspec rspec_junit_formatter
rake spec
open rspec.html
open rspec.xml
```
