### PR TITLE
test-infra: no HOME in the Jenkinsfile

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -134,10 +134,7 @@ def runTest(){
       } else {
         // worker-0a434dec4bdcd060f does not have any reference repos
         def runPackerCacheTests = PLATFORM.equals('worker-0a434dec4bdcd060f') ? 'false' : 'true'
-        // Ephemeral workers don't have a HOME env variable.
-        withEnv(["HOME=${env.WORKSPACE}"]){
-          sh(returnStatus: true, script: "./resources/scripts/jenkins/beats-ci/test.sh ${runPackerCacheTests}")
-        }
+        sh(returnStatus: true, script: "./resources/scripts/jenkins/beats-ci/test.sh ${runPackerCacheTests}")
         docker.image('node:12').inside(){
           withEnv(["HOME=${env.WORKSPACE}/${BASE_DIR}"]){
             sh(script: './resources/scripts/jenkins/build.sh')


### PR DESCRIPTION
## What does this PR do?

Fix the docker experimental tests
See https://github.com/elastic/apm-pipeline-library/pull/590 , this is a leftover from that particular PR.


## Why is it important?

Make our test-infra for beats-ci stable