### PR TITLE
template: size to kbs format

### DIFF
--- a/resources/templates/bundlesize.md.j2
+++ b/resources/templates/bundlesize.md.j2
@@ -10,5 +10,5 @@ Filename | Size(bundled) | Size(gzip) | Diff(gzip)
         {%- set status = "green" -%}
     {%- endif -%} 
 {%- endif -%} 
-{{ item.label }} | {{ item.parsedSize }} B | {{ item.gzipSize }} B | {% if item.previousGzipSize %} (<span style="color:{{ status }}"> {{ item.gzipSize - item.previousGzipSize }}</span> ) {% endif %}
+{{ item.label }} | {{ item.parsedSize | int | filesizeformat(true) }} | {{ item.gzipSize | int | filesizeformat(true) }} | {% if item.previousGzipSize %} (<span style="color:{{ status }}"> {{ ( item.gzipSize - item.previousGzipSize | int ) | filesizeformat(true) }}</span> ) {% endif %}
 {% endfor %}


### PR DESCRIPTION
## What does this PR do?

As requested let's use Kb format

## Why is it important?

Human-readable

See [filesizeformat](https://jinja.palletsprojects.com/en/2.11.x/templates/#filesizeformat)

## Related issues

Caused by https://github.com/elastic/apm-agent-rum-js/pull/826


## Tests

![image](https://user-images.githubusercontent.com/2871786/86008553-da201480-ba10-11ea-9298-021ca9bf499a.png)
