### PR TITLE
ci(jenkins): run docker in the new home context

### DIFF
--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -42,12 +42,11 @@ def call(Map params = [:]) {
 
   sshagent([credentialsId]) {
 
-    if (registry && secretRegistry) {
-      dockerLogin(secret: "${secretRegistry}", registry: "${registry}")
-    }
-
     def newHome = env.HOME ?: env.WORKSPACE
     withEnv(["HOME=${newHome}"]) {
+      if (registry && secretRegistry) {
+        dockerLogin(secret: "${secretRegistry}", registry: "${registry}")
+      }
       sh """
         export PATH=${newHome}/bin:${env.PATH}
         curl https://pre-commit.com/install-local.py | python -


### PR DESCRIPTION
## What does this PR do?

Docker login in the new home env path

## Why is it important?

Otherwise cannot pull

## Related issues

See https://github.com/elastic/infra/issues/18164