### PR TITLE
fix: run APM UI e2e tests for master branch only

### DIFF
--- a/.ci/jobs/apm-ui-e2e-tests-mbp.yml
+++ b/.ci/jobs/apm-ui-e2e-tests-mbp.yml
@@ -12,8 +12,11 @@
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
+          discover-branch: ex-pr
           discover-tags: false
-          head-filter-regex: '(master|PR-.*)'
+          head-filter-regex: 'master'
+          filter-by-name-wildcard:
+            includes: 'master'
           repo: kibana
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
## What does this PR do?
It modifies the JJBB definition of the APM UI e2e tests pipeline, with these main changes:

1. **discover-branch**: we set this value to `ex-pr` to exclude all PRs
1. **head-filter-regex**: we changed the regex to filter by the 'master' branch, only
1. **filter-by-name-wildcard**: we configure this property to include the 'master' branch, only

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
The APM UI wants to disable this pipeline from PRs temporarily, only running it for the master branch.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Resolves https://github.com/elastic/observability-robots/issues/210