### PR TITLE
test: move the job to multibranch pipeline

### DIFF
--- a/.ci/jobs/apm-chatops.yml
+++ b/.ci/jobs/apm-chatops.yml
@@ -9,6 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
+          disable-pr-notifications: true
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current


### PR DESCRIPTION
## What does this PR do?

Move the Job from a regular pipeline to Multibranch Pipeline.

## Why is it important?

The job is not triggered by comments in PRs if it is a regular pipeline, so we have to use a Multibranch pipeline with the SCM trigger disabled.

