### PR TITLE
fix: ignore label team:automation on changelogs

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -7,7 +7,8 @@ module.exports = {
     "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
     "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
       "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
-      "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows"],
+      "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows",
+      "team:automation"],
     "groupBy": {
         "Enhancements": ["enhancement", "internal", "feature", "feat"],
         "Bug Fixes": ["bug", "fix"],


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It adds `team:automation` label to the ignore list

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

we should not show the `team:automation` label in changelogs.
