### PR TITLE
test-infra: arch is supported in 5.1.0

### DIFF
--- a/test-infra/beats-ci/test_installed_tools.py
+++ b/test-infra/beats-ci/test_installed_tools.py
@@ -18,7 +18,7 @@ def test_git_installed(host):
   assert cmd.rc == 0, "it is required for all the Beats projects"
 
 def test_jq_installed(host):
-  if host.system_info.arch != "aarch64" :
+  if host.check_output("uname -m") == "aarch64" :
     pytest.skip("jq is unsupported for aarch64 configuration")
   else :
     cmd = host.run("jq --version")


### PR DESCRIPTION
## What does this PR do?

Testinfra 5.1.0 is not available in the MacOSX

Support to old versions of test-infra, to fix

```
[2020-05-20T04:00:56.209Z] ___________________________ test_jq_installed[local] ___________________________

[2020-05-20T04:00:56.209Z] 

[2020-05-20T04:00:56.209Z] host = <testinfra.host.Host object at 0x1044a2d90>

[2020-05-20T04:00:56.209Z] 

[2020-05-20T04:00:56.209Z]     def test_jq_installed(host):

[2020-05-20T04:00:56.209Z] >     if host.system_info.arch != "aarch64" :

[2020-05-20T04:00:56.209Z] E     AttributeError: 'SystemInfo' object has no attribute 'arch'

[2020-05-20T04:00:56.209Z] 

[2020-05-20T04:00:56.209Z] test-infra/beats-ci/test_installed_tools.py:21: AttributeError

[2020-05-20T04:00:56.209Z] - generated xml file: /private/var/lib/jenkins/workspace/Beats/beats-test-infra/src/github.com/elastic/apm-pipeline-library/target/junit-test-infra.xml -
```

## Why is it important?

Otherwise it won't work

## Related issues
5.1.0 was released recently -> https://github.com/philpep/testinfra/pull/550

## Test

Tested manually:

```
(venv) bash-3.2$ ./resources/scripts/jenkins/beats-ci/test-mac.sh
...
Requirement already satisfied: testinfra in ./venv/lib/python2.7/site-packages (3.4.0)
...

test-infra/beats-ci/test_installed_tools.py::test_jq_installed[local] PASSED   
...


```