### PR TITLE
ci(jenkins): support String[] in isGitRegionMatch

### DIFF
--- a/src/test/groovy/IsGitRegionMatchStepTests.groovy
+++ b/src/test/groovy/IsGitRegionMatchStepTests.groovy
@@ -284,4 +284,19 @@ class IsGitRegionMatchStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('echo', 'isGitRegionMatch: CHANGE_TARGET or GIT_PREVIOUS_COMMIT and GIT_BASE_COMMIT env variables are required to evaluate the changes.'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testMultiplePatternMatchWithArrayString() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = ''' foo
+                      | bar
+                    '''.stripMargin().stripIndent()
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def result = false
+    def String[] patterns = [ '^foo$', '^bar$' ]
+    result = script.call(patterns: patterns)
+    printCallStack()
+    assertTrue(result)
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/isGitRegionMatch.groovy
+++ b/vars/isGitRegionMatch.groovy
@@ -34,7 +34,7 @@ def call(Map params = [:]) {
   if(!isUnix()){
     error('isGitRegionMatch: windows is not supported yet.')
   }
-  def patterns = params.containsKey('patterns') ? params.patterns : error('isGitRegionMatch: Missing patterns argument.')
+  def patterns = params.containsKey('patterns') ? params.patterns.toList() : error('isGitRegionMatch: Missing patterns argument.')
   def shouldMatchAll = params.get('shouldMatchAll', false)
   def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)
   def to = params.get('to', env.GIT_BASE_COMMIT)


### PR DESCRIPTION
## What does this PR do?

Support String[] in addition to ArrayString/List

## Why is it important?

split('') is String rather than a List class

![image](https://user-images.githubusercontent.com/2871786/78573662-e1c08a80-7820-11ea-9ed4-51dc35faa1ca.png)

## Related issues
Closes #ISSUE