### PR TITLE
dockerLogin step without a previous sleep causes DDoS

### DIFF
--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -44,18 +44,14 @@ def call(Map params = [:]){
       "DOCKER_PASSWORD=${dockerPassword}"
     ]) {
       retry(3) {
-        try {
-          sh(label: "Docker login", script: """
-            set +x
-            host ${registry} 2>&1 > /dev/null
-            docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
-            """)
-        } catch(e) {
-          // When running in the CI with multiple parallel stages
-          // the access could be considered as a DDOS attack. Let's sleep a bit if it fails.
-          sleep randomNumber(min: 5, max: 10)
-          throw e
-        }
+        // When running in the CI with multiple parallel stages
+        // the access could be considered as a DDOS attack.
+        sleep randomNumber(min: 5, max: 10)
+        sh(label: "Docker login", script: """
+          set +x
+          host ${registry} 2>&1 > /dev/null
+          docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
+          """)
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Enable the previous implementation to first sleep for and the run the docker login command.

## Why is it important?

Avoid any failed builds related to the ddos
## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/376