### PR TITLE
Fix isMemberOf data structure

### DIFF
--- a/src/test/groovy/isMemberOfStepTests.groovy
+++ b/src/test/groovy/isMemberOfStepTests.groovy
@@ -58,7 +58,7 @@ class IsMemberOfStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_active_membership() throws Exception {
-    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{ "message": {"state":"active","role":"maintainer","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"} }') })
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{"state":"active","role":"maintainer","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"}') })
     def ret = script.call(user: 'foo', team: 'apm-ui')
     printCallStack()
     assertTrue(ret)
@@ -67,7 +67,7 @@ class IsMemberOfStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_pending_membership() throws Exception {
-    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{ "message": {"state":"pending","role":"member","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"} }') })
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{"state":"pending","role":"member","url":"https://api.github.com/organizations/6764390/team/2448411/memberships/foo"}') })
     def ret = script.call(user: 'foo', team: 'apm-ui')
     printCallStack()
     assertFalse(ret)

--- a/vars/isMemberOf.groovy
+++ b/vars/isMemberOf.groovy
@@ -33,7 +33,11 @@ def call(Map args = [:]) {
     def token = getGithubToken()
     def url = "https://api.github.com/orgs/${org}/teams/${team}/memberships/${user}"
     def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true, url: url)
-    return membershipResponse.message?.state?.equals('active')
+    if (membershipResponse?.state) {
+      return membershipResponse?.state?.equals('active')
+    } else {
+      return false
+    }
   } catch(err) {
     return false
   }


### PR DESCRIPTION
## What does this PR do?


Use the data structure as expected, message is only when there was an error in the API call

## Why is it important?

Otherwise the step won't work

## Tests

```
pipeline {
  agent any
  environment {
    PIPELINE_LOG_LEVEL = 'DEBUG'
  }
  stages {
    stage('log with info') {
      steps {
          script {
              def apm_updated = true
            def isMember = isMemberOf(user: 'sqren', team: 'apm-ui')  
            setEnvVar('RUN_APM_E2E', (apm_updated && isMember))
            echo "${env.RUN_APM_E2E}"
          }
      }
    }
  }
}
```
![image](https://user-images.githubusercontent.com/2871786/93086759-80ce9580-f68f-11ea-94cc-3ac940aec092.png)
