### PR TITLE
fix: when using limits

### DIFF
--- a/vars/getBuildInfoJsonFiles.groovy
+++ b/vars/getBuildInfoJsonFiles.groovy
@@ -66,7 +66,7 @@ def bulkDownload(map) {
   }
   def command = ['#!/usr/bin/env bash', 'set -x', 'source /usr/local/bin/bash_standard_lib.sh', 'status=0']
   map.each { url, file ->
-    command << "(retry 3 curl -sfS --max-time 60 --connect-timeout 30 -o ${file} ${url}/) || status=1"
+    command << "(retry 3 curl -sfS --max-time 60 --connect-timeout 30 -o ${file} ${url}) || status=1"
     command << """[ -e "${file}" ] || echo "{}" > "${file}" """
   }
   command << 'exit ${status}'


### PR DESCRIPTION
## What does this PR do?

```
10:40:08  net.sf.json.JSONException: Invalid JSON String
10:40:08  	at net.sf.json.JSONSerializer.toJSON(JSONSerializer.java:143)
10:40:08  	at net.sf.json.JSONSerializer.toJSON(JSONSerializer.java:103)
10:40:08  	at net.sf.json.JSONSerializer.toJSON(JSONSerializer.java:84)
10:40:08  	at org.jenkinsci.plugins.pipeline.utility.steps.json.ReadJSONStepExecution.doRun(ReadJSONStepExecution.java:77)
```

Caused 
![image](https://user-images.githubusercontent.com/2871786/79574750-8ca23580-80b8-11ea-906c-ec7c474fd7eb.png)

![image](https://user-images.githubusercontent.com/2871786/79574776-95930700-80b8-11ea-9055-d734def39df6.png)

## Why is it important?

NotifyBuild is broken

## Related issues

Regression from #466