### PR TITLE
test: exclude windows-2012-r2

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -63,6 +63,14 @@ pipeline {
             values 'ubuntu && immutable', 'worker-c07l34n6dwym', 'worker-c07y20b6jyvy', 'worker-c07ll940dwyl', 'worker-c07y20b9jyvy', 'worker-c07y20b4jyvy', 'worker-c07y20bcjyvy', 'worker-395930', 'worker-0a434dec4bdcd060f', 'immutable && windows-2019', 'immutable && windows-2016', 'immutable && windows-2012-r2', 'immutable && windows-10', 'immutable && windows-8', 'immutable && windows-2008-r2', 'immutable && windows-7', 'immutable && windows-7-32-bit'
           }
         }
+        excludes {
+          exclude {
+            axis {
+              name 'PLATFORM'
+              values 'immutable && windows-2012-r2'
+            }
+          }
+        }
         stages {
           stage('Report') {
             options { skipDefaultCheckout() }


### PR DESCRIPTION
See https://github.com/elastic/infra/issues/20389


## What does this PR do?

Exclude windows-2012 for the time being

## Why is it important?

To avoid abort the test-infra builds

## Related issues
Closes #ISSUE