### PR TITLE
template: fix conditional and emoticons

### DIFF
--- a/resources/templates/bundlesize.md.j2
+++ b/resources/templates/bundlesize.md.j2
@@ -3,12 +3,12 @@
 Filename | Size(bundled) | Size(gzip) | Diff(gzip)
  --- | --- | --- | ---
 {% for item in data -%}
-{%- if item.previousParsedSize -%}
+{%- if item.previousGzipSize -%}
     {%- if item.gzipSize - item.previousGzipSize > 0 -%}
-        {%- set status = "red" -%}
+        {%- set status = ":warning:" -%}
     {% else %}
-        {%- set status = "green" -%}
+        {%- set status = ":green_heart:" -%}
     {%- endif -%} 
 {%- endif -%} 
-{{ item.label }} | {{ item.parsedSize | int | filesizeformat(true) }} | {{ item.gzipSize | int | filesizeformat(true) }} | {% if item.previousGzipSize %} (<span style="color:{{ status }}"> {{ ( item.gzipSize - item.previousGzipSize | int ) | filesizeformat(true) }}</span> ) {% endif %}
+{{ item.label }} | {{ item.parsedSize | int | filesizeformat(true) }} | {{ item.gzipSize | int | filesizeformat(true) }} | {% if item.previousGzipSize %} {{ status }} {{ ( item.gzipSize - item.previousGzipSize | int ) | filesizeformat(true) }} {% endif %}
 {% endfor %}


### PR DESCRIPTION
## What does this PR do?

span is not supported in the GH markdown, so let's notify the diff with some emoticons instead

## Why is it important?

Help to visualise the bundlesize diff and fix the conditional. For instance,  https://github.com/elastic/apm-agent-rum-js/pull/825#issuecomment-651127304  is not showing the green color when the diff is negative