### PR TITLE
release: fix checkouts of an ambiguous

### DIFF
--- a/resources/scripts/setup-git-release.sh
+++ b/resources/scripts/setup-git-release.sh
@@ -33,6 +33,9 @@ USER_NAME=$(git log -1 --pretty=format:'%an')
 git config user.email "${USER_MAIL}"
 git config user.name "${USER_NAME}"
 
+# Set default remote for the checkout (See https://github.com/elastic/apm-agent-ruby/issues/796)
+git config checkout.defaultRemote 'origin'
+
 # Checkout the branch as it's detached based by default.
 # See https://issues.jenkins-ci.org/browse/JENKINS-33171
 git fetch --all


### PR DESCRIPTION
## What does this PR do?

Fixes the issues we have seen when reusing the same script for different agents and the backport to the x.y branch failed with the below error


```
12:51:01  + rake release:update_branch
12:51:01  error: pathspec '3.x' did not match any file(s) known to git
```

## Why is it important?

One script for everyone.

## Related issues

Caused by https://github.com/elastic/apm-agent-ruby/issues/796

## Tests

- Reproduce the issue locally
```bash
$ git clone github.com:v1v/apm-agent-ruby.git && cd apm-agent-ruby
$ export GIT_BASE_COMMIT=6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
$ export GITHUB_USER=v1v                                         
$ export GITHUB_TOKEN=****
$ export ORG_NAME=v1v    
$ export REPO_NAME=apm-agent-ruby
$ export BRANCH_NAME=master      
$ sh -x /Users/vmartinez/work/src/github.com/elastic/apm-pipeline-library/resources/scripts/setup-git-release.sh
...
++ git log -1 --pretty=format:%ae
+ USER_MAIL=victormartinezrubio@gmail.com
++ git log -1 --pretty=format:%an
+ USER_NAME='Victor Martinez'
+ git config user.email victormartinezrubio@gmail.com
+ git config user.name 'Victor Martinez'
+ git fetch --all
...
$ git config checkout.defaultRemote
$ git checkout 3.x                                                                            
error: pathspec '3.x' did not match any file(s) known to git
hint: '3.x' matched more than one remote tracking branch.
hint: We found 2 remotes with a reference that matched. So we fell back
hint: on trying to resolve the argument as a path, but failed there too!
hint: 
hint: If you meant to check out a remote tracking branch on, e.g. 'origin',
hint: you can do so by fully qualifying the name with the --track option:
hint: 
hint:     git checkout --track origin/<name>
hint: 
hint: If you'd like to always have checkouts of an ambiguous <name> prefer
hint: one remote, e.g. the 'origin' remote, consider setting
hint: checkout.defaultRemote=origin in your config.
```

- Validate the issue works as expected for the apm-agent-ruby

```bash
$ git clone github.com:v1v/apm-agent-ruby.git && cd apm-agent-ruby
$ export GIT_BASE_COMMIT=6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
$ export GITHUB_USER=v1v                                         
$ export GITHUB_TOKEN=****
$ export ORG_NAME=v1v    
$ export REPO_NAME=apm-agent-ruby
$ export BRANCH_NAME=master      
$ sh -x /Users/vmartinez/work/src/github.com/elastic/apm-pipeline-library/resources/scripts/setup-git-release.sh
+ set -exo pipefail
+ BRANCH_NAME=master
+ GIT_BASE_COMMIT=6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
+ GITHUB_TOKEN=*****
+ GITHUB_USER=v1v
+ ORG_NAME=v1v
+ REPO_NAME=apm-agent-ruby
+ git config remote.origin.url https://v1v:****@github.com/v1v/apm-agent-ruby.git
+ git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
++ git log -1 --pretty=format:%ae
+ USER_MAIL=victormartinezrubio@gmail.com
++ git log -1 --pretty=format:%an
+ USER_NAME='Victor Martinez'
+ git config user.email victormartinezrubio@gmail.com
+ git config user.name 'Victor Martinez'
+ git config checkout.defaultRemote origin
+ git fetch --all
Fetching origin
+ git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.
+ git show-ref --verify --quiet refs/heads/master
+ git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.
+ git remote add upstream https://v1v:****@github.com/v1v/apm-agent-ruby.git
+ git fetch --all
Fetching origin
Fetching upstream
From https://github.com/v1v/apm-agent-ruby
....
+ git show-ref --verify --quiet refs/heads/master
++ git rev-parse --git-dir
+ '[' -f .git/shallow ']'
++ git rev-parse --is-shallow-repository
+ '[' false = true ']'
+ git pull
Already up to date.
+ git reset --hard 6e83ea63f9a32286f2dad4ed28a189bb2f8dfdd5
HEAD is now at 6e83ea6 ci(jenkins): refactor with withGitRelease step (#770)

$ git config checkout.defaultRemote                               
origin
$ git checkout 3.x
Branch '3.x' set up to track remote branch '3.x' from 'origin'.
Switched to a new branch '3.x'
```

- Validate the new changes won't break the apm-agent-rum-js
```bash
$ git clone github.com:v1v/apm-agent-rum-js.git && cd apm-agent-rum-js
$ export GIT_BASE_COMMIT=0cbd3f4843402b5d2575008243ef6c7efcc3c679
$ export GITHUB_USER=v1v                                         
$ export GITHUB_TOKEN=****
$ export ORG_NAME=v1v    
$ export REPO_NAME=apm-agent-rum-js
$ export BRANCH_NAME=master      
$ sh -x /Users/vmartinez/work/src/github.com/elastic/apm-pipeline-library/resources/scripts/setup-git-release.sh
+ set -exo pipefail
+ BRANCH_NAME=master
+ GIT_BASE_COMMIT=0cbd3f4843402b5d2575008243ef6c7efcc3c679
+ GITHUB_TOKEN=***
+ GITHUB_USER=v1v
+ ORG_NAME=v1v
+ REPO_NAME=apm-agent-rum-js
+ git config remote.origin.url https://v1v:****@github.com/v1v/apm-agent-rum-js.git
+ git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
++ git log -1 --pretty=format:%ae
+ USER_MAIL=victormartinezrubio@gmail.com
++ git log -1 --pretty=format:%an
+ USER_NAME='Victor Martinez'
+ git config user.email victormartinezrubio@gmail.com
+ git config user.name 'Victor Martinez'
+ git fetch --all
Fetching origin
+ git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.
+ git show-ref --verify --quiet refs/heads/master
+ git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.
+ git remote add upstream https://v1v:*****@github.com/v1v/apm-agent-rum-js.git
+ git fetch --all
....
+ git show-ref --verify --quiet refs/heads/master
++ git rev-parse --git-dir
+ '[' -f .git/shallow ']'
++ git rev-parse --is-shallow-repository
+ '[' false = true ']'
+ git pull
Already up to date.
+ git reset --hard 0cbd3f4843402b5d2575008243ef6c7efcc3c679
HEAD is now at 0cbd3f4 ci(jenkins): refactor with withGitRelease step (#756)

```
