### PR TITLE
ci(jenkins): support from/to sha commits for isGitRegionMatch

### DIFF
--- a/src/test/groovy/IsGitRegionMatchStepTests.groovy
+++ b/src/test/groovy/IsGitRegionMatchStepTests.groovy
@@ -248,4 +248,40 @@ class IsGitRegionMatchStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('sh', 'something...bar'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testWithFromAndTo() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = ''' foo/bar/file.txt
+                    '''.stripMargin().stripIndent()
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def result = false
+    result = script.call(patterns: [ '^foo/.*/file.txt' ], from: 'something', to: 'else')
+    printCallStack()
+    assertTrue(result)
+    assertTrue(assertMethodCallContainsPattern('sh', 'something...else'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testFromAndToWithEmptyValues() throws Exception {
+    def script = loadScript(scriptName)
+    def result = false
+    result = script.call(patterns: [ '^foo/.*/file.txt' ], from: '', to: '')
+    printCallStack()
+    assertFalse(result)
+    assertTrue(assertMethodCallContainsPattern('echo', 'isGitRegionMatch: CHANGE_TARGET or GIT_PREVIOUS_COMMIT and GIT_BASE_COMMIT env variables are required to evaluate the changes.'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testToWithEmptyValue() throws Exception {
+    def script = loadScript(scriptName)
+    def result = false
+    result = script.call(patterns: [ '^foo/.*/file.txt' ], to: '')
+    printCallStack()
+    assertFalse(result)
+    assertTrue(assertMethodCallContainsPattern('echo', 'isGitRegionMatch: CHANGE_TARGET or GIT_PREVIOUS_COMMIT and GIT_BASE_COMMIT env variables are required to evaluate the changes.'))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -731,8 +731,10 @@ evaluates the change list with the pattern list:
 
 * patterns: list of patterns to be matched. Mandatory
 * shouldMatchAll: whether all the elements in the patterns should match with all the elements in the changeset. Default: false. Optional
-* from: to override the diff from sha. Optional.
-* to: to override the commit to. Optional. Default: GIT_BASE_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT
+* to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
+
+NOTE: This particular implementation requires to checkout with the step gitCheckout
 
 ## isTimerTrigger
 Check it the build was triggered by a timer (scheduled job).

--- a/vars/isGitRegionMatch.groovy
+++ b/vars/isGitRegionMatch.groovy
@@ -36,7 +36,7 @@ def call(Map params = [:]) {
   }
   def patterns = params.containsKey('patterns') ? params.patterns : error('isGitRegionMatch: Missing patterns argument.')
   def shouldMatchAll = params.get('shouldMatchAll', false)
-  def from = params.get('from')
+  def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)
   def to = params.get('to', env.GIT_BASE_COMMIT)
 
   if (patterns.isEmpty()) {
@@ -45,10 +45,7 @@ def call(Map params = [:]) {
 
   def gitDiffFile = 'git-diff.txt'
   def match = false
-  if (!from?.trim()) {
-    from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT
-  }
-  if (from && to) {
+  if (from?.trim() && to?.trim()) {
     def changes = sh(script: "git diff --name-only ${from}...${to} > ${gitDiffFile}", returnStdout: true)
     if (shouldMatchAll) {
       match = isFullPatternMatch(gitDiffFile, patterns)

--- a/vars/isGitRegionMatch.txt
+++ b/vars/isGitRegionMatch.txt
@@ -28,5 +28,7 @@ evaluates the change list with the pattern list:
 
 * patterns: list of patterns to be matched. Mandatory
 * shouldMatchAll: whether all the elements in the patterns should match with all the elements in the changeset. Default: false. Optional
-* from: to override the diff from sha. Optional.
-* to: to override the commit to. Optional. Default: GIT_BASE_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT
+* to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
+
+NOTE: This particular implementation requires to checkout with the step gitCheckout


### PR DESCRIPTION
## What does this PR do?

Support single pipelines without MBP. Git diff with to and from sha commits

## Why is it important?

To support single pipelines

## Related issues
Closes #452