### PR TITLE
fix: git pull only for branches

### DIFF
--- a/resources/scripts/setup-git-release.sh
+++ b/resources/scripts/setup-git-release.sh
@@ -42,16 +42,16 @@ git checkout "${BRANCH_NAME}"
 git remote add upstream "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ORG_NAME}/${REPO_NAME}.git"
 git fetch --all
 
-# Pull the git history when repo was cloned with shallow/depth.
-if [ -f "$(git rev-parse --git-dir)/shallow" ] || [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-    # If in a branch
-    if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}" ; then
+ # If in a branch then pull changes
+if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}" ; then
+    # Pull the git history when repo was cloned with shallow/depth.
+    if [ -f "$(git rev-parse --git-dir)/shallow" ] || [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
         git pull --unshallow
     else
-        echo 'INFO: git refs is not a branch but a tag'
+        git pull
     fi
 else
-    git pull
+    echo 'INFO: git refs is not a branch but a tag'
 fi
 
 # Ensure the branch points to the original commit to avoid commit injection


### PR DESCRIPTION
## What does this PR do?

The generic prepare git context doesn't require to pull when running in a tag

## Why is it important?

To fix the issues with the release of the apm-agent-ruby

## Related issues
Closes #ISSUE

## Tests

For an unknown branch

```
$ BRANCH_NAME=FOO
$ git show-ref --verify "refs/heads/${BRANCH_NAME}" 
fatal: 'refs/heads/FOO' - not a valid ref
$ BRANCH_NAME=current
$ git show-ref --verify "refs/heads/${BRANCH_NAME}" 
fatal: 'refs/heads/FOO' - not a valid ref
```

For a known branch:

```
$ BRANCH_NAME=master                                       
$ git show-ref --verify "refs/heads/${BRANCH_NAME}"
8253a806d79be9f62c3a7cc89acd0226b3c6cc78 refs/heads/master
```


Using the apm-agent-ruby:

```
export BRANCH_NAME=v3.7.0
export GIT_BASE_COMMIT=6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
export GITHUB_TOKEN=****
export GITHUB_USER=****
export ORG_NAME=elastic
export REPO_NAME=apm-agent-ruby
sh ~/work/src/github.com/elastic/apm-pipeline-library/resources/scripts/setup-git-release.sh
+ BRANCH_NAME=v3.7.0
+ GIT_BASE_COMMIT=6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
+ GITHUB_TOKEN=*****
+ GITHUB_USER=****
+ ORG_NAME=elastic
+ REPO_NAME=apm-agent-ruby
+ git config remote.origin.url https://****:*****@github.com/elastic/apm-agent-ruby.git
+ git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
++ git log -1 --pretty=format:%ae
+ USER_MAIL=victormartinezrubio@gmail.com
++ git log -1 --pretty=format:%an
+ USER_NAME='Victor Martinez'
+ git config user.email victormartinezrubio@gmail.com
+ git config user.name 'Victor Martinez'
+ git fetch --all
Fetching origin
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Total 17 (delta 14), reused 14 (delta 14), pack-reused 3
Unpacking objects: 100% (17/17), done.
From https://github.com/elastic/apm-agent-ruby
   6e83ea6..b371515  master     -> origin/master
   c9b89bd..1c13d9e  2.x        -> origin/2.x
 + 406f726...978b5b8 3.x        -> origin/3.x  (forced update)
 * [new tag]         v2.11.0    -> v2.11.0
 * [new tag]         v2.12.0    -> v2.12.0
 * [new tag]         v3.0.0     -> v3.0.0
 * [new tag]         v3.1.0     -> v3.1.0
 * [new tag]         v3.3.0     -> v3.3.0
 * [new tag]         v3.4.0     -> v3.4.0
 * [new tag]         v3.5.0     -> v3.5.0
 * [new tag]         v3.6.0     -> v3.6.0
+ git checkout v3.7.0
Note: switching to 'v3.7.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at d40b570 ci: changes
+ git remote add upstream https://****:****@github.com/elastic/apm-agent-ruby.git
+ git fetch --all
Fetching origin
Fetching upstream
From https://github.com/elastic/apm-agent-ruby
 * [new branch]      1.x        -> upstream/1.x
 * [new branch]      2.x        -> upstream/2.x
 * [new branch]      3.x        -> upstream/3.x
 * [new branch]      master     -> upstream/master
+ git show-ref --verify --quiet refs/heads/v3.7.0
+ echo 'INFO: git refs is not a branch but a tag'
INFO: git refs is not a branch but a tag
+ git reset --hard 6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
HEAD is now at 6e83ea6 ci(jenkins): refactor with withGitRelease step (#770)
```