### PR TITLE
ci: avoid template when no PRs

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -14,7 +14,7 @@
 <% if(build?.durationInMillis >= 0) {%>
 * Duration: ${Math.round(build.durationInMillis/1000/60)} min ${Math.round(build.durationInMillis/1000)%60} sec (${build.durationInMillis})
 <%}%>
-<% if(build?.commitId?.trim()) {%>
+<% if(build?.commitId != null && build?.commitId?.trim()) {%>
 * Commit: ${build?.commitId.split('\\+')[0]}
 <%}%>
 

--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -47,12 +47,11 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
   void test() throws Exception {
     def script = loadScript(scriptName)
     script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
-
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
     assertTrue(assertMethodCallOccurrences('archiveArtifacts', 1))
     assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results by email'))
-    assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
     assertTrue(assertMethodCallOccurrences('deleteDir', 1))
   }
 
@@ -301,5 +300,14 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     script.call(prComment: true)
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+  }
+
+  @Test
+  void test_notify_pr_in_a_branch() throws Exception {
+    env.remove('CHANGE_ID')
+    def script = loadScript(scriptName)
+    script.call(prComment: true)
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -46,7 +46,7 @@ def call(Map args = [:]) {
         getBuildInfoJsonFiles(env.JOB_URL, env.BUILD_NUMBER)
         archiveArtifacts(allowEmptyArchive: true, artifacts: '*.json')
 
-        if(shouldNotify || notifyPRComment) {
+        if(shouldNotify || (notifyPRComment && env.CHANGE_ID)) {
           // Read files only once and if timeout then use default values
           def buildData = {}
           def changeSet = []


### PR DESCRIPTION
## What does this PR do?

Comment was not sent but the template was generated even for branches/tags.
Therefore, moved the conditional to the step that is reponsible for the notifications.

## Why is it important?

Avoid extra processing of templates when it's not required.

## Related issues
Closes #ISSUE