### PR TITLE
chore: add force parameter to the JJBB job for APM specs sync

### DIFF
--- a/.ci/jobs/apm-update-gherkin-pipeline.yml
+++ b/.ci/jobs/apm-update-gherkin-pipeline.yml
@@ -10,6 +10,10 @@
           name: DRY_RUN_MODE
           default: false
           description: "If true, allows to execute this pipeline in dry run mode, without sending a PR."
+      - bool:
+          name: FORCE_SEND_PR
+          default: false
+          description: "If true, will force sending a PR."
     pipeline-scm:
       script-path: .ci/Jenkinsfile
       scm:


### PR DESCRIPTION
## What does this PR do?
It adds a Jenkins parameter to force sending the PRs to synchronise the APM specs (gherkin, json)

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
We need a way to force the sync when something is out-to-date and we do not want to change the files.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Relates https://github.com/elastic/observability-robots/issues/222
- Relates https://github.com/elastic/apm/pull/317