### PR TITLE
ci: log report if no success

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -71,6 +71,7 @@
   </details>
 <%}%>
 
+<% if (!statusSuccess) {%>
 <!-- LOG OUTPUT-->
 ### Log output
 
@@ -83,3 +84,5 @@ ${log}
 
 </p>
 </details>
+
+<%}%>


### PR DESCRIPTION
## What does this PR do?

Disable logs for builds that did not fail

## Why is it important?

Reduce the notifications with details that are not necessarily useful.

> Can we turn the log output off for successful builds? I do most of my github notifications via email, which doesn't support collapsing sections, which means for a notification like this I get a wall of text in the email.

## Related issues

Relates to https://github.com/elastic/observability-robots/issues/37