### PR TITLE
ci(test-infra): validate hub is installed

### DIFF
--- a/test-infra/test_installed_tools_extra.py
+++ b/test-infra/test_installed_tools_extra.py
@@ -12,3 +12,7 @@ def test_docker_compose_installed(host):
 def test_python3_installed(host):
   cmd = host.run("python3 --version")
   assert cmd.rc == 0, "it is required for the apm-agent-python and apm-integration-testing"
+
+def test_hub_installed(host):
+  cmd = host.run("hub --version")
+  assert cmd.rc == 0, "it is required for the apm and apm-agent-rum-js"


### PR DESCRIPTION
## What does this PR do?

Hub is now enabled in our CI linux workers, let's validate it's there

## Why is it important?

Ensure our configuration is in a good shape

## Related issues

Caused by https://github.com/elastic/infra/pull/19360