### PR TITLE
Fix missing def in DefaultParallelTaskGenerator

### DIFF
--- a/src/co/elastic/matrix/DefaultParallelTaskGenerator.groovy
+++ b/src/co/elastic/matrix/DefaultParallelTaskGenerator.groovy
@@ -174,7 +174,7 @@ class DefaultParallelTaskGenerator {
     if(results.size() == 0){
       error("Must generate tests first. Did you run generateParallelTests()?")
     } else {
-      dump = []
+      def dump = []
       results.x.each{ x ->
         // def column = buildColumn(x, results.y, results.excludes)
         yItems.each{ y ->


### PR DESCRIPTION
## What does this PR do?

Makes dumpMatrix actually work instead of causing a stacktrace.

## Why is it important?
Fixes errors in apm-agent-python build

## Related issues
Refs https://github.com/elastic/apm-agent-python/pull/735