### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -35,7 +35,7 @@ docker.elastic.co/observability-ci/shellcheck
 docker.elastic.co/observability-ci/yamllint
 widerplan/jenkins-job-builder
 "
-if [ -f "$(command -v docker)" ]; then
+if [ -x "$(command -v docker)" ]; then
   for di in ${DOCKER_IMAGES}
   do
   (retry 2 docker pull "${di}") || echo "Error pulling ${di} Docker image, we continue"


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.

## Related issues
related to https://github.com/elastic/observability-robots/issues/148
