### PR TITLE
ci: local jenkins improvements

### DIFF
--- a/local/Makefile
+++ b/local/Makefile
@@ -8,7 +8,7 @@ build:  ## Build the jenkins image
 		docker-compose \
 			--log-level ${LOG_LEVEL} \
 			--file docker-compose.yml \
-			build jenkins
+			build --no-cache jenkins
 
 .PHONY: clean
 clean:  ## Reset the environment; stop Jenkins


### PR DESCRIPTION
## What does this PR do?

Avoid warnings and ensure the build does not cache the docker images.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE