### PR TITLE
fix read only env variable

### DIFF
--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -168,11 +168,13 @@ def call(Map pipelineParams) {
                   // opbeans-frontend uses a different tag versioning
                   script {
                     if (env.VERSION.contains('@')) {
-                      env.VERSION = env.VERSION.replaceAll('.*@', 'agent-')
+                      env.TAG = env.VERSION.replaceAll('.*@', 'agent-')
+                    } else {
+                      env.TAG = env.VERSION
                     }
                   }
                   dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-                  sh "VERSION=${env.VERSION} make publish"
+                  sh "VERSION=${env.TAG} make publish"
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do?

Initial approach did not work since env variables can be assigned only once

## Why is it important?

Support opbeans-frontend releases for tags.

See https://hub.docker.com/layers/opbeans/opbeans-frontend/agent-5.4.0/images/sha256-79d71f681bf45a9beeabbbdadebb1ea65ef6138199bc832a10bc5a3b01b243bf?context=explore