### PR TITLE
revert: limit cause some performance issues

### DIFF
--- a/vars/getBuildInfoJsonFiles.groovy
+++ b/vars/getBuildInfoJsonFiles.groovy
@@ -33,7 +33,7 @@ def call(jobURL, buildNumber){
   bulkDownload(["${restURLJob}": 'job-info.json',
                 "${restURLBuild}/": 'build-info.json',
                 "${restURLBuild}/blueTestSummary/": 'tests-summary.json',
-                "${restURLBuild}/tests/?limit=100000000": 'tests-info.json',
+                "${restURLBuild}/tests/": 'tests-info.json',
                 "${restURLBuild}/changeSet/": 'changeSet-info.json',
                 "${restURLBuild}/artifacts/": 'artifacts-info.json',
                 "${restURLBuild}/steps/": 'steps-info.json',


### PR DESCRIPTION
## What does this PR do?

The current json transformation uses the jenkins internals, therefore the more  data the more it takes to be parsed.
 
## Why is it important?

Avoid current performance issues with 504 errors in the jenkins ui.

## Related issues
Closes #ISSUE

## Follow ups

- To move the logic to a script