### PR TITLE
ci: store docker logs for the opbeans

### DIFF
--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -75,6 +75,14 @@ def call(Map pipelineParams) {
             unstash 'source'
             dir(BASE_DIR){
               sh 'make build'
+              // Let's store the docker log files for debugging purposes
+              script {
+                if (fileExists('docker-compose.yml')) {
+                  sh(label: 'docker-compose start', script: 'docker-compose up --build -d')
+                  dockerLogs()
+                  sh(label: 'docker-compose stop', script: 'docker-compose down -v')
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## What does this PR do?

Add an extra step to generate the docker images and run them to gather the logs.

## Why is it important?

This is the less intrusive approach to avoid changing each opbeans (there are 6 different opbeans). The make test goal does delete each container after each test. If we want to change it then we need to apply the same changes in all those 6 different git projects.

Let's see if this approach is sufficient.

## Related issues
Closes https://github.com/elastic/observability-robots/issues/15