### PR TITLE
fix quotes in tap2Junit

### DIFF
--- a/src/test/groovy/Tap2JunitStepTests.groovy
+++ b/src/test/groovy/Tap2JunitStepTests.groovy
@@ -35,9 +35,9 @@ class Tap2JunitStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'node:12-alpine'))
     assertTrue(assertMethodCallContainsPattern('sh', '-junit-report.xml'))
-    assertTrue(assertMethodCallContainsPattern('sh', "--package='co.elastic'"))
+    assertTrue(assertMethodCallContainsPattern('sh', '--package="co.elastic"'))
     assertTrue(assertMethodCallContainsPattern('junit', 'junit-report.xml'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'for i in *.tap'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'for i in "*.tap"'))
     assertJobStatusSuccess()
   }
 
@@ -64,7 +64,7 @@ class Tap2JunitStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(package: 'foo.bar')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('sh', "--package='foo.bar'"))
+    assertTrue(assertMethodCallContainsPattern('sh', '--package="foo.bar"'))
     assertJobStatusSuccess()
   }
 
@@ -73,7 +73,7 @@ class Tap2JunitStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(pattern: 'foo.*')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('sh', 'for i in foo.*'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'for i in "foo.*"'))
     assertJobStatusSuccess()
   }
 }

--- a/vars/tap2Junit.groovy
+++ b/vars/tap2Junit.groovy
@@ -40,7 +40,8 @@ def call(Map args = [:]) {
         -w /usr/src/app \
         -u \$(id -u):\$(id -g) \
         ${nodeVersion} \
-        sh -c 'export HOME=/tmp ; mkdir ~/.npm-global; npm config set prefix '~/.npm-global' ; npm install tap-xunit -g ; for i in ${pattern}; do cat \${i} | /tmp/.npm-global/bin/tap-xunit --package='${packageName}' > \${i%.*}-${suffix} ; done'
+        sh -c 'export HOME=/tmp ; mkdir ~/.npm-global; npm config set prefix ~/.npm-global ; npm install tap-xunit -g ; for i in "${pattern}" ; do cat \${i} | /tmp/.npm-global/bin/tap-xunit --package="${packageName}" > \${i%.*}-${suffix} ; done'
     """)
   junit testResults: "*-${suffix}", allowEmptyResults: true, keepLongStdio: true
 }
+  


### PR DESCRIPTION
## What does this PR do?

Single quotes were in several places and the shell step did fail.

## Why is it important?

Step is broken

```

[2020-07-21T13:32:53.551Z] + pwd

[2020-07-21T13:32:53.551Z] + id -u

[2020-07-21T13:32:53.551Z] + id -g

[2020-07-21T13:32:53.551Z] + docker run --rm -v /var/lib/jenkins/workspace/ejs_apm-agent-nodejs-mbp_PR-1794:/usr/src/app -w /usr/src/app -u 1154:1155 node:12-alpine sh -c export HOME=/tmp ; mkdir ~/.npm-global; npm config set prefix ~/.npm-global ; npm install tap-xunit -g ; for i in *-output.tap; do cat ${i} | /tmp/.npm-global/bin/tap-xunit --package=Node.js > ${i%.*}-junit.xml ; done

[2020-07-21T13:32:53.551Z] Unable to find image 'node:12-alpine' locally

[2020-07-21T13:32:54.122Z] 12-alpine: Pulling from library/node

[2020-07-21T13:32:54.122Z] cbdbe7a5bc2a: Already exists

[2020-07-21T13:32:54.122Z] bd07af9ed1a4: Already exists

[2020-07-21T13:32:54.122Z] 3556ccf180b2: Already exists

[2020-07-21T13:32:54.122Z] 089d4748da74: Already exists

[2020-07-21T13:32:54.385Z] Digest: sha256:1660c1b9d3fd9711eb9936e66d4656954cd14b0d2b23a2185c39587dad0239b4

[2020-07-21T13:32:54.385Z] Status: Downloaded newer image for node:12-alpine

[2020-07-21T13:33:00.990Z] /tmp/.npm-global/bin/tap-xunit -> /tmp/.npm-global/lib/node_modules/tap-xunit/bin/tap-xunit

[2020-07-21T13:33:00.990Z] /tmp/.npm-global/bin/txunit -> /tmp/.npm-global/lib/node_modules/tap-xunit/bin/tap-xunit

[2020-07-21T13:33:00.990Z] + tap-xunit@2.4.1

[2020-07-21T13:33:00.990Z] added 21 packages from 21 contributors in 2.457s

[2020-07-21T13:33:00.990Z] cat: can't open '*-output.tap': No such file or directory
```

## Tests

![image](https://user-images.githubusercontent.com/2871786/88066376-96c74a80-cb65-11ea-8ce8-f43fcfb55621.png)
