### PR TITLE
ci(release): skip labels and fix stalled issue

### DIFF
--- a/.ci/docker/gren/Dockerfile
+++ b/.ci/docker/gren/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get update -qq -y \
   && apt-get install -qq -y --no-install-recommends git \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install github-release-notes@0.17.0 -g
+RUN npm install github-release-notes@0.17.1 -g
 WORKDIR /app
 ENTRYPOINT [ "/usr/local/bin/gren" ]

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
     "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
       "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
-      "perf", "test", "style"],
+      "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows"],
     "groupBy": {
         "Enhancements": ["enhancement", "internal", "feature", "feat"],
         "Bug Fixes": ["bug", "fix"],

--- a/resources/scripts/jenkins/release-notes.sh
+++ b/resources/scripts/jenkins/release-notes.sh
@@ -3,6 +3,6 @@ set -uxeo pipefail
 
 GREN_GITHUB_TOKEN=${GREN_GITHUB_TOKEN:?"missing GREN_GITHUB_TOKEN"}
 
-gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js -t all
+gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js --limit 10
 # it is generated from scratch to have reverse version order
 gren changelog --token="${GREN_GITHUB_TOKEN}" --override -c .grenrc.js -t all -G


### PR DESCRIPTION
## What does this PR do?

- Exclude PR labels.
- Limit the latest releases to be generated for the last 10 ones.

## Why is it important?

Unblock the release automation

## Related issues
Closes #ISSUE