### PR TITLE
[opbeans] fix the docker logs happy path

### DIFF
--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -75,12 +75,18 @@ def call(Map pipelineParams) {
             unstash 'source'
             dir(BASE_DIR){
               sh 'make build'
+            }
+          }
+        }
+        post {
+          always {
+            dir(BASE_DIR){
               // Let's store the docker log files for debugging purposes
               script {
                 if (fileExists('docker-compose.yml')) {
-                  sh(label: 'docker-compose start', script: 'docker-compose up --build -d')
+                  sh(label: 'docker-compose start', script: 'docker-compose up --build -d', returnStatus: true)
                   dockerLogs()
-                  sh(label: 'docker-compose stop', script: 'docker-compose down -v')
+                  sh(label: 'docker-compose stop', script: 'docker-compose down -v', returnStatus: true)
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do?

Avoid the docker logs generation to stop a build if something bad happens.


## Why is it important?

Otherwise, builds can fail when exporting the docker logs.

[build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-dotnet%2Fopbeans-dotnet-mbp/detail/master/55/pipeline#step-71-log-92) failed when running the docker-compose although all the magic should be handled with the make test and it should fail there, otherwise, we might need to add some extra validations for the docker-compose files.

## Related issues
Closes #ISSUE