### PR TITLE
fix the refspec as used to be

### DIFF
--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -41,7 +41,7 @@ def call(Map params = [:]){
   def shallowValue = params.containsKey('shallow') ? params.get('shallow') : false
   def depthValue = params.containsKey('depth') ? params.get('depth') : 5
   def retryValue = params.containsKey('retry') ? params.get('retry') : 3
-  def refspec = '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*'
+  def refspec = '+refs/pull/*/head:refs/remotes/origin/pr/*'
 
   if(!env?.GIT_URL && params.repo) {
     log(level: 'DEBUG', text: 'Override GIT_URL with the params.repo to support simple pipeline rather than multibranch pipelines only.')
@@ -97,7 +97,7 @@ def call(Map params = [:]){
         extensions: extensions,
         submoduleCfg: [],
         userRemoteConfigs: [[
-          refspec: refspec,
+          refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*',
           credentialsId: "${credentialsId}",
           url: "${repo}"]]])
     } else {


### PR DESCRIPTION
## What does this PR do?

refspecs were normalised but it seems there is a corner case that causes some issues in the `apm-agent-dotnet`

## Why is it important?

gitCheckout is broken in the apm-agent-dotnet

```
fatal: Cannot fetch both refs/heads/pr/82 and refs/pull/82/head to refs/remotes/origin/pr/82
```

![image](https://user-images.githubusercontent.com/2871786/84399974-5fc25880-abf9-11ea-8d48-816a14c8b919.png)

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/563

