### PR TITLE
fix: unshallow with unshallow

### DIFF
--- a/resources/scripts/setup-git-release.sh
+++ b/resources/scripts/setup-git-release.sh
@@ -38,11 +38,6 @@ git config user.name "${USER_NAME}"
 git fetch --all
 git checkout "${BRANCH_NAME}"
 
-# Ensure the branch points to the original commit to avoid commit injection
-# when running the release pipeline.
-# used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
-git reset --hard "${GIT_BASE_COMMIT}"
-
 # Enable upstream with git+https.
 git remote add upstream "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ORG_NAME}/${REPO_NAME}.git"
 git fetch --all
@@ -53,3 +48,8 @@ if [ -f "$(git rev-parse --git-dir)/shallow" ] || [ "$(git rev-parse --is-shallo
 else
     git pull
 fi
+
+# Ensure the branch points to the original commit to avoid commit injection
+# when running the release pipeline.
+# used GIT_BASE_COMMIT instead GIT_COMMIT to support the MultiBranchPipelines.
+git reset --hard "${GIT_BASE_COMMIT}"


### PR DESCRIPTION
## What does this PR do?

Detect if the repo is shallowed and if so then unshallowed. Support for different git versions

## Why is it important?

Fixes

```
12:15:37  + git remote add upstream https://****:****@github.com/elastic/apm-agent-rum-js.git
12:15:37  + git fetch upstream
12:15:38  From https://github.com/elastic/apm-agent-rum-js
12:15:38   * [new branch]      0.x        -> upstream/0.x
12:15:38   * [new branch]      1.x        -> upstream/1.x
12:15:38   * [new branch]      2.x        -> upstream/2.x
12:15:38   * [new branch]      3.x        -> upstream/3.x
12:15:38   * [new branch]      4.x        -> upstream/4.x
12:15:38   * [new branch]      5.x        -> upstream/5.x
12:15:38   * [new branch]      master     -> upstream/master
12:15:38  + git pull --unshallow
12:15:38  fatal: --unshallow on a complete repository does not make sense
```

## Related issues
Closes #ISSUE

## Tests

![image](https://user-images.githubusercontent.com/2871786/79983405-a7512180-849f-11ea-9453-33de6ef828b5.png)

## Reference

stackoverflow [here](https://stackoverflow.com/questions/37531605/how-to-test-if-git-repository-is-shallow)