### PR TITLE
ci(jenkins): opbeans release from tags only

### DIFF
--- a/src/test/groovy/OpbeansPipelineStepTests.groovy
+++ b/src/test/groovy/OpbeansPipelineStepTests.groovy
@@ -65,7 +65,7 @@ class OpbeansPipelineStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('stage', 'Downstream'))
     assertTrue(assertMethodCallContainsPattern('build', 'folder/foo'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'VERSION=latest make publish'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'make publish'))
     assertJobStatusSuccess()
   }
 

--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -136,13 +136,7 @@ def call(Map pipelineParams) {
       }
       stage('Release') {
         when {
-          anyOf {
-            branch 'master'
-            tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
-          }
-        }
-        environment {
-          VERSION = "${env.BRANCH_NAME.equals('master') ? 'latest' : 'agent-' + env.BRANCH_NAME}"
+          tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
         }
         stages {
           stage('Publish') {
@@ -152,7 +146,7 @@ def call(Map pipelineParams) {
                 unstash 'source'
                 dir(BASE_DIR){
                   dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-                  sh "VERSION=${env.VERSION} make publish"
+                  sh "VERSION=agent-${env.BRANCH_NAME} make publish"
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do?

Release from tags only, the opbeans repos will care of pushing a latest tag when they do the release.

## Why is it important?

Simplify the release process to be tag based.

## Concerns

I've got some concerns about whether this approach will add more complexity in the Makefile for each opbeans-xxx repo. WDYT? esp @mdelapenya 

## Related issues

Causes https://github.com/elastic/opbeans-dotnet/pull/26