### PR TITLE
[test] add more tests for the gitMatchingGroup step

### DIFF
--- a/src/test/groovy/GetGitMatchingGroupStepTests.groovy
+++ b/src/test/groovy/GetGitMatchingGroupStepTests.groovy
@@ -513,9 +513,7 @@ metricbeat/module/zookeeper/connection/connection.go
 x-pack/auditbeat/module/system/system.go
 x-pack/auditbeat/module/system/fields.go'''.stripMargin().stripIndent()
     helper.registerAllowedMethod('readFile', [String.class], { return realData })
-    def module = script.call(pattern: beatsPattern, exclude: getExcludePattern('metricbeat'))
-    assertEquals('zookeeper', module)
-    module = script.call(pattern: beatsXpackPattern, exclude: getExcludePattern('x-pack/auditbeat'))
+    def module = script.call(pattern: beatsXpackPattern, exclude: getExcludePattern('x-pack/auditbeat'))
     assertEquals('system', module)
     assertJobStatusSuccess()
   }


### PR DESCRIPTION
## What does this PR do?

Add some test cases to validate a multimodule beat with some exclusions.


## Why is it important?

Avoid the corner case of detecting a quite generic regex that should not apply for another beats

## Related issues

Caused by https://github.com/elastic/beats/pull/19985 and therefore https://github.com/elastic/beats/issues/19986