### PR TITLE
isMemberOf step to query GitHub user/teams

### DIFF
--- a/src/test/groovy/isMemberOfStepTests.groovy
+++ b/src/test/groovy/isMemberOfStepTests.groovy
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import hudson.model.Cause
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsMemberOfStepTests extends ApmBasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isMemberOf.groovy')
+  }
+
+  @Test
+  void test_without_user_parameter() throws Exception {
+    try {
+      script.call()
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'user param is required'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_without_team_parameter() throws Exception {
+    try {
+      script.call(user: 'foo')
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'team param is required'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_active_membership() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{ "message": {"state":"active","role":"maintainer","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"} }') })
+    def ret = script.call(user: 'foo', team: 'apm-ui')
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_pending_membership() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{ "message": {"state":"pending","role":"member","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"} }') })
+    def ret = script.call(user: 'foo', team: 'apm-ui')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_no_membership() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], {
+      return net.sf.json.JSONSerializer.toJSON( """{
+        "Code": "404",
+        "message": "Not Found",
+        "documentation_url": "https://developer.github.com/v3"
+      }""")
+    })
+    def ret = script.call(user: 'foo', team: 'bar')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_no_membership_with_error() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], {
+      throw new Exception('Forced a failure')
+    })
+    def ret = script.call(user: 'foo', team: 'bar')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1071,6 +1071,25 @@ Whether the given tools is installed and available.
 * tool: The name of the tool to check whether it is installed and available. Mandatory.
 * flag: The flag to be added to the validation. For instance `--version`. Optional.
 
+## isMemberOf
+Check if the given GitHub user is member of the given GitHub team.
+
+```
+whenTrue(isMemberOf(user: 'my-user', team: 'my-team')) {
+    //...
+}
+
+// using another organisation
+whenTrue(isMemberOf(user: 'my-user', team: 'my-team', org: 'acme')) {
+    //...
+}
+
+```
+
+* user: the GitHub user. Mandatory
+* team: the GitHub teamd. Mandatory
+* org: the GitHub organisation. Optional. Default: 'elastic'
+
 ## isPR
 Whether the build is based on a Pull Request or no
 

--- a/vars/isMemberOf.groovy
+++ b/vars/isMemberOf.groovy
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import com.cloudbees.groovy.cps.NonCPS
+/**
+  Check if the given GitHub user is member of the given GitHub team.
+
+  whenTrue(isMemberOf(user: 'my-user', team: 'my-team'))
+
+  NOTE: https://developer.github.com/v3/teams/members/#get-team-membership-for-a-user
+*/
+
+def call(Map args = [:]) {
+  def user = args.containsKey('user') ? args.user : error('isMemberOf: user param is required')
+  def team = args.containsKey('team') ? args.team : error('isMemberOf: team param is required')
+  def org = args.containsKey('org') ? args.org : 'elastic'
+
+  try {
+    def token = getGithubToken()
+    def url = "https://api.github.com/orgs/${org}/teams/${team}/memberships/${user}"
+    def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true, url: url)
+    return membershipResponse.message?.state?.equals('active')
+  } catch(err) {
+    return false
+  }
+  return false
+}

--- a/vars/isMemberOf.txt
+++ b/vars/isMemberOf.txt
@@ -1,0 +1,17 @@
+Check if the given GitHub user is member of the given GitHub team.
+
+```
+whenTrue(isMemberOf(user: 'my-user', team: 'my-team')) {
+    //...
+}
+
+// using another organisation
+whenTrue(isMemberOf(user: 'my-user', team: 'my-team', org: 'acme')) {
+    //...
+}
+
+```
+
+* user: the GitHub user. Mandatory
+* team: the GitHub teamd. Mandatory
+* org: the GitHub organisation. Optional. Default: 'elastic'


### PR DESCRIPTION
## What does this PR do?

Add step to search for GitHub memberships for a given user and team.

## Why is it important?

Filter PRs for the APM-UI e2e if their owners are members of the given GH teams

## How to use it

https://github.com/elastic/kibana/pull/76764