### PR TITLE
docs: Add vault as a requirement for local infra

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -117,7 +117,14 @@ open http://localhost:18080
 make build
 ```
 
-2. Start the local Jenkins master service by running:
+2. Ensure you have access to Elastic's secrets infrastructure with Vault:
+```bash
+export VAULT_ADDR="https://secrets.elastic.co:8200"
+export ELASTIC_SECRETS_SERVICE_TOKEN="<Your GitHub token for Vault>"
+vault login -method github token="${ELASTIC_SECRETS_SERVICE_TOKEN}"
+```
+
+3. Start the local Jenkins master service by running:
 
 ```bash
 make start


### PR DESCRIPTION
## What does this PR do?
This PR adds vault login as a requirement for the creation of the local environment

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
If vault is not accesible, then no worker nor master will be able to use Elastic's Vault infra

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->