### PR TITLE
Adjust mock message for sh

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -191,8 +191,8 @@ class ApmBasePipelineTest extends BasePipelineTest {
     helper.registerAllowedMethod('bat', [Map.class], { 'OK' })
     helper.registerAllowedMethod('bat', [String.class], null)
     helper.registerAllowedMethod('booleanParam', [Map.class], null)
-    helper.registerAllowedMethod('brokenTestsSuspects', { "OK" })
-    helper.registerAllowedMethod('brokenBuildSuspects', { "OK" })
+    helper.registerAllowedMethod('brokenTestsSuspects', { "OK (mocked)" })
+    helper.registerAllowedMethod('brokenBuildSuspects', { "OK (mocked)" })
     helper.registerAllowedMethod('build', [Map.class], null)
     helper.registerAllowedMethod('catchError', [Closure.class], { body ->
       try{


### PR DESCRIPTION
## What does this PR do?

This just makes it more obvious that we have mocked the `sh` step.
## Why is it important?

Prevents developer confusion when the step appears to run successfully but doesn't represent accurate output.
