### PR TITLE
add more debug traces in isCommentTrigger

### DIFF
--- a/vars/githubApiCall.groovy
+++ b/vars/githubApiCall.groovy
@@ -75,7 +75,7 @@ def call(Map params = [:]){
     } else if (ret == null ) {
       error ("githubApiCall: something happened with the toJson")
     } else {
-      log(level: 'DEBUG', text: "githubApiCall: The REST API call ${url} return ${ret}")
+      log(level: 'DEBUG', text: "githubApiCall: The REST API call ${url} returned ${ret}")
     }
     return ret
   }

--- a/vars/isCommentTrigger.groovy
+++ b/vars/isCommentTrigger.groovy
@@ -38,7 +38,7 @@ def call(){
       // githubApiCall returns either a raw ouput or an error message if so it means the user is not a member.
       found = membershipResponse.message?.trim() ? false : true
     } catch(err) {
-      log(level: 'WARN', text: "isCommentTrigger: only users under the elastic organisation are allowed. Message: See ${err.toString()}")
+      log(level: 'WARN', text: "isCommentTrigger: only users under the Elastic organisation are allowed. Message: See ${err.toString()}")
       // Then it means 404 errorcode.
       // See https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-not-a-member
       found = false


### PR DESCRIPTION
## What does this PR do?

Add debug traces to help with when there is an unexpected test failure.

## Why is it important?

Avoid misleading with the traces and silently miss a genuine failure. For instance, `isCommentTrigger` requires a `node` where to run to since it does mask some environment variables and they are required. (see https://github.com/jenkinsci/mask-passwords-plugin/blob/master/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java#L36)

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/issues/667
