### PR TITLE
Hardcode large limit for test query

### DIFF
--- a/vars/getBuildInfoJsonFiles.groovy
+++ b/vars/getBuildInfoJsonFiles.groovy
@@ -33,7 +33,7 @@ def call(jobURL, buildNumber){
   bulkDownload(["${restURLJob}": 'job-info.json',
                 "${restURLBuild}": 'build-info.json',
                 "${restURLBuild}/blueTestSummary": 'tests-summary.json',
-                "${restURLBuild}/tests": 'tests-info.json',
+                "${restURLBuild}/tests?limit=100000000": 'tests-info.json',
                 "${restURLBuild}/changeSet": 'changeSet-info.json',
                 "${restURLBuild}/artifacts": 'artifacts-info.json',
                 "${restURLBuild}/steps": 'steps-info.json',


### PR DESCRIPTION
## What does this PR do?

This increase the number of results which are returned when querying the Blue Ocean `tests/` endpoint.

Jenkins, by default, will only return the first 100 results. It does support range queries, but in this specific case, I elected not to implement full pagination and instead to just issue one large request. I made this choice for a few reasons.

1) We have a long-term desire to move away from this and use the `testReport/` endpoint instead. Therefore, it's not worth putting a bunch of work into this.

2) Pagination wouldn't buy us that much. We're dealing with documents are likely to be 2-3 MB in size and so we shouldn't be putting undue load on Jenkins to generate these nor should we have any problem downloading them once they are generated.

3) In the extremely unlikely scenario that we end up snipping off the end of these documents because they're larger than the arbitrary large number that I've chosen, the worst that will happen is that we'll potentially miss some tests when we're doing our analytics. See point 1 about replacing this API endpoint anyway, which is the long-term solution.

## Why is it important?
Unblocks the project to generate Jenkins statistics.

## Related issues
No related issue filed.
