### PR TITLE
Dynamic mock object injection

### DIFF
--- a/src/test/groovy/DummyStepTests.groovy
+++ b/src/test/groovy/DummyStepTests.groovy
@@ -26,6 +26,67 @@ class DummyStepTests extends ApmBasePipelineTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
+}
+
+  @Test
+  void test() throws Exception {
+    def script = loadScript(scriptName)
+    script.call(text: "dummy")
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('log', 'I am a dummy step - dummy'))
+    assertJobStatusSuccess()
+  }
+}
+
+class DummyStepTestsWithMockInjection extends ApmBasePipelineTest {
+  String scriptName = 'vars/dummy.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    /* This is an illustration of how to remove a default mock object. This would apply
+    if the var in question (in this case, dummy.groovy was using `sh` which was then invoked
+    by a test.
+
+    To do this, ensure that the following conditions are met:
+
+    1.  The mock object you wish to override is in the approved list
+        entitled `allowedMockOverrides` which is present in the ApmBasePipelineTest
+        class.
+    2.  Make sure that getScriptedMethods contains the correct default for the
+        mocked method. This should come from the registration method (ex: registerScriptedMethods())
+    3.  Remove the default definition from the registration method (ex: registerScriptedMethods())
+    4.  Create an injector as illustrated below with the key being the mock you wish to override and
+        the value being a closure which defines its behavior.
+    5.  Have fun storming the castle.
+    */
+    binding.setVariable('mockInjector', ['sh': {k ->
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.command(k);
+
+        try {
+
+            Process process = processBuilder.start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+
+            int exitCode = process.waitFor();
+            System.out.println("\nExited with error code : " + exitCode);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }])
+
+    super.setUp()
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

This gives our testing suite the capability to dynamically add and remove mocks during the test run. Objects which are mocked can be temporarily "unmocked" or they can be replaced on-the-fly with an arbitrary block of code to do as you wish and then assert against.

This means that we no longer have to rely on the statically defined set of mock objects. If a test wishes to use a "live" version of `sh`, for example, this is now possible, without affecting any tests upstream or downstream.

## Why is it important?
Certain tests might _want_ to interact with the system and this allows for that to happen in isolation.


