### PR TITLE
feat: generic job to scan licenses

### DIFF
--- a/.ci/jobs/license-scan-general.yml
+++ b/.ci/jobs/license-scan-general.yml
@@ -15,7 +15,7 @@
           default:
           description: the Git repository to scan
     pipeline-scm:
-      script-path: .ci/licenseScanGenaral.groovy
+      script-path: .ci/licenseScanGeneral.groovy
       scm:
         - git:
             url: git@github.com:elastic/apm-pipeline-library.git

--- a/.ci/licenseScanGeneral.groovy
+++ b/.ci/licenseScanGeneral.groovy
@@ -34,7 +34,7 @@ pipeline {
   }
   parameters {
     string(name: 'branch_specifier', defaultValue: 'master', description: 'the Git branch specifier to scan.')
-    string(name: 'repo', defaultValue: 'git@github.com:elastic/apm-pipeline-library.git', description: 'the Git repository to scan.')
+    string(name: 'repo', defaultValue: 'apm-pipeline-library', description: 'the Git repository to scan.')
   }
   stages {
     stage('License Scan') {
@@ -44,7 +44,7 @@ pipeline {
         }
         dir("${env.BASE_DIR}"){
           git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-            url: "${params.repo}",
+            url: "git@github.com:elastic/${params.repo}.git",
             branch: "${params.branch_specifier}"
           )
           licenseScan()


### PR DESCRIPTION
## What does this PR do?

It is a new job to scan the third-party licenses on any repo.

## Why is it important?

When we have the job we can trigger on schedule the scan over all our repos.

## Related issues
related to https://github.com/elastic/observability-robots/issues/106
