### PR TITLE
test-infra: jq is not installed in the aarch64 box

### DIFF
--- a/.ci/jobs/license-scan-general.yml
+++ b/.ci/jobs/license-scan-general.yml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: apm-shared/license-scan-general
+    display-name: APM Pipeline Library License Scan on any repo.
+    description: Scans thrid-party licenses and report the results.
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to scan
+      - string:
+          name: repo
+          default:
+          description: the Git repository to scan
+    pipeline-scm:
+      script-path: .ci/licenseScanGeneral.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/apm-pipeline-library.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/apm-test-pipeline.git
+            branches:
+              - master
+    triggers: []

--- a/.ci/licenseScanGeneral.groovy
+++ b/.ci/licenseScanGeneral.groovy
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'ubuntu && immutable' }
+  environment {
+    BASE_DIR = "license/scan"
+    HOME = "${env.WORKSPACE}"
+  }
+  options {
+    timeout(time: 2, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    disableConcurrentBuilds()
+  }
+  parameters {
+    string(name: 'branch_specifier', defaultValue: 'master', description: 'the Git branch specifier to scan.')
+    string(name: 'repo', defaultValue: 'apm-pipeline-library', description: 'the Git repository to scan.')
+  }
+  stages {
+    stage('License Scan') {
+      steps {
+        script {
+          currentBuild.description = "Third-party license scan of ${params.repo}/${params.branch}"
+        }
+        dir("${env.BASE_DIR}"){
+          git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+            url: "git@github.com:elastic/${params.repo}.git",
+            branch: "${params.branch_specifier}"
+          )
+          licenseScan()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fix temporarily the issue with one of the workers in the beats-ci.


## Why is it important?

Otherwise our pipeline is broken

## Related issues

Relates to https://github.com/elastic/infra/pull/20458