### PR TITLE
ci: cornercase when comment has been deleted

### DIFF
--- a/src/test/groovy/GithubPrCommentStepTests.groovy
+++ b/src/test/groovy/GithubPrCommentStepTests.groovy
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import co.elastic.mock.PullRequestMock
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertEquals
@@ -111,6 +112,22 @@ class GithubPrCommentStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('copyArtifacts', 'filter=comment.id'))
     assertTrue(assertMethodCallContainsPattern('log', "githubPrComment: Edit comment with id '2'."))
+    assertTrue(assertMethodCallContainsPattern('writeFile', 'file=comment.id'))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'artifacts=comment.id'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_addOrEditComment_fallback_to_addComment() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('fileExists', [String.class], { return true } )
+    helper.registerAllowedMethod('readFile', [String.class], { return "${PullRequestMock.ERROR}" } )
+    script.addOrEditComment('foo')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('copyArtifacts', 'filter=comment.id'))
+    assertTrue(assertMethodCallContainsPattern('log', "githubPrComment: Edit comment with id '${PullRequestMock.ERROR}'. If comment still exists."))
+    assertTrue(assertMethodCallContainsPattern('log', "githubPrComment: Edit comment with id '${PullRequestMock.ERROR}' failed with error"))
+    assertTrue(assertMethodCallContainsPattern('log', 'githubPrComment: Add a new comment.'))
     assertTrue(assertMethodCallContainsPattern('writeFile', 'file=comment.id'))
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'artifacts=comment.id'))
     assertJobStatusSuccess()

--- a/src/test/groovy/co/elastic/mock/PullRequestMock.groovy
+++ b/src/test/groovy/co/elastic/mock/PullRequestMock.groovy
@@ -24,6 +24,8 @@ class PullRequestMock implements Serializable {
 
   String description = ''
 
+  static int ERROR = -1
+
   public PullRequestMock() { }
 
   public Map comment(String description) {
@@ -32,6 +34,9 @@ class PullRequestMock implements Serializable {
   }
 
   public void editComment(int id, String description) {
+    if (id == ERROR) {
+      throw new Exception('org.eclipse.egit.github.core.client.RequestException: Not Found (404)')
+    }
     this.description = description
   }
 }

--- a/vars/githubPrComment.groovy
+++ b/vars/githubPrComment.groovy
@@ -65,15 +65,24 @@ def addOrEditComment(String details) {
   def id
   if (commentId?.trim() && commentId.isInteger()) {
     id = commentId as Integer
-    log(level: 'DEBUG', text: "githubPrComment: Edit comment with id '${commentId}'.")
-    pullRequest.editComment(id, details)
+    try {
+      log(level: 'DEBUG', text: "githubPrComment: Edit comment with id '${commentId}'. If comment still exists.")
+      pullRequest.editComment(id, details)
+    } catch (err) {
+      log(level: 'DEBUG', text: "githubPrComment: Edit comment with id '${commentId}' failed with error '${err}'. Let's fallback to add a comment.")
+      id = addComment(details)
+    }
   } else {
-    log(level: 'DEBUG', text: 'githubPrComment: Add a new comment.')
-    def comment = pullRequest.comment(details)
-    id = comment?.id
+    id = addComment(details)
   }
   writeFile(file: "${commentIdFileName()}", text: "${id}")
   archiveArtifacts(artifacts: commentIdFileName())
+}
+
+def addComment(String details) {
+  log(level: 'DEBUG', text: 'githubPrComment: Add a new comment.')
+  def comment = pullRequest.comment(details)
+  return comment?.id
 }
 
 def getCommentFromFile() {


### PR DESCRIPTION
## What does this PR do?

If comment message has been deleted then let's fallback to add a new comment with the build status

## Why is it important?

A cornercase that actually doesn't report the build status

Fixes 

![image](https://user-images.githubusercontent.com/2871786/80987999-c69a6800-8e2a-11ea-9969-726075b22349.png)


## Related issues
Closes #ISSUE