### PR TITLE
fix: add the mandatory tag argument

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -347,6 +347,7 @@ pipeline {
         dockerLoginElasticRegistry()
         buildDockerImage(
           repo: 'https://github.com/elastic/observability-robots.git',
+          tag: 'test-plans',
           buildCommand: 'make build',
           pushCommand: 'make push',
           push: true,


### PR DESCRIPTION
## What does this PR do?
It adds the `tag` argument to the buildDockerImage method call, as it's mandatory
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Otherwise, the CI build will fail with error, as we are forcing an error if the tag is not present: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-docker-images-pipeline/detail/apm-docker-images-pipeline/470/pipeline

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Closes #685