### PR TITLE
ci: cosmetic changes in the PR comment

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@feature/cosmetic-pr-comments') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/src/test/groovy/AbortBuildStepTest.groovy
+++ b/src/test/groovy/AbortBuildStepTest.groovy
@@ -41,7 +41,7 @@ class AbortBuildStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(build: build, message: "let's stop it")
     printCallStack()
-    assertFalse(assertMethodCallContainsPattern('log', "let's stop it"))
+    assertTrue(assertMethodCallContainsPattern('log', "let's stop it"))
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Get rid of redundant step/test status as they are only reported if the failed.
Quote description/name to avoid interpolate URLs

## Why is it important?

Enrich the GH comments

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/82443415-5aaa3780-9a99-11ea-840a-8ca53a4e95a4.png)
