### PR TITLE
ci(jenkins): release stage requires the PATH

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -122,6 +122,10 @@ pipeline {
       }
     }
     stage('Release') {
+      environment {
+        // gren and other tools are in the .ci/scripts folder.
+        PATH = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.PATH}"
+      }
       when {
         expression {
           return params.make_release


### PR DESCRIPTION
## What does this PR do?

Fix the issue in the release process

## Why is it important?

PATH is required to be changed to enable the gren command

```
[2020-03-05T10:35:09.633Z] + ./resources/scripts/jenkins/release-notes.sh

[2020-03-05T10:35:09.633Z] + GREN_GITHUB_TOKEN=****

[2020-03-05T10:35:09.633Z] + gren release --token=**** --override -c .grenrc.js -t all

[2020-03-05T10:35:09.633Z] ./resources/scripts/jenkins/release-notes.sh: line 6: gren: command not found

script returned exit code 127
```

## Related issues
Closes #ISSUE