### PR TITLE
Write credentials for opbot

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -335,12 +335,16 @@ pipeline {
           version: "latest",
           push: true)
       }
+      post {
+        cleanup {
+          deleteDir()
+        }
+      }
     }
   }
   post {
     cleanup {
       notifyBuildResult()
-      deleteDir()
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Pulls in stored credentials file into the workspace just before we build the Docker image.

## Why is it important?

In order to deploy the opbeat, [we need to have credentials](https://cloud.google.com/docs/authentication/getting-started) which correctly annotate OAuth requests with the developer profile belonging to the application.

This data is pseudo-sensitive and so it's better if we can keep it in our secret store and write it out just before build time. 

## Related issues
Refs https://github.com/elastic/observability-robots/issues/39
