### PR TITLE
Add shell-worker to Makefile

### DIFF
--- a/local/Makefile
+++ b/local/Makefile
@@ -63,6 +63,10 @@ shell:  ## Open a Bash shell on the local Jenkins master
 			--file docker-compose.yml \
 			exec $${SERVICE:-jenkins} sh
 
+.PHONY: shell-worker
+shell-worker:  ## Open a Bash shell on the local Jenkins worker
+	VAGRANT_CWD=workers/linux/ vagrant ssh
+
 .PHONY: start
 start:  ## Start the local Jenkins master
 start: master


### PR DESCRIPTION
## What does this PR do?

Adds the ability to run `make shell-worker` and get a shell on the vagrant worker

## Why is it important?
Just for consistency with other make commands.

