### PR TITLE
test-infra: make for windows in apm-ci is not required

### DIFF
--- a/test-infra/apm-ci/test_windows.py
+++ b/test-infra/apm-ci/test_windows.py
@@ -4,10 +4,6 @@ def test_dotnet_installed(host):
   cmd = host.run("dotnet --info")
   assert cmd.rc == 0, "it is required for the apm-agent-dotnet"
 
-def test_make_installed(host):
-  cmd = host.run("make --version")
-  assert cmd.rc == 0, "it is required for all the APM projects"
-
 def test_python_installed(host):
   cmd = host.run("python --version")
   assert cmd.rc == 0, "it is required for the apm-agent-python"


### PR DESCRIPTION
## What does this PR do?

Make is not required so far in the windows CI workers for the apm-ci

## Why is it important?

Assertion not required

## Related issues
Closes #ISSUE