### PR TITLE
Support setEvnVar with booleans

### DIFF
--- a/src/test/groovy/SetEnvVarStepTests.groovy
+++ b/src/test/groovy/SetEnvVarStepTests.groovy
@@ -36,4 +36,13 @@ class SetEnvVarStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_boolean() throws Exception {
+    def script = loadScript(scriptName)
+    script.call('MY_VAR', true)
+    assertTrue(env['MY_VAR'] == 'true')
+    printCallStack()
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1551,10 +1551,14 @@ def body = sendDataToElasticsearch(es: "https://ecs.example.com:9200",
 
 ## setEnvVar
 
-It sets an environment var with a value passed as a parameter, it simplifies Declarative syntax
+It sets an environment variable with either a string or boolean value as a parameter, it simplifies the declarative syntax.
 
 ```
+  // Support string value
   setEnvVar('MY_ENV_VAR', 'value')
+
+  // Support boolean value
+  setEnvVar('MY_ENV_VAR', true)
 ```
 
   it replaces the following code

--- a/vars/setEnvVar.groovy
+++ b/vars/setEnvVar.groovy
@@ -30,3 +30,7 @@ It sets an environment var with a value passed as a parameter, it simplifies Dec
 def call(String name, String value){
   env[name] = value
 }
+
+def call(String name, Boolean value){
+  env[name] = Boolean.toString(value)
+}

--- a/vars/setEnvVar.txt
+++ b/vars/setEnvVar.txt
@@ -1,8 +1,12 @@
 
-It sets an environment var with a value passed as a parameter, it simplifies Declarative syntax
+It sets an environment variable with either a string or boolean value as a parameter, it simplifies the declarative syntax.
 
 ```
+  // Support string value
   setEnvVar('MY_ENV_VAR', 'value')
+
+  // Support boolean value
+  setEnvVar('MY_ENV_VAR', true)
 ```
 
   it replaces the following code


### PR DESCRIPTION
## What does this PR do?

Support boolean value

## Why is it important?

To fix issues such as

```
No signature of method: setEnvVar.call() is applicable for argument types: (java.lang.String, java.lang.Boolean) values: [RUN_APM_E2E, false]
```

## Tests
```
pipeline {
  agent any
  stages {
      stage('debug disabled') {
        steps { 
            setEnvVar('MY_ENV_VAR', 'something')
            setEnvVar('MY_ENV_VAR1', true)
            log(level: 'INFO', text: "${MY_ENV_VAR}")
            log(level: 'INFO', text: "${MY_ENV_VAR1}")   
        }
     }
  }
}
```

![image](https://user-images.githubusercontent.com/2871786/93077704-1ca4d500-f681-11ea-8ff7-d11d33191e5c.png)
