### PR TITLE
fix: skip preview docs with aborted builds

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -14,7 +14,7 @@
 <%}%>
 
 <!-- BUILD BADGES-->
-[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim()) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>
+[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim() && !buildStatus?.equals('ABORTED')) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>
 
 <!-- BUILD SUMMARY-->
 <details><summary>Expand to view the summary</summary>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -167,6 +167,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       build: readJSON(file: "build-info.json"),
       buildStatus: "SUCCESS",
       changeSet: readJSON(file: "changeSet-info.json"),
+      docsUrl: 'foo',
       log: f.getText(),
       statsUrl: "https://ecs.example.com/app/kibana",
       stepsErrors: readJSON(file: "steps-errors.json"),
@@ -175,6 +176,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('libraryResource', 'github-comment-markdown.template'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'badge/docs-preview'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Succeeded'))
     assertJobStatusSuccess()
   }
@@ -257,6 +259,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Aborted'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', '> There is a new build on-going so the previous on-going builds have been aborted'))
+    assertFalse(assertMethodCallContainsPattern('githubPrComment', 'badge/docs-preview'))
     assertJobStatusSuccess()
   }
 
@@ -285,6 +288,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       build: readJSON(file: "build-info.json"),
       buildStatus: "UNSTABLE",
       changeSet: readJSON(file: "changeSet-info.json"),
+      docsUrl: 'foo',
       log: f.getText(),
       statsUrl: "https://ecs.example.com/app/kibana",
       stepsErrors: readJSON(file: "steps-errors.json"),
@@ -293,6 +297,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Tests Failed'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'badge/docs-preview'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Skip the preview docs if the build gets aborted.

_NOTE_: We could potentially parse the `GIT_URL` env variable if `REPO_NAME` has not been defined yet. Although there will be a potential corner-case of aborting the build even before the default checkout has been triggered. That's the reason for being a bit more drastic and apply this particular go or no go approach.

## Why

Fixes a corner case when the builds get aborted then the docsUrl might not be interpolated correctly

@bmorelli25 found this particular issue in this [comment](https://github.com/elastic/apm-agent-python/pull/829#issuecomment-631536203):

![image](https://user-images.githubusercontent.com/2871786/82532266-e32be500-9b38-11ea-83f4-66104adcacb6.png)

## Related issues
Closes #ISSUE