### PR TITLE
test: fix windows7-32 labels

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -60,7 +60,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu && immutable', 'worker-c07l34n6dwym', 'worker-c07y20b6jyvy', 'worker-c07ll940dwyl', 'worker-c07y20b9jyvy', 'worker-c07y20b4jyvy', 'worker-c07y20bcjyvy', 'worker-395930', 'worker-0a434dec4bdcd060f', 'windows-immutable && windows-2019', 'windows-immutable && windows-2016', 'windows-immutable && windows-2012', 'windows-immutable && windows-10', 'windows-immutable && windows-8', 'windows-immutable && windows-2008-r2', 'windows-immutable && windows-7', 'windows-immutable && windows-7-32-bit'
+            values 'ubuntu && immutable', 'worker-c07l34n6dwym', 'worker-c07y20b6jyvy', 'worker-c07ll940dwyl', 'worker-c07y20b9jyvy', 'worker-c07y20b4jyvy', 'worker-c07y20bcjyvy', 'worker-395930', 'worker-0a434dec4bdcd060f', 'windows-immutable && windows-2019', 'windows-immutable && windows-2016', 'windows-immutable && windows-2012', 'windows-immutable && windows-10', 'windows-immutable && windows-8', 'windows-immutable && windows-2008-r2', 'windows-immutable && windows-7', 'windows-immutable-32-bit && windows-7-32-bit'
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

Use the labels for the windows-7-32-bits workers (see https://github.com/elastic/infra/blob/7160ef68ee7d26b97c9de5ba5ab88b9850979731/terraform/providers/gcp/env/elastic-apps/helm/values/gobld/beats-ci.yml#L134-L135)

## Why is it important?

Otherwise pipeline will get stuck

## Related issues
Closes #ISSUE