### PR TITLE
[jjbb]: folder description is required

### DIFF
--- a/.ci/jobs/apm-shared.yml
+++ b/.ci/jobs/apm-shared.yml
@@ -1,4 +1,5 @@
 ---
 - job:
     name: apm-shared
+    description: apm-shared
     project-type: folder

--- a/.ci/jobs/apm-ui.yml
+++ b/.ci/jobs/apm-ui.yml
@@ -1,4 +1,5 @@
 ---
 - job:
     name: apm-ui
+    description: apm-ui
     project-type: folder

--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -1,4 +1,5 @@
 ---
 - job:
     name: beats
+    description: beats
     project-type: folder

--- a/.ci/jobs/stack.yml
+++ b/.ci/jobs/stack.yml
@@ -1,4 +1,5 @@
 ---
 - job:
     name: stack
+    description: stack
     project-type: folder


### PR DESCRIPTION
## What does this PR do?

Fixes the description issue as spotted 

## Why is it important?


Otherwise the JJBB won't work

```
2020-06-18 09:41:58,516 [jjbb.jenkins_server] [ERROR] 'NoneType' object has no attribute 'endswith'
```

## Related issues

Relates https://github.com/elastic/infra/pull/21184