### PR TITLE
java: add kananindzya as trusted user

### DIFF
--- a/resources/approval-list/apm-agent-java.yml
+++ b/resources/approval-list/apm-agent-java.yml
@@ -3,3 +3,4 @@
 # The name of the YAML file should match the name of the GitHub repo.
 USERS:
     - v1v
+    - kananindzya


### PR DESCRIPTION
## What does this PR do?

Add kananindzya as trusted user for the elastic/apm-agent-java.git repo

He's the most frequent community contributor: https://github.com/elastic/apm-agent-java/graphs/contributors

## Why is it important?

As stated in elastic/observability-robots#16
