### PR TITLE
Flake threshold

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -41,12 +41,13 @@ def analyzeFlakey(Map params = [:]) {
     def secret = params.containsKey('es_secret') ? params.es_secret : null
     def flakyReportIdx = params.containsKey('flakyReportIdx') ? params.flakyReportIdx : error('analyzeFlakey: flakyReportIdx parameter is not valid')
     def testsErrors = params.containsKey('testsErrors') ? params.testsErrors : []
+    def flakyThreshold = params.containsKey('flakyThreshold') ? params.flakyThreshold : 0.0
     
     if (!flakyReportIdx || !flakyReportIdx.trim()) {
       error "Did not receive flakyReportIdx data" 
     }
 
-    def q = toJSON(["query":["range": ["test_score": ["gt": 0.0]]]])
+    def q = toJSON(["query":["range": ["test_score": ["gt": flakyThreshold]]]])
     def c = '/' + flakyReportIdx + '/_search'
     def flakeyTestsRaw = sendDataToElasticsearch(es: es, secret: secret, data: q, restCall: c)
     def flakeyTestsParsed = toJSON(flakeyTestsRaw)

--- a/vars/README.md
+++ b/vars/README.md
@@ -292,6 +292,7 @@ script, template and outputs that are generated.
 * compare: Whether to compare the outcome with a particular TARGET_BRANCH. NOTE: only available for Pull Requests. Optional. Default 'true'
 
 _NOTE_: It only supports *nix.
+
 ## getBlueoceanDisplayURL
 Provides the Blueocean URL for the current build/run
 
@@ -1199,6 +1200,8 @@ Besides, if there are checkout environmental issues then it will rebuild the pip
 emails on Failed builds that are not pull request.
 * prComment: Whether to add a comment in the PR with the build summary as a comment. Default: `true`.
 * analyzeFlakey: Whether or not to add a comment in the PR with tests which have been detected as flakey. Default: `false`.
+* flakyReportIdx: The flaky index to compare this jobs results to. e.g. reporter-apm-agent-java-apm-agent-java-master
+* flakyThreshold: The threshold below which flaky tests will be ignored. Default: 0.0
 * rebuild: Whether to rebuild the pipeline in case of any environmental issues. Default true
 * downstreamJobs: The map of downstream jobs that were launched within the upstream pipeline. Default empty.
 * newPRComment: The map of the data to be populated as a comment. Default empty.

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -37,6 +37,7 @@ def call(Map args = [:]) {
   def analyzeFlakey = args.containsKey('analyzeFlakey') ? args.analyzeFlakey : false
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
   def flakyReportIdx = args.containsKey('flakyReportIdx') ? args.flakyReportIdx : ""
+  def flakyThreshold = args.containsKey('flakyThreshold') ? args.flakyThreshold : 0.0
 
   node('master || metal || immutable'){
     stage('Reporting build status'){
@@ -69,6 +70,7 @@ def call(Map args = [:]) {
           data['es'] = es
           data['es_secret'] = secret
           data['flakyReportIdx'] = flakyReportIdx
+          data['flakyThreshold'] = flakyThreshold
           log(level: 'DEBUG', text: "notifyBuildResult: Generating flakey test analysis.")
           catchError(message: "There were some failures when generating flakey test results", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
             notificationManager.analyzeFlakey(data)

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -22,6 +22,8 @@ Besides, if there are checkout environmental issues then it will rebuild the pip
 emails on Failed builds that are not pull request.
 * prComment: Whether to add a comment in the PR with the build summary as a comment. Default: `true`.
 * analyzeFlakey: Whether or not to add a comment in the PR with tests which have been detected as flakey. Default: `false`.
+* flakyReportIdx: The flaky index to compare this jobs results to. e.g. reporter-apm-agent-java-apm-agent-java-master
+* flakyThreshold: The threshold below which flaky tests will be ignored. Default: 0.0
 * rebuild: Whether to rebuild the pipeline in case of any environmental issues. Default true
 * downstreamJobs: The map of downstream jobs that were launched within the upstream pipeline. Default empty.
 * newPRComment: The map of the data to be populated as a comment. Default empty.


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

Some projects have a higher threshold for flaky test detection. This allows that threshold to be specified in the pipeline itself.

## Related issues
Closes https://github.com/elastic/observability-robots/issues/169
