### PR TITLE
New stage for apm-proxy

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -56,6 +56,7 @@ pipeline {
     booleanParam(name: 'flakey', defaultValue: "false", description: "Flake detection app")
     booleanParam(name: 'testPlans', defaultValue: "false", description: "Test Plans app")
     booleanParam(name: 'heartbeat', defaultValue: "false", description: "Heartbeat to monitor Jenkins jobs")
+    booleanParam(name: 'apm_proxy', defaultValue: "false", description: "APM proxy [https://github.com/elastic/observability-dev/tree/master/tools/apm-proxy]")
   }
   stages {
     stage('Cache Weblogic Docker Image'){
@@ -332,6 +333,27 @@ pipeline {
           version: 'latest',
           push: true,
           folder: "apps/automation/jenkins-toolbox")
+      }
+    }
+    stage('Build APM Proxy'){
+      options {
+        skipDefaultCheckout()
+      }
+      when{
+        beforeAgent true
+        expression { return params.apm_proxy}
+      }
+      steps{
+        deleteDir()
+        dockerLoginElasticRegistry()
+        buildDockerImage(
+          repo: 'https://github.com/elastic/observability-dev',
+          prepareWith: {git credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/haproxytech/spoa-mirror.git"},
+          tag: "apm-proxy",
+          version: "latest",
+          folder: "tools/apm_proxy",
+          push: true
+        )
       }
     }
     stage('Build test-plans'){


### PR DESCRIPTION
## What does this PR do?

Add new stage for APM proxy project: https://github.com/elastic/observability-dev/pull/1078

## Why is it important?
We need a pipeline that can build the container and push it into the Elastic docker repo on demand in order to proceed with getting things deployed over in Elastic Apps.

## Related issues
Refs: https://github.com/elastic/observability-robots/issues/220