### PR TITLE
Install Docker in image

### DIFF
--- a/local/workers/linux/Vagrantfile
+++ b/local/workers/linux/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
     sh get-docker.sh
   fi
   su - vagrant -c 'curl -s https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.9/swarm-client-3.9.jar > swarm-client.jar'
-  su - vagrant -c 'nohup java -jar swarm-client.jar -labels "linux docker immutable ubuntu" -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1 &'
+  sudo nohup java -jar swarm-client.jar -labels "linux docker immutable ubuntu" -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1 &
   SCRIPT
 
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
## What does this PR do?
Installs Docker in the default image for local testing.

This also changes the Jenkins agent so that it runs as `root` instead of as the `vagrant` user. This is needed in order to successfully connect to the Docker daemon.

## Why is it important?

It's common for pipelines to use Docker and to call `docker login`. If Docker is not installed, this will quietly fail with `Error 127`. 
