### PR TITLE
feat: licenseScan step

### DIFF
--- a/.ci/jobs/license-scan.yml
+++ b/.ci/jobs/license-scan.yml
@@ -1,0 +1,48 @@
+---
+- job:
+    name: apm-shared/license-scan
+    display-name: APM Pipeline Library License Scan
+    description: Scans thrid-party licenses and report the results.
+    view: APM-CI
+    project-type: multibranch
+    script-path: .ci/licenseScan.groovy
+    triggers:
+      - timed: 'H H(0-7) * * 1-5'
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: true
+          notification-context: 'license-scan'
+          property-strategies:
+            all-branches:
+            - suppress-scm-triggering: true
+          repo: apm-pipeline-library
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - tags:
+                ignore-tags-older-than: -1
+                ignore-tags-newer-than: -1
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: false
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 4
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'

--- a/.ci/licenseScan.groovy
+++ b/.ci/licenseScan.groovy
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+   agent { label 'ubuntu && immutable' }
+   environment {
+     REPO = 'apm-pipeline-library'
+     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+     HOME = "${env.WORKSPACE}"
+    }
+   options {
+     timeout(time: 2, unit: 'HOURS')
+     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+     timestamps()
+     ansiColor('xterm')
+     disableResume()
+     durabilityHint('PERFORMANCE_OPTIMIZED')
+     disableConcurrentBuilds()
+   }
+   triggers {
+     issueCommentTrigger('(?i)^\\/license-scan$')
+   }
+   stages {
+      stage('License Scan') {
+         steps {
+            dir("${env.BASE_DIR}"){
+                checkout scm
+                licenseScan()
+            }
+         }
+      }
+   }
+}

--- a/src/test/groovy/LicenseScanTest.groovy
+++ b/src/test/groovy/LicenseScanTest.groovy
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class LicenseScanTest extends ApmBasePipelineTest {
+  String scriptName = 'vars/licenseScan.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+  }
+
+  @Test
+  void test() throws Exception {
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('getVaultSecret', 'secret=secret/jenkins-ci/fossa/api-token'))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', 'FOSSA_API_KEY'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'fossa analyze'))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -805,6 +805,13 @@ it stores the username in the BUILD_CAUSE_USER environment variable.
 def userTrigger = isUserTrigger()
 ```
 
+## licenseScan
+Scan the repository for third-party dependencies and report the results.
+
+```
+licenseScan()
+```
+
 ## log
 Allow to print messages with different levels of verbosity. It will show all messages that match
 to an upper log level than defined, the default level is debug.
@@ -1423,7 +1430,7 @@ The secret must normally have this format
 `{ data: { user: 'username', password: 'user_password'} }`
 
 If the secret does not have this format, the `user_key` and `pass_key` flags
-can be set to specify alternative lookup keys for the `username` and `password`
+can be set to specify alternative lookup keys for the `user` and `password`
 fields.
 
 The passed data variables will be exported and masked on logs
@@ -1433,7 +1440,6 @@ withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: '
   //block
 }
 ```
-
 
 ## withTotpVault
 Get the [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm) code from the vault, define the environment variables which have been

--- a/vars/licenseScan.groovy
+++ b/vars/licenseScan.groovy
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Scan the repository for third-party dependencies and report the results.
+
+licenseScan()
+
+*/
+def call(Map params = [:]) {
+  withEnvMask(vars: [
+      [var: "FOSSA_API_KEY", password: getVaultSecret(secret: 'secret/jenkins-ci/fossa/api-token')?.data?.token ],
+    ]){
+      sh(label: 'License Scanning', script: '''
+      if [ -f .go-version ]; then
+        eval $(gvm $(cat .go-version))
+        export GOPATH=${WORKSPACE}
+      fi
+      if [ ! -f .fossa.yml ]; then
+        fossa init --include-all
+      fi
+      fossa analyze
+      ''')
+    }
+}

--- a/vars/licenseScan.txt
+++ b/vars/licenseScan.txt
@@ -1,0 +1,5 @@
+Scan the repository for third-party dependencies and report the results.
+
+```
+licenseScan()
+```


### PR DESCRIPTION
## What does this PR do?

It adds a step to scan third-party licenses, also a job to do that on the PAM Pipeline library.

## Why is it important?

This report the third-party allowing us to detect issues with licensing.

https://www.elastic.co/third-party-dependencies

## Related issues
related to https://github.com/elastic/observability-robots/issues/106
