### PR TITLE
enable daily docker image generation for Node.js

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -50,6 +50,7 @@ pipeline {
             string(name: 'registry', value: 'docker.elastic.co'),
             string(name: 'tag_prefix', value: 'observability-ci'),
             string(name: 'secret', value: 'secret/apm-team/ci/docker-registry/prod'),
+            booleanParam(name: 'nodejs', value: true),
             booleanParam(name: 'python', value: true),
             booleanParam(name: 'ruby', value: true),
             booleanParam(name: 'weblogic', value: true),


### PR DESCRIPTION
## What does this PR do?

Enable the docker image generation on daily basis

## Why is it important?

Otherwise the build won't happen

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/382