### PR TITLE
test-infra: docker in 64 bits only

### DIFF
--- a/test-infra/beats-ci/test_installed_tools.py
+++ b/test-infra/beats-ci/test_installed_tools.py
@@ -2,12 +2,18 @@ import testinfra
 import pytest
 
 def test_docker_installed(host):
-  cmd = host.run("docker --version")
-  assert cmd.rc == 0, "it is required for all the Beats projects"
+  if host.system_info.arch == 'x86_64' :
+    cmd = host.run("docker --version")
+    assert cmd.rc == 0, "it is required for all the Beats projects"
+  else:
+    pytest.skip("unsupported configuration")
 
 def test_docker_compose_installed(host):
-  cmd = host.run("docker-compose --version")
-  assert cmd.rc == 0, "it is required for all the Beats projects"
+  if host.system_info.arch == 'x86_64' :
+    cmd = host.run("docker-compose --version")
+    assert cmd.rc == 0, "it is required for all the Beats projects"
+  else:
+    pytest.skip("unsupported configuration")
 
 def test_docker_experimental_configured(host):
   if host.system_info.type == 'darwin' :


### PR DESCRIPTION
## What does this PR do?

Validate only in 64 bits

## Why is it important?

To avoid the misleading when docker is not supported for 32bit arch

## Related issues

Relates to https://github.com/elastic/infra/issues/21302