### PR TITLE
ci: exclude environments section in the docker inspect

### DIFF
--- a/resources/scripts/docker-logs.sh
+++ b/resources/scripts/docker-logs.sh
@@ -43,5 +43,5 @@ for id in ${DOCKER_IDS}
 do
   docker ps -af id="${id}" --no-trunc &> "${id}-cmd.txt"
   docker logs "${id}" &> "${id}.log" || echo "It is not possible to grab the logs of ${id}"
-  (docker inspect "${id}" &> "${id}-inspect.json" | jq 'del(.[].Config.Env)' || echo "It is not possible to grab the inspect of ${id}"
+  (docker inspect "${id}" | jq 'del(.[].Config.Env)' &> "${id}-inspect.json") || echo "It is not possible to grab the inspect of ${id}"
 done


### PR DESCRIPTION
## What does this PR do?

Avoid any potential security breach if the docker container inspect command can contain certain sensitive details.

## Why is it important?

As explained in https://github.com/elastic/apm-agent-rum-js/pull/810#pullrequestreview-423346460

## Important

Logs might also contain some relevant information though :S 