### PR TITLE
[CI] git commit with correct user.email

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,6 +25,8 @@ pipeline {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'DEBUG'
     MAVEN_CONFIG = "${params.MAVEN_CONFIG}"
+    LANG = "C.UTF-8"
+    LC_ALL = "C.UTF-8"
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

For some reason the user.email gets changed from + to -

```
commit 989f3c8e66bd5bc72d3b292ba9e4d300bb592774 (upstream/master, master)
Author: apmmachine <infra-root-apmmachine@elastic.co>
Date:   Tue Aug 18 10:00:23 2020 +0000

    docs: update CHANGELOG.md
```

![image](https://user-images.githubusercontent.com/2871786/90529969-9de97480-e174-11ea-861e-d29c345f3157.png)


## Why is it important?

Let's see if the git commit somehow requires the LANG env variables that are not available by default in the workers.

## Related issues
Closes #ISSUE