### PR TITLE
Use real email account

### DIFF
--- a/vars/setupAPMGitEmail.groovy
+++ b/vars/setupAPMGitEmail.groovy
@@ -25,6 +25,6 @@ def call(Map params = [:]) {
   def flag = params.containsKey('global') ? (params.global ? '--global' : '') : ''
   sh(label: 'Git config', script: """
     git config ${flag} user.name apmmachine
-    git config ${flag} user.email 58790750+apmmachine@users.noreply.github.com
+    git config ${flag} user.email infra-root+apmmachine@elastic.co
   """)
 }


### PR DESCRIPTION
## What does this PR do?

Use real email account for the apmmachine GH user.

## Why is it important?

Otherwise the git commits won't be linked to the `apmmachine` user.

![image](https://user-images.githubusercontent.com/2871786/90379438-094f1b80-e07b-11ea-8c9b-544e51d5cc5b.png)

https://github.com/elastic/apm-agent-go/pull/801/commits

## Related issues
Closes #ISSUE