### PR TITLE
fix: remove refspec because is no longer needed

### DIFF
--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -97,7 +97,6 @@ def call(Map params = [:]){
         extensions: extensions,
         submoduleCfg: [],
         userRemoteConfigs: [[
-          refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*',
           credentialsId: "${credentialsId}",
           url: "${repo}"]]])
     } else {


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

* remove a refspec parameter not needed and that causes an issue (https://github.com/elastic/beats/pull/19681).

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

To grab these two refspecs in the same command can generate a conflict like we saw in https://github.com/elastic/beats/pull/19681. The solution is to split the command in two, and we made it time ago,
we have the checkout that takes the regular refspec (+refs/heads/*:refs/remotes/origin/*) and `fetchPullRefs(refspec)` that tech the pull request references.

