### PR TITLE
Remove folder jobdsl reference

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -106,7 +106,6 @@ jobs:
   - file: "/var/pipeline-library/src/test/resources/folders/beats.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/getBuildInfoJsonFiles.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
-  - file: "/var/pipeline-library/src/test/resources/folders/timeout.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/beats/beatsStages.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/beats/beatsWhen.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/cancelPreviousRunningBuilds.dsl"


### PR DESCRIPTION
## What does this PR do?

Remove reference since it was deleted but was not removed from the JCasC

## Why is it important?

Otherwise the JCasC won't work

## Issues

Caused by https://github.com/elastic/apm-pipeline-library/pull/708 (merge commit was not solved correctly manually)
