### PR TITLE
fix: run the swarm agent as vagrant user

### DIFF
--- a/local/workers/linux/Vagrantfile
+++ b/local/workers/linux/Vagrantfile
@@ -27,8 +27,9 @@ Vagrant.configure("2") do |config|
     curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.2
     cp bin/hub /usr/bin
   fi
+  sudo usermod vagrant -a -G docker
   su - vagrant -c 'curl -s https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.9/swarm-client-3.9.jar > swarm-client.jar'
-  sudo nohup java -jar swarm-client.jar -labels "linux docker immutable ubuntu" -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1 &
+  su - vagrant -c 'nohup java -jar swarm-client.jar -labels "linux docker immutable ubuntu" -master http://10.0.2.2:18080 >/tmp/jenkins-swarm.log 2>&1' &
   SCRIPT
 
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
## What does this PR do?

Change to use the vagrant user to run the swarm process.

## Why is it important?

Currently, the process runs as root, this generates files as root in the workspace and some compilation like Kibana does not support running with a root user.
After this change, you have to run the following script in provisioned vagrant VMs.

```
cd local/workers/linux
vagrant ssh
sudo chmod -R vagran:vagrant /home/vagrant
vagrant halt
vagrant up --provision
```

or directly

```
cd local/workers/linux
vagrant destroy
vagrant up --provision
```
