### PR TITLE
script: add always the previous size

### DIFF
--- a/resources/scripts/bundlesize.sh
+++ b/resources/scripts/bundlesize.sh
@@ -47,9 +47,7 @@ function addPreviousSizeIfPossible() {
     tmp="$(mktemp -d)/compare.json"
     # shellcheck disable=SC2016
     previous_size=$($JQ --arg id "${label}" --arg v "$size" '(.[] | select(.label==$id) | .[$v])' "${compare_to}")
-    # shellcheck disable=SC2016
-    current_size=$($JQ --arg id "${label}" --arg v "$size" '(.[] | select(.label==$id) | .[$v])' "${report}")
-    if [ "${previous_size}" != "${current_size}" ] ; then
+    if [ -n "${previous_size}" ] ; then
         # shellcheck disable=SC2016
         $JQ --arg id "${label}" --arg v "${new_size}" --argjson new "${previous_size}" '(.[] | select(.label==$id) | .[$v]) |= $new' "${report}" > "$tmp"
         mv "$tmp" "${report}"


### PR DESCRIPTION
This will help to support the diff even though the values are the same


## Why is it important?

To support the report when the target branch got the same values that the PR.

Otherwise

![image](https://user-images.githubusercontent.com/2871786/86459518-caf5db00-bd1e-11ea-95bd-2b92ebbc362e.png)

## Test

```bash
$ ./resources/scripts/bundlesize.sh bundlesize build '../apm-agent-rum-js/packages/rum/reports/apm-*-report.html' 'target/master.json'
$ cp build/bundlesize.json target/master.json
$ ./resources/scripts/bundlesize.sh bundlesize build '../apm-agent-rum-js/packages/rum/reports/apm-*-report.html' 'target/master.json'
cat build/bundlesize.json                                                                                                
[
  {
    "label": "elastic-apm-opentracing.umd.min.js",
    "isAsset": true,
    "statSize": 170215,
    "parsedSize": 61515,
    "gzipSize": 19716,
    "previousParsedSize": 61515,
    "previousGzipSize": 19716,
    "previousStatSize": 170215
  },
  {
    "label": "elastic-apm-rum.umd.min.js",
    "isAsset": true,
    "statSize": 142956,
    "parsedSize": 55470,
    "gzipSize": 18223,
    "previousParsedSize": 55470,
    "previousGzipSize": 18223,
    "previousStatSize": 142956
  }
]
```