### PR TITLE
Remove PYTHON_EXE when building beats images

### DIFF
--- a/.ci/buildBeatsDockerImages.groovy
+++ b/.ci/buildBeatsDockerImages.groovy
@@ -31,7 +31,6 @@ pipeline {
     NOTIFY_TO = credentials('notify-to')
     PATH = "${env.GOPATH}/bin:${env.PATH}"
     PIPELINE_LOG_LEVEL='INFO'
-    PYTHON_EXE='python2.7'
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

Remove `PYTHON_EXE` environment variable when building beats images.

## Why is it important?

`PYTHON_EXE` is set to Python 2, what makes build [fail](https://apm-ci.elastic.co/blue/organizations/jenkins/beats%2Fbeats-docker-images-pipeline/detail/beats-docker-images-pipeline/100/pipeline/57) since we migrated to Python 3. Mage code selects the proper version of Python now.