### PR TITLE
Add dumpMatrix() method

### DIFF
--- a/src/co/elastic/matrix/DefaultParallelTaskGenerator.groovy
+++ b/src/co/elastic/matrix/DefaultParallelTaskGenerator.groovy
@@ -172,7 +172,7 @@ class DefaultParallelTaskGenerator {
   */
   public List dumpMatrix(marker){
     if(results.size() == 0){
-      raise Exception("Must generate tests first. Did you run generateParallelTests()?")
+      error("Must generate tests first. Did you run generateParallelTests()?")
     } else {
       dump = []
       results.x.each{ x ->


### PR DESCRIPTION
## What does this PR do?

Adds a new method that can dump the matrix.
## Why is it important?

Gives us a way to see the matrix that will be processed.

## Related issues
This unblocks https://github.com/elastic/apm-agent-python/pull/735