### PR TITLE
ci: evaluate test results do exist

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -132,7 +132,7 @@ function fetchAndPrepareTestsInfo() {
     ## Tests json response differs when there were tests executed in
     ## the pipeline, otherwise it returns:
     ##   { message: "no tests", code: 404, errors: [] }
-    if jq -e 'select(.code==404)' "${file}" ; then
+    if jq -e 'select(.code==404)' "${file}" > /dev/null ; then
         echo "${default}" > "${file}"
     else
         normaliseTests "${file}"
@@ -225,7 +225,7 @@ function fetchAndDefaultTestsErrors() {
     ## Tests json response differs when there were tests executed in
     ## the pipeline, otherwise it returns:
     ##   { message: "no tests", code: 404, errors: [] }
-    if jq -e 'select(.code==404)' "${file}" ; then
+    if jq -e 'select(.code==404)' "${file}" > /dev/null ; then
         echo "${default}" > "${file}"
     else
         normaliseTests "${file}"


### PR DESCRIPTION
## What does this PR do?

Transform the test json output to the default when there are no tests in the build.

For instance:

![image](https://user-images.githubusercontent.com/2871786/80700606-e56cc780-8ad5-11ea-8cca-b1f99c70a475.png)


## Why is it important?

This will avoid a misbehaving in the feedback templating. This is caused when builds do not run tests, or when the build failed before running any tests.

## Related issues
Closes #ISSUE

## Tests

For the given call:

```bash
$ resources/scripts/generate-build-data.sh \
    https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/ \
    https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2 \
    FAILURE \
    161449
```

- The stdout and data are:

```
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/steps/?limit=10000 -o steps-info.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/tests/?status=FAILED -o tests-errors.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/log/ -o pipeline-log.txt
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061// -o job-info.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/blueTestSummary/ -o tests-summary.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/changeSet/ -o changeSet-info.json
INFO: fetchAndPrepareArtifactsInfo (see artifacts-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/artifacts/ -o artifacts-info.json
INFO: fetchAndPrepareTestsInfo (see tests-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/tests/?limit=10000000 -o tests-info.json
INFO: fetchAndPrepareBuildInfo (see build-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/ -o build-info.json

$ cat tests-info.json
[ ]
```

- While it used to be:

```
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/steps/?limit=10000 -o steps-info.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/tests/?status=FAILED -o tests-errors.json
jq: error (at tests-errors.json:4): Cannot index string with string "_links"
jq: error (at tests-errors.json:4): Cannot index string with string "_class"
jq: error (at tests-errors.json:4): Cannot index string with string "state"
jq: error (at tests-errors.json:4): Cannot index string with string "hasStdLog"
jq: error (at tests-errors.json:4): Cannot index string with string "errorStackTrace"
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/log/ -o pipeline-log.txt
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061// -o job-info.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/blueTestSummary/ -o tests-summary.json
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/changeSet/ -o changeSet-info.json
INFO: fetchAndPrepareArtifactsInfo (see artifacts-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/artifacts/ -o artifacts-info.json
INFO: fetchAndPrepareTestsInfo (see tests-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/tests/?limit=10000000 -o tests-info.json
jq: error (at tests-info.json:4): Cannot index string with string "_links"
jq: error (at tests-info.json:4): Cannot index string with string "_class"
jq: error (at tests-info.json:4): Cannot index string with string "state"
jq: error (at tests-info.json:4): Cannot index string with string "hasStdLog"
jq: error (at tests-info.json:4): Cannot index string with string "errorStackTrace"
INFO: fetchAndPrepareBuildInfo (see build-info.json)
INFO: curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats-beats-mbp/PR-18061/runs/2/ -o build-info.json
$ cat tests-info.json
{
  "message" : "no tests",
  "code" : 404,
  "errors" : [ ]
}

```


## Follow-ups

- I'm working on the ITs to validate this particular use cases programmatically, but still on it