### PR TITLE
ci: add forceInstall flag

### DIFF
--- a/src/test/groovy/PublishToCDNStepTests.groovy
+++ b/src/test/groovy/PublishToCDNStepTests.groovy
@@ -113,12 +113,22 @@ class PublishToCDNStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(source: 'foo', target: 'gs://bar', secret: VaultSecret.SECRET_GCP.toString(), headers: ['my_header'])
     printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'rm -rf /home/google-cloud-sdk'))
     assertTrue(assertMethodCallContainsPattern('sh', 'https://sdk.cloud.google.com'))
     assertTrue(assertMethodCallContainsPattern('writeJSON', 'file=service-account.json'))
     assertTrue(assertMethodCallContainsPattern('sh', 'PATH=/home/google-cloud-sdk/bin:'))
     assertTrue(assertMethodCallContainsPattern('sh', '--key-file=service-account.json'))
     assertTrue(assertMethodCallContainsPattern('sh', '-h my_header cp foo gs://bar'))
     assertTrue(assertMethodCallContainsPattern('sh', 'rm service-account.json'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_without_force_install() throws Exception {
+    def script = loadScript(scriptName)
+    script.call(source: 'foo', target: 'gs://bar', secret: VaultSecret.SECRET_GCP.toString(), forceInstall: false)
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', 'rm -rf /home/google-cloud-sdk'))
     assertJobStatusSuccess()
   }
 

--- a/vars/README.md
+++ b/vars/README.md
@@ -1105,6 +1105,7 @@ with the given headers.
 
 * headers: a list of the metadata of the objects to be uploaded to the bucket. Optional
 * install: whether to install the google cloud tools. Default true. Optional
+* forceInstall: whether to force the installation in the default path. Default true. Optional
 * secret: what's the secret with the service account details. Mandatory
 * source: local files. Mandatory. See the supported formats [here](https://cloud.google.com/storage/docs/gsutil/commands/cp)
 * target: where to copy those files to. Mandatory

--- a/vars/publishToCDN.groovy
+++ b/vars/publishToCDN.groovy
@@ -32,13 +32,19 @@ def call(Map params = [:]){
     error('publishToCDN: windows is not supported yet.')
   }
   def install = params.get('install', true)
+  def forceInstall = params.get('forceInstall', true)
   def headers = params.containsKey('headers') ? params.headers.toList() : []
   def source = params.containsKey('source') ? params.source : error('publishToCDN: Missing source argument.')
   def target = params.containsKey('target') ? params.target : error('publishToCDN: Missing target argument.')
   def secret = params.containsKey('secret') ? params.secret : error('publishToCDN: Missing secret argument.')
   def keyFile = 'service-account.json'
 
+  def installPath = "${env.HOME}/google-cloud-sdk"
+
   if(install) {
+    if(forceInstall) {
+      sh(label: 'Delete install folder', script: "rm -rf ${installPath}")
+    }
     withEnv(["CLOUDSDK_CORE_DISABLE_PROMPTS=1"]){
       sh(label: 'Install gcloud', script: 'curl -s https://sdk.cloud.google.com | bash > install.log')
     }
@@ -46,7 +52,7 @@ def call(Map params = [:]){
   prepareCredentials(keyFile: keyFile, secret: secret)
   if(install) {
     // path argument is a workaround since withEnv(PATH) does not work within the docker.inside step
-    upload(keyFile: keyFile, source: source, target: target, headers: headers, path: "${env.HOME}/google-cloud-sdk/bin")
+    upload(keyFile: keyFile, source: source, target: target, headers: headers, path: "${installPath}/bin")
   } else {
     upload(keyFile: keyFile, source: source, target: target, headers: headers)
   }

--- a/vars/publishToCDN.txt
+++ b/vars/publishToCDN.txt
@@ -13,6 +13,7 @@ with the given headers.
 
 * headers: a list of the metadata of the objects to be uploaded to the bucket. Optional
 * install: whether to install the google cloud tools. Default true. Optional
+* forceInstall: whether to force the installation in the default path. Default true. Optional
 * secret: what's the secret with the service account details. Mandatory
 * source: local files. Mandatory. See the supported formats [here](https://cloud.google.com/storage/docs/gsutil/commands/cp)
 * target: where to copy those files to. Mandatory


### PR DESCRIPTION
## What

Add flag to reinstall the tools in the same folder

## Why is it important?

When running the same step in the same worker then it will fail if reinstalling the tools, so this will help to reinstall them by default.

## Tests

![image](https://user-images.githubusercontent.com/2871786/82876342-882b3100-9f30-11ea-8aec-9863802d3b9c.png)

