### PR TITLE
Install yaml via pip for Heartbeat stage

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -347,6 +347,7 @@ pipeline {
         git credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: 'https://github.com/elastic/observability-robots'
         dir("apps/beats/heartbeat"){
           script{
+            sh("pip install yaml")
             sh("./generate_heartbeat_configs.py")
             def writeClosure = {sh(script: "cp -R ${WORKSPACE}/apps/beats/heartbeat/configs configs/ && cp ${WORKSPACE}/apps/beats/heartbeat/heartbeat.yml heartbeat.yml")}
             buildDockerImage(


### PR DESCRIPTION
## What does this PR do?
Installs yaml via pip prior to running the heartbeat generation script

## Why is it important?
Script requires yaml to be installed or it will crash.

