### PR TITLE
pre-commit: change vault secrets

### DIFF
--- a/src/test/groovy/PreCommitStepTests.groovy
+++ b/src/test/groovy/PreCommitStepTests.groovy
@@ -101,7 +101,7 @@ class PreCommitStepTests extends ApmBasePipelineTest {
     script.call(commit: 'foo')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sshagent', '[f6c7695a-671e-4f4f-a331-acdce44ff9ba]'))
-    assertTrue(assertMethodCallContainsPattern('dockerLogin', '{secret=secret/apm-team/ci/docker-registry/prod, registry=docker.elastic.co}'))
+    assertTrue(assertMethodCallContainsPattern('dockerLogin', '{secret=secret/observability-team/ci/docker-registry/prod, registry=docker.elastic.co}'))
     assertJobStatusSuccess()
   }
 

--- a/vars/README.md
+++ b/vars/README.md
@@ -1254,7 +1254,7 @@ preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/apm-team/ci/doc
 * commit: what git commit to compare with. Default: env.GIT_BASE_COMMIT. Optional
 * credentialsId: what credentialsId to be loaded to enable git clones from private repos. Default: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'. Optional
 * registry: what docker registry to be logged to consume internal docker images. Default: 'docker.elastic.co'. Optional
-* secretRegistry: what secret credentials to be used for login the docker registry. Default: 'secret/apm-team/ci/docker-registry/prod'. Optional
+* secretRegistry: what secret credentials to be used for login the docker registry. Default: 'secret/observability-team/ci/docker-registry/prod'. Optional
 
 ## preCommitToJunit
 Parse the pre-commit log file and generates a junit report

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -32,7 +32,7 @@ def call(Map params = [:]) {
   def commit = params.get('commit', env.GIT_BASE_COMMIT)
   def credentialsId = params.get('credentialsId', 'f6c7695a-671e-4f4f-a331-acdce44ff9ba')
   def registry = params.get('registry', 'docker.elastic.co')
-  def secretRegistry = params.get('secretRegistry', 'secret/apm-team/ci/docker-registry/prod')
+  def secretRegistry = params.get('secretRegistry', 'secret/observability-team/ci/docker-registry/prod')
 
   if (!commit?.trim()) {
     commit = env.GIT_BASE_COMMIT ?: error('preCommit: git commit to compare with is required.')

--- a/vars/preCommit.txt
+++ b/vars/preCommit.txt
@@ -15,4 +15,4 @@ preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/apm-team/ci/doc
 * commit: what git commit to compare with. Default: env.GIT_BASE_COMMIT. Optional
 * credentialsId: what credentialsId to be loaded to enable git clones from private repos. Default: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba'. Optional
 * registry: what docker registry to be logged to consume internal docker images. Default: 'docker.elastic.co'. Optional
-* secretRegistry: what secret credentials to be used for login the docker registry. Default: 'secret/apm-team/ci/docker-registry/prod'. Optional
+* secretRegistry: what secret credentials to be used for login the docker registry. Default: 'secret/observability-team/ci/docker-registry/prod'. Optional


### PR DESCRIPTION
## What does this PR do?

Use the new credentials that should be supported for beats-ci and apm-ci

## Why is it important?

Help with the default configuration to be also supported in the beats-ci


## Related issues

Caused by https://github.com/elastic/e2e-testing/pull/158

## Tests

I created a test-branch and it worked fine (https://github.com/elastic/apm-pipeline-library/tree/test/change-secrets-to-obs11-genericone)

![image](https://user-images.githubusercontent.com/2871786/86465721-1eb9f180-bd2a-11ea-995d-6c01e16f0a77.png)

