### PR TITLE
test-infra: arch is supported in 5.1.0

### DIFF
--- a/test-infra/beats-ci/test_installed_tools.py
+++ b/test-infra/beats-ci/test_installed_tools.py
@@ -2,14 +2,14 @@ import testinfra
 import pytest
 
 def test_docker_installed(host):
-  if host.system_info.arch == 'x86_64' :
+  if host.check_output("uname -m") == "x86_64" :
     cmd = host.run("docker --version")
     assert cmd.rc == 0, "it is required for all the Beats projects"
   else:
     pytest.skip("unsupported configuration")
 
 def test_docker_compose_installed(host):
-  if host.system_info.arch == 'x86_64' :
+  if host.check_output("uname -m") == "x86_64" :
     cmd = host.run("docker-compose --version")
     assert cmd.rc == 0, "it is required for all the Beats projects"
   else:


### PR DESCRIPTION
`Testinfra` 5.1.0 is not available in some workers therefore


```
Workers Checks / Matrix - PLATFORM = 'ubuntu-1404-i386' / Test / test_docker_installed[local] – test-infra.beats-ci.test_installed_tools
<1s
Error
AttributeError: 'SystemInfo' object has no attribute 'arch'
Stacktrace
host = <testinfra.host.Host object at 0xb6c0d72c>
    def test_docker_installed(host):
>     if host.system_info.arch == 'x86_64' :
E     AttributeError: 'SystemInfo' object has no attribute 'arch'
test-infra/beats-ci/test_installed_tools.py:5: AttributeError

```


Similar to https://github.com/elastic/apm-pipeline-library/pull/550