### PR TITLE
[packer-cache] Cache jjbb images

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -27,11 +27,13 @@ alpine:3.10.1
 node:12-slim
 node:12.7.0-stretch-slim
 python:3.7.4-alpine3.10
+docker.elastic.co/infra/jjbb
 docker.elastic.co/observability-ci/codecov
 docker.elastic.co/observability-ci/golang-mage
 docker.elastic.co/observability-ci/gren
 docker.elastic.co/observability-ci/shellcheck
 docker.elastic.co/observability-ci/yamllint
+widerplan/jenkins-job-builder
 "
 
 for di in ${DOCKER_IMAGES}


### PR DESCRIPTION
## What does this PR do?

Cache more docker images to speedup the pre-commit validation

## Why is it important?

Less fetching and errors when pulling images, trying to tackle the bellow error in our CI that happens from time to time:

```
Error response from daemon: pull access denied for docker.elastic.co/infra/jjbb, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Transform JJBB to JJB
Unable to find image 'docker.elastic.co/infra/jjbb:latest' locally
```

## Related issues
Closes #ISSUE