### PR TITLE
Better error-handling flags for cURL in codecov step

### DIFF
--- a/vars/codecov.groovy
+++ b/vars/codecov.groovy
@@ -73,7 +73,7 @@ def call(Map params = [:]){
         "CODECOV_TOKEN=${token}"]) {
         sh label: 'Send report to Codecov', script: """#!/bin/bash
         set -x
-        curl -sfSLo codecov.sh https://codecov.io/bash
+        curl -sSLo codecov.sh https://codecov.io/bash
         bash codecov.sh ${flags} || echo "codecov exited with \$?"
         """
       }


### PR DESCRIPTION
## What does this PR do?

Increase the tendency for cURL to report HTTP errors.

## Why is it important?
Improves ability to debug problems when communciating with codecov.

## Related issues
Closes https://github.com/elastic/observability-robots/issues/60