### PR TITLE
ci(jenkins): release generation without override

### DIFF
--- a/resources/scripts/jenkins/release-notes.sh
+++ b/resources/scripts/jenkins/release-notes.sh
@@ -3,6 +3,6 @@ set -uxeo pipefail
 
 GREN_GITHUB_TOKEN=${GREN_GITHUB_TOKEN:?"missing GREN_GITHUB_TOKEN"}
 
-gren release --token="${GREN_GITHUB_TOKEN}" --override -c .grenrc.js -t all
+gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js -t all
 # it is generated from scratch to have reverse version order
 gren changelog --token="${GREN_GITHUB_TOKEN}" --override -c .grenrc.js -t all -G


### PR DESCRIPTION
## What does this PR do?

Let's not override the release but generate the release details for the ones that don't exist.

## Why is it important?

Release gets stalled in the CI

## Related issues
Closes #ISSUE