### PR TITLE
Fix ordering which causes crash

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -98,8 +98,8 @@ unclassified:
     globalConfigName: username
     globalConfigEmail: username@example.com
 jobs:
-  - file: "/var/pipeline-library/src/test/resources/folders/getBuildInfoJsonFiles.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
+  - file: "/var/pipeline-library/src/test/resources/folders/getBuildInfoJsonFiles.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/timeout.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/cancelPreviousRunningBuilds.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/dockerLogin.dsl"


### PR DESCRIPTION
## What does this PR do?

Prevents a crash on start for Jenkins. Details on the stacktrace are here: https://gist.github.com/cachedout/46604561146eae54aa1dff0e66e53be2

Credit to @v1v for a quick resolution!

## Why is it important?

Crashes aren't so good.

