### PR TITLE
test-infra: support new workers

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -60,7 +60,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu && immutable', 'worker-c07l34n6dwym', 'worker-c07y20b6jyvy', 'worker-c07ll940dwyl', 'worker-c07y20b9jyvy', 'worker-c07y20b4jyvy', 'worker-c07y20bcjyvy', 'worker-395930', 'worker-0a434dec4bdcd060f', 'immutable && windows-2019', 'immutable && windows-2016', 'immutable && windows-2012-r2', 'immutable && windows-10', 'immutable && windows-8', 'immutable && windows-2008-r2', 'immutable && windows-7', 'immutable && windows-7-32-bit'
+            values 'ubuntu && immutable', 'ubuntu-1404-i386', 'worker-c07l34n6dwym', 'worker-c07y20b6jyvy', 'worker-c07ll940dwyl', 'worker-c07y20b9jyvy', 'worker-c07y20b4jyvy', 'worker-c07y20bcjyvy', 'worker-395930', 'worker-0a434dec4bdcd060f', 'immutable && windows-2019', 'immutable && windows-2016', 'immutable && windows-2012-r2', 'immutable && windows-10', 'immutable && windows-8', 'immutable && windows-2008-r2', 'immutable && windows-7', 'immutable && windows-7-32-bit'
           }
         }
         excludes {

--- a/resources/JenkinsfileTemplate.groovy
+++ b/resources/JenkinsfileTemplate.groovy
@@ -139,6 +139,7 @@ pipeline {
         beforeAgent true
         expression { return env.ONLY_DOCS == "false" }
       }
+      failFast false
       parallel {
         stage('linux && immutable check'){
           agent { label 'linux && immutable' }
@@ -360,6 +361,32 @@ pipeline {
         }
         stage('BareMetal worker-1095690 check'){
           agent { label 'worker-1095690' }
+          options { skipDefaultCheckout() }
+          steps {
+            buildUnix()
+            testBaremetal()
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/junit-*.xml")
+            }
+          }
+        }
+        stage('BareMetal worker-1213919 check'){
+          agent { label 'worker-1213919' }
+          options { skipDefaultCheckout() }
+          steps {
+            buildUnix()
+            testBaremetal()
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/**/junit-*.xml")
+            }
+          }
+        }
+        stage('BareMetal worker-1225339 check'){
+          agent { label 'worker-1225339' }
           options { skipDefaultCheckout() }
           steps {
             buildUnix()


### PR DESCRIPTION
## What does this PR do?

Add new workers to the test-infra in beats-ci and apm-ci

## Why is it important?

Validate the dependencies are in place

## Related issues

Caused by https://github.com/elastic/infra/pull/21219 , https://github.com/elastic/infra/issues/19603 and https://github.com/elastic/infra/issues/19114