### PR TITLE
fix: execute host only if exists

### DIFF
--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -50,6 +50,9 @@ def call(Map params = [:]){
             if command -v host; then
               host ${registry} 2>&1 > /dev/null 
             fi
+            if command -v dig; then
+              dig ${registry} 2>&1 > /dev/null 
+            fi
             docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
             """)
         } else {


### PR DESCRIPTION
## What does this PR do?

It adds a check that the command `host` exists.

## Why is it important?

In some workers, we detected that `host` command is not installed, fo we check it is installed and execute it, as an alternative we do the same with the `dig` command.

## Related issues
related to https://github.com/elastic/package-registry/pull/210
