### PR TITLE
Add name param to github release

### DIFF
--- a/src/test/groovy/GithubReleasePublishTests.groovy
+++ b/src/test/groovy/GithubReleasePublishTests.groovy
@@ -78,7 +78,7 @@ class GithubReleasePublishTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod("githubApiCall", [Map.class], apiInterceptor)
     def script = loadScript(scriptName)
     script.BUILD_TAG = "dummy_tag"
-    def ret = script.call(url: "dummy", token: "dummy", id: 1)
+    def ret = script.call(url: "dummy", token: "dummy", id: 1, name: "Release v1.0.0")
     printCallStack()
     assertTrue(ret.tag_name == "v1.0.0")
     assertJobStatusSuccess()
@@ -89,7 +89,7 @@ class GithubReleasePublishTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod("githubApiCall", [Map.class], apiInterceptor)
     def script = loadScript(scriptName)
     try {
-      script.call(url: "dummy", token: "dummy")
+      script.call(url: "dummy", token: "dummy", name: "Release v1.0.0")
     } catch(e) {
       //NOOP
     }
@@ -98,12 +98,25 @@ class GithubReleasePublishTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void testNoName() throws Exception {
+    helper.registerAllowedMethod("githubApiCall", [Map.class], apiInterceptor)
+    def script = loadScript(scriptName)
+    try {
+      script.call(url: "dummy", token: "dummy", id: 1)
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'name is required'))
+  }
+
+  @Test
   void testNoOrg() throws Exception {
     helper.registerAllowedMethod("githubApiCall", [Map.class], apiInterceptor)
     def script = loadScript(scriptName)
     env.remove("ORG_NAME")  // Will be reset by setUp()
     try {
-      script.call(url: "dummy", token: "dummy")
+      script.call(url: "dummy", token: "dummy", name: "Release v1.0.0")
     } catch(e) {
       //NOOP
     }

--- a/vars/githubReleasePublish.groovy
+++ b/vars/githubReleasePublish.groovy
@@ -34,7 +34,8 @@ the data structure of the return.
   Example invocation:
 
     githubReleasePublish(
-      id: '1',         // Release ID
+      id: '1',                // Release ID
+      name: 'Release v1.0.0', // Release name 
     )
 
 To learn more about what individual flags mean, please visit the GitHub
@@ -52,6 +53,7 @@ def call(Map params = [:]){
   def token = getGithubToken()
 
   def id = params.containsKey('id') ? params.id : error('githubReleasePublish: id param is required.')
+  def name = params.containsKey('name') ? params.id : error('githubReleasePublish: name is required.')
 
   // Construct GitHub API URL
   def apiURL = "https://api.github.com/repos/${env.ORG_NAME}/${env.REPO_NAME}/releases/${id}"

--- a/vars/githubReleasePublish.txt
+++ b/vars/githubReleasePublish.txt
@@ -1,7 +1,8 @@
 Takes a GitHub release that is written as a draft and makes it public.
 ```
     githubReleasePublish(
-      id: '1',         // Release ID
+      id: '1',                // Release ID
+      name: 'Release v1.0.0'  // Release name 
     )
 ```
 * id: The ID of the draft release to publish. This should be in the return from githubReleaseCreate()


### PR DESCRIPTION
## What does this PR do?

Adds a `name` parameter.

## Why is it important?
Needed to support https://github.com/elastic/apm-agent-java/pull/1058

## Related issues
Refs https://github.com/elastic/apm-agent-java/pull/1058