### PR TITLE
test-infra: docker experimental client side

### DIFF
--- a/test-infra/apm-ci/test_installed_tools_docker.py
+++ b/test-infra/apm-ci/test_installed_tools_docker.py
@@ -10,5 +10,5 @@ def test_docker_compose_installed(host):
   assert cmd.rc == 0, "it is required for all the APM projects"
 
 def test_docker_experimental_configured(host):
-  cmd = "docker version -f '{{.Server.Experimental}}'"
+  cmd = "docker version -f '{{.Client.Experimental}}'"
   assert host.check_output(cmd) == "true", "it is required for building the ARM docker images in the Beats project"

--- a/test-infra/beats-ci/test_installed_tools.py
+++ b/test-infra/beats-ci/test_installed_tools.py
@@ -10,7 +10,7 @@ def test_docker_compose_installed(host):
   assert cmd.rc == 0, "it is required for all the Beats projects"
 
 def test_docker_experimental_configured(host):
-  cmd = "docker version -f '{{.Server.Experimental}}'"
+  cmd = "docker version -f '{{.Client.Experimental}}'"
   assert host.check_output(cmd) == "true", "it is required for building the ARM docker images in the Beats project"
 
 def test_gvm_installed(host):


### PR DESCRIPTION
## What does this PR do?

Apply the assert for the client

## Why is it important?

Fix the assertion

```
jenkins@apm-ci-immutable-ubuntu-1804-1591277533261356218:~$ cat ~/.docker/config.json 
{
    "experimental" : "enabled",
    "auths": {
        "container-registry-test.elastic.co": {
                        "auth": "amVua2luczpxSzhmWXJLVkVj"
                    },
        "docker.elastic.co": {
                        "auth": "amVua2luczpOZDRNRlJ1VEp4"
                    }
    }
}
jenkins@apm-ci-immutable-ubuntu-1804-1591277533261356218:~$ docker version -f '{{.Server.Experimental}}'
false

jenkins@apm-ci-immutable-ubuntu-1804-1591277533261356218:~$ docker version
Client: Docker Engine - Community
 Version:           19.03.11
 API version:       1.40
 Go version:        go1.13.10
 Git commit:        42e35e61f3
 Built:             Mon Jun  1 09:12:22 2020
 OS/Arch:           linux/amd64
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          19.03.11
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.10
  Git commit:       42e35e61f3
  Built:            Mon Jun  1 09:10:54 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.13
  GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683

```

## Related issues

Relates to https://github.com/elastic/apm-pipeline-library/pull/584
