### PR TITLE
test-infra: docker experimental

### DIFF
--- a/test-infra/apm-ci/test_installed_tools_docker.py
+++ b/test-infra/apm-ci/test_installed_tools_docker.py
@@ -8,3 +8,7 @@ def test_docker_installed(host):
 def test_docker_compose_installed(host):
   cmd = host.run("docker-compose --version")
   assert cmd.rc == 0, "it is required for all the APM projects"
+
+def test_docker_experimental_configured(host):
+  cmd = "docker version -f '{{.Server.Experimental}}'"
+  assert host.check_output(cmd) == "true", "it is required for building the ARM docker images in the Beats project"

--- a/test-infra/beats-ci/test_installed_tools.py
+++ b/test-infra/beats-ci/test_installed_tools.py
@@ -9,6 +9,10 @@ def test_docker_compose_installed(host):
   cmd = host.run("docker-compose --version")
   assert cmd.rc == 0, "it is required for all the Beats projects"
 
+def test_docker_experimental_configured(host):
+  cmd = "docker version -f '{{.Server.Experimental}}'"
+  assert host.check_output(cmd) == "true", "it is required for building the ARM docker images in the Beats project"
+
 def test_gvm_installed(host):
   cmd = host.run("gvm --version")
   assert cmd.rc == 0, "it is required for the beats"


### PR DESCRIPTION
## What does this PR do?

Assert docker experimental configuration in the CI workers

## Why is it important?

Required for building ARM docker images -> https://github.com/elastic/beats/issues/18334

_NOTE_: We don't need it in our APM workers, although adding it will help us to have more control about what's installed. Besdieis, the pipeline for apm-ci workers uses `@master` while the one for the beats-ci workers uses `@current`. So if we merge this particular PR we will be able to validate it before doing a release


## Related issues

Relates to 	https://github.com/elastic/infra/pull/20607