### PR TITLE
feat: job to check the GitHub API quota

### DIFF
--- a/src/test/resources/jobs/checkGithubQuota.dsl
+++ b/src/test/resources/jobs/checkGithubQuota.dsl
@@ -1,0 +1,27 @@
+NAME = 'checkGithubQuota'
+DSL = '''pipeline {
+   agent { label 'linux && immutable' }
+   stages {
+      stage('check') {
+         steps {
+            withCredentials([
+              usernamePassword(
+                credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+                passwordVariable: 'PASSWORD',
+                usernameVariable: 'USERNAME'
+              )
+            ]) {
+              sh 'set +x;curl -sSfL -u ${USERNAME}:${PASSWORD} https://api.github.com/rate_limit'
+            }
+         }
+      }
+   }
+}'''
+
+pipelineJob(NAME) {
+  definition {
+    cps {
+      script(DSL.stripIndent())
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

It adds a job to the local instances to check the GitHub API quota.

## Why is it important?

It is a quick way to do it without having to search for the credentials the URL and so on.

https://developer.github.com/v3/rate_limit/