### PR TITLE
dockerLogin step with less verbose output

### DIFF
--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -46,10 +46,10 @@ def call(Map params = [:]){
         if (isUnix()) {
           sh(label: "Docker login", script: """
             set +x
-            if command -v host; then
+            if command -v host 2>&1 > /dev/null; then
               host ${registry} 2>&1 > /dev/null 
             fi
-            if command -v dig; then
+            if command -v dig 2>&1 > /dev/null; then
               dig ${registry} 2>&1 > /dev/null 
             fi
             docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null


### PR DESCRIPTION
## What does this PR do?

Less verbose output, for instance

```
10:29:57  + set +x
10:29:57  /usr/bin/host
10:29:57  /usr/bin/dig

```
## Why is it important?

It does not provide any value though

## Test

![image](https://user-images.githubusercontent.com/2871786/89025800-59aa4780-d31f-11ea-8217-61008b30caed.png)
