### PR TITLE
Add a pipeline to run the e2e tests for Ingest Manager in a daily manner

### DIFF
--- a/.ci/jobs/e2e-testing-ingest-manager-daily.yml
+++ b/.ci/jobs/e2e-testing-ingest-manager-daily.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: stack/e2e-testing-ingest-manager-daily
+    display-name: End-2-End tests for Ingest Manager Pipeline
+    description: Run E2E Ingest Manager test suite daily
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/e2eTestingIngestManagerDaily.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/e2e-testing.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: '@daily'


### PR DESCRIPTION
## What does this PR do?
It adds a Jenkins pipeline that grabs a pipeline from the e2e-testing repository
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It will allow running the Ingest Manager tests in a daily manner

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Relates https://github.com/elastic/e2e-testing/issues/142