### PR TITLE
fix: getBuildInfoJsonFiles with retry 3

### DIFF
--- a/vars/getBuildInfoJsonFiles.groovy
+++ b/vars/getBuildInfoJsonFiles.groovy
@@ -66,7 +66,7 @@ def bulkDownload(map) {
   }
   def command = ['status=0']
   map.each { url, file ->
-    command << "curl -sfSL --max-time 60 --connect-timeout 10 -o ${file} ${url} || status=1"
+    command << "(retry 3 curl -sfSL --max-time 60 --connect-timeout 10 -o ${file} ${url}) || status=1"
     command << """[ -e "${file}" ] || echo "{}" > "${file}" """
   }
   command << 'exit ${status}'


### PR DESCRIPTION
## What does this PR do?

When timeouts then let's retry with some sleep

## Why is it important?

Enable to notify the status of the build with meaningful details. For some reason the recent Jenkins upgrade caused some timeouts when accessing the BO entry points...

This will help to mitigate those issues although it might delay a bit the notifications...


## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/issues/387
Caused originally by https://github.com/elastic/infra/issues/18025