### PR TITLE
Revert "fix: run APM UI e2e tests for master branch only (#682)"

### DIFF
--- a/.ci/jobs/apm-ui-e2e-tests-mbp.yml
+++ b/.ci/jobs/apm-ui-e2e-tests-mbp.yml
@@ -12,11 +12,8 @@
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
-          discover-branch: ex-pr
           discover-tags: false
-          head-filter-regex: 'master'
-          filter-by-name-wildcard:
-            includes: 'master'
+          head-filter-regex: '(master|PR-.*)'
           repo: kibana
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
This reverts commit d963a7512da4c6982da418cfcdff49798c82e1c3.


## What does this PR do?

To support filtering those owners that are members of the apm-ui team

## Why is it important?

Let's put back the pipeline for PRs

## Related issues

Requires https://github.com/elastic/kibana/pull/76764