### PR TITLE
Fix opbeans-frontend release process

### DIFF
--- a/src/test/groovy/OpbeansPipelineStepTests.groovy
+++ b/src/test/groovy/OpbeansPipelineStepTests.groovy
@@ -94,6 +94,18 @@ class OpbeansPipelineStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_when_tag_release_for_opbeans_frontend() throws Exception {
+    def script = loadScript(scriptName)
+    // When the tag release does match
+    env.BRANCH_NAME = '@elastic/apm-rum@1.0'
+    script.call()
+    printCallStack()
+    // Then publish shell step
+    assertTrue(assertMethodCallContainsPattern('sh', 'VERSION=agent-1.0 make publish'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_getForkedRepoOrElasticRepo() throws Exception {
     def script = loadScript(scriptName)
     env.CHANGE_FORK = 'user/forked_repo'

--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -152,7 +152,7 @@ def call(Map pipelineParams) {
         when {
           anyOf {
             branch 'master'
-            tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
+            tag pattern: '(v\\d+\\.\\d+|@).*', comparator: 'REGEXP'
           }
         }
         environment {
@@ -165,6 +165,12 @@ def call(Map pipelineParams) {
                 deleteDir()
                 unstash 'source'
                 dir(BASE_DIR){
+                  // opbeans-frontend uses a different tag versioning
+                  script {
+                    if (env.VERSION.contains('@')) {
+                      env.VERSION = env.VERSION.replaceAll('.*@', 'agent-')
+                    }
+                  }
                   dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
                   sh "VERSION=${env.VERSION} make publish"
                 }


### PR DESCRIPTION
## What does this PR do?

Support tag releases for the opbeans-frontend

## Why is it important?

Otherwise, docker images are related to latest but no agent based releases.

## Further details

- https://hub.docker.com/r/opbeans/opbeans-frontend
- https://github.com/elastic/opbeans-frontend/tags
