### PR TITLE
ci(jenkins): support more generic cases for the pre-commit

### DIFF
--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -56,7 +56,7 @@ def call(Map params = [:]) {
         pre-commit install --install-hooks
 
         ## Search for the repo with the scripts to be added to the PATH
-        searchFile=\$(find ${newHome}/.cache/pre-commit -type d -name "scripts" | grep '.ci/scripts')
+        searchFile=\$(find ${newHome}/.cache/pre-commit -type d -name 'scripts' | grep '.ci/scripts')
         if [ -e "\${searchFile}" ] ; then
           export PATH=\${PATH}:\$(dirname \${searchFile})
         else


### PR DESCRIPTION
## What does this PR do?

Enable more generic search cases for the scripts hosted in this repo

## Why is it important?

If shellcheck is not enabled in the pre-commit then it won't be updated as expected.


```
[2020-02-26T14:38:59.143Z] + find /var/lib/jenkins/workspace/apm-integration-tests_PR-785/.cache/pre-commit -type f -name shellcheck
[2020-02-26T14:38:59.402Z] + searchFile=
[2020-02-26T14:38:59.402Z] + [ -e  ]
[2020-02-26T14:38:59.402Z] + echo WARN: PATH has not been configured with the shell scripts that might be required!
[2020-02-26T14:38:59.402Z] WARN: PATH has not been configured with the shell scripts that might be required!
...
[2020-02-26T14:39:00.484Z] Check syntax of the Jenkinsfiles................................................................Failed
[2020-02-26T14:39:00.484Z] - hook id: Jenkinsfile-linter
[2020-02-26T14:39:00.484Z] - duration: 0s
[2020-02-26T14:39:00.484Z] - exit code: 1
[2020-02-26T14:39:00.484Z] 
[2020-02-26T14:39:00.484Z] Executable `/var/lib/jenkins/workspace/apm-integration-tests_PR-785/src/github.com/elastic/apm-integration-testing/.ci/scripts/validate.sh` not found

```

See [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-integration-tests/detail/PR-785/1/pipeline/82#step-146-log-113)