### PR TITLE
Allow withGoEnv to accept an OS override arg

### DIFF
--- a/src/test/groovy/WithGoEnvStepTests.groovy
+++ b/src/test/groovy/WithGoEnvStepTests.groovy
@@ -87,6 +87,24 @@ class WithGoEnvStepTests extends ApmBasePipelineTest {
     assertJobStatusSuccess()
   }
 
+@Test
+void testOSArg() throws Exception {
+  def script = loadScript(scriptName)
+  env.GO_VERSION = "1.12.2"
+  def isOK = false
+
+  script.call(os: 'custom-os'){
+    if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.custom-os.amd64/bin:/foo/bin"
+      && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.custom-os.amd64"
+      && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+  }
+  printCallStack()
+  assertTrue(isOK)
+  assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+  assertJobStatusSuccess()
+}
 
   @Test
   void testPkgs() throws Exception {

--- a/vars/withGoEnv.groovy
+++ b/vars/withGoEnv.groovy
@@ -37,7 +37,7 @@ def call(Map args = [:], Closure body) {
   def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
   def version = args.containsKey('version') ? args.version : goDefaultVersion
   def pkgs = args.containsKey('pkgs') ? args.pkgs : []
-  def os = nodeOS()
+  def os = args.containsKey('os') ? args.os : nodeOS()
   def lastCoordinate = version[-2..-1]
   // gvm remove the last coordinate if it is 0
   def goDir = ".gvm/versions/go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.amd64"

--- a/vars/withGoEnv.txt
+++ b/vars/withGoEnv.txt
@@ -19,3 +19,4 @@
 
 * version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
 * pkgs: Go packages to install with Go get before to execute any command.
+* os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.


### PR DESCRIPTION
## What does this PR do?
This covers an edge case where auto-detection for a worker's operating system might not be correct on bare-metal workers. Instead of relying on it, we allow a user of `withGoEnv` to simply specify the OS they wish to use.
## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

