### PR TITLE
fix: if grep fails then the errors

### DIFF
--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -57,6 +57,8 @@ def call(Map params = [:]) {
 
         ## Search for the repo with the scripts to be added to the PATH
         set +e
+        ## For debugging purposes only
+        find ${newHome}/.cache/pre-commit -depth 2 -type d
         searchFile=\$(find ${newHome}/.cache/pre-commit -type d -name 'scripts' | grep '.ci/scripts')
         if [ -e "\${searchFile}" ] ; then
           export PATH=\${PATH}:\$(dirname \${searchFile})


### PR DESCRIPTION
## What does this PR do?

Fixes the no happy path!

## Why is it important?

By default grep returns 1 if no match, then let's disable the error level for this particular section

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/407