### PR TITLE
[test-infra] run docker if docker-machine installed

### DIFF
--- a/resources/scripts/jenkins/apm-ci/test-mac.sh
+++ b/resources/scripts/jenkins/apm-ci/test-mac.sh
@@ -23,15 +23,19 @@ virtualenv venv
 source venv/bin/activate
 pip install testinfra
 
-## Prepare the docker for mac
-docker-machine start default || true
-eval "$(docker-machine env default)"
-set -x
+## Prepare the docker for mac if docker-machine is installed
+if command -v docker-machine ; then
+  docker-machine start default || true
+  eval "$(docker-machine env default)"
+  docker_py_test=test-infra/apm-ci/test_installed_tools_docker.py
+else
+  docker_py_test=""
+fi
 
 ## Run test-infra and trap error to notify when required
+set -x
 { py.test -v \
-    test-infra/apm-ci/test_installed_tools.py \
-    test-infra/apm-ci/test_installed_tools_docker.py \
+    test-infra/apm-ci/test_installed_tools.py "${docker_py_test}" \
     --junit-xml=target/junit-test-infra.xml; \
   err="$?"; } || true
 


### PR DESCRIPTION
## What does this PR do?

Add more dynamic evaluation if a particular test suite should be running for macosx

## Why is it important?

Fix the false positives regarding docker for mac

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/702
