### PR TITLE
fix: using capital on the refspec does not have colisions

### DIFF
--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -97,6 +97,7 @@ def call(Map params = [:]){
         extensions: extensions,
         submoduleCfg: [],
         userRemoteConfigs: [[
+          refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/PR/*',
           credentialsId: "${credentialsId}",
           url: "${repo}"]]])
     } else {


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
it adds again the refspec to grasp the PRs.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

This refspec is needed to have the commit SHA references, if we use `PR` in capitals it does not collision with the GitHub refspec.

it fixes the following issue

```
[2020-07-08T09:15:45.291Z] using credential f6c7695a-671e-4f4f-a331-acdce44ff9ba
[2020-07-08T09:15:45.329Z] Cloning the remote Git repositor
[2020-07-08T09:15:45.340Z] Cloning repository git@github.com:elastic/apm-integration-testing.git
[2020-07-08T09:15:45.361Z]  > git init /var/lib/jenkins/workspace/_integration-test-downstream_7.x/src/github.com/elastic/apm-integration-testing # timeout=10
[2020-07-08T09:15:45.371Z] [WARNING] Reference path does not exist: /var/lib/jenkins/apm-integration-testing.git
[2020-07-08T09:15:45.372Z] Fetching upstream changes from git@github.com:elastic/apm-integration-testing.git
[2020-07-08T09:15:45.372Z]  > git --version # timeout=10
[2020-07-08T09:15:45.385Z] using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
[2020-07-08T09:15:45.389Z]  > git fetch --tags --progress -- git@github.com:elastic/apm-integration-testing.git +refs/heads/*:refs/remotes/origin/* # timeout=10
[2020-07-08T09:15:46.275Z]  > git config remote.origin.url git@github.com:elastic/apm-integration-testing.git # timeout=10
[2020-07-08T09:15:46.278Z]  > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
[2020-07-08T09:15:46.285Z]  > git config remote.origin.url git@github.com:elastic/apm-integration-testing.git # timeout=10
[2020-07-08T09:15:46.292Z] Fetching upstream changes from git@github.com:elastic/apm-integration-testing.git
[2020-07-08T09:15:46.292Z] using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
[2020-07-08T09:15:46.295Z]  > git fetch --tags --progress -- git@github.com:elastic/apm-integration-testing.git +refs/heads/*:refs/remotes/origin/* # timeout=10
[2020-07-08T09:15:46.857Z]  > git rev-parse ea838c80672c8929e690692fa13e4696cf952a6c^{commit} # timeout=10
[2020-07-08T09:15:46.869Z]  > git rev-parse origin/ea838c80672c8929e690692fa13e4696cf952a6c^{commit} # timeout=10
[2020-07-08T09:15:46.885Z]  > git rev-parse ea838c80672c8929e690692fa13e4696cf952a6c^{commit} # timeout=10
Couldn't find any revision to build. Verify the repository and branch configuration for this job.
```

## Related issues
related to https://github.com/elastic/apm-pipeline-library/pull/658
