### PR TITLE
Move to fe/be config for apm-proxy

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -352,7 +352,14 @@ pipeline {
           prepareWith: {dir("spoa-mirror"){git credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/haproxytech/spoa-mirror.git"}},
           tag: "apm-proxy",
           version: "latest",
-          folder: "tools/apm_proxy",
+          folder: "tools/apm_proxy/frontend",
+          push: true
+        )
+        buildDockerImage(
+          repo: 'https://github.com/elastic/observability-dev',
+          tag: "apm-proxy-be",
+          version: "latest",
+          folder: "tools/apm_proxy/backend",
           push: true
         )
       }


### PR DESCRIPTION
## What does this PR do?

Changes the pipeline to correspond with changes here: https://github.com/elastic/observability-dev/pull/1102

## Why is it important?

The pipeline now needs to use an updated path as well as build a second container for the repo.

## Related issues
Closes #ISSUE
