### PR TITLE
feat: support passing custom build commands from the target project

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -54,6 +54,7 @@ pipeline {
     booleanParam(name: 'helm_kubectl', defaultValue: "false", description: "")
     booleanParam(name: 'opbot', defaultValue: "false", description: "")
     booleanParam(name: 'flakey', defaultValue: "false", description: "Flake detection app")
+    booleanParam(name: 'testPlans', defaultValue: "false", description: "Test Plans app")
     booleanParam(name: 'heartbeat', defaultValue: "false", description: "Heartbeat to monitor Jenkins jobs")
   }
   stages {
@@ -331,6 +332,25 @@ pipeline {
           version: 'latest',
           push: true,
           folder: "apps/automation/jenkins-toolbox")
+      }
+    }
+    stage('Build test-plans'){
+      options {
+        skipDefaultCheckout()
+      }
+      when{
+        beforeAgent true
+        expression { return params.testPlans}
+      }
+      steps {
+        deleteDir()
+        dockerLoginElasticRegistry()
+        buildDockerImage(
+          repo: 'https://github.com/elastic/observability-robots.git',
+          buildCommand: 'make build',
+          pushCommand: 'make push',
+          push: true,
+          folder: "apps/test-plans")
       }
     }
     stage('Build Heartbeat'){


### PR DESCRIPTION
## What does this PR do?
Adds support to provide build commands on the target project, using existing docker build/push commands as defaults

Once the build/push commands is in place, we are adding the build of the image for the test-plans

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Maybe the target project is providing build commands, andd we want to use them
<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->