### PR TITLE
local: use jjb docker image with 3.x jjb version

### DIFF
--- a/local/test-jjbb.sh
+++ b/local/test-jjbb.sh
@@ -14,12 +14,12 @@ while getopts "l:j:" options; do
     j)
       echo "Setting job to ${OPTARG}"
       FILENAME=${OPTARG} ;;
-    :)
+    *)
       echo "Error: -l expected argument info|warn|error|debug or needs -f <filename>" ;;
   esac
   done
 
-if [ -z ${FILENAME} ] ; then
+if [ -z "${FILENAME}" ] ; then
   echo "To specify a job to deploy, you must use -j"
   exit 1
 fi
@@ -53,7 +53,7 @@ docker run -t --rm --user "$(id -u):$(id -g)" \
         -v "${TMPFOLDER}:/jjbb" \
         -w '/jjbb' \
         -e HOME=/tmp \
-        widerplan/jenkins-job-builder -l ${LOG_LEVEL} test "${BASENAME}" > "${JJB_REPORT}"
+        osmman/jenkins-job-builder:3.1.0 -l "${LOG_LEVEL}" test "${BASENAME}" > "${JJB_REPORT}"
 
 # shellcheck disable=SC2181
 if [ $? -gt 0 ] ; then
@@ -71,5 +71,5 @@ docker run -t --rm --user "$(id -u):$(id -g)" \
         -w '/jjbb' \
         -v "$(pwd)/local/jenkins_jobs.ini":/etc/jenkins_jobs/jenkins_jobs.ini \
         --network local_apm-pipeline-library \
-        osmman/jenkins-job-builder:3.0.2 -l ${LOG_LEVEL} update "${BASENAME}"
+        osmman/jenkins-job-builder:3.0.2 -l "${LOG_LEVEL}" update "${BASENAME}"
 printf '\tpassed\n'


### PR DESCRIPTION
## What does this PR do?

JJB 3.x is the version used in our jenkins instances, so let's support it

## Why is it important?

To fix an existing issue when ussing jjb syntax that's supported but not in 2.x

```
Setting job to .ci/jobs/beats-windows-mbp.yml
Transform JJBB to JJB
2020-06-10 18:00:01,214 [jjbb.main] [INFO] No templates found in .ci/templates, continuing without them.
2020-06-10 18:00:01,391 [jjbb.main] [INFO] No views found at .ci/views/views.yml, continuing without them.
	passed
Validate JJB
WARNING:jenkins_jobs.config:Config file, /etc/jenkins_jobs/jenkins_jobs.ini, not found. Using default config values.
Traceback (most recent call last):
  File "/usr/local/bin/jenkins-jobs", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/cli/entry.py", line 165, in main
    jjb.execute()
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/cli/entry.py", line 146, in execute
    ext.obj.execute(self.options, self.jjb_config)
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/cli/subcommand/test.py", line 63, in execute
    options, jjb_config)
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/cli/subcommand/update.py", line 115, in _generate_xmljobs
    xml_jobs = xml_job_generator.generateXML(job_data_list)
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/xml_config.py", line 82, in generateXML
    xml_objs.append(self._getXMLForData(data))
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/xml_config.py", line 92, in _getXMLForData
    xml = mod.root_xml(data)
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/modules/project_multibranch.py", line 261, in root_xml
    github_scm(bs, scm_data[scm])
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/modules/project_multibranch.py", line 972, in github_scm
    property_strategies(xml_parent, data)
  File "/usr/local/lib/python3.6/dist-packages/jenkins_jobs/modules/project_multibranch.py", line 1178, in property_strategies
    for dbs_list in prop_strats.get('all-branches', None):
TypeError: 'NoneType' object is not iterable
```

## Issues

I was not able to validate https://github.com/elastic/beats/pull/19116 with `widerplan/jenkins-job-builder`