### PR TITLE
runbld wrappers

### DIFF
--- a/src/test/groovy/JunitAndStoreStepTests.groovy
+++ b/src/test/groovy/JunitAndStoreStepTests.groovy
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class JunitAndStoreStepTests extends ApmBasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/junitAndStore.groovy')
+  }
+
+  @Test
+  void test_no_stashedTestReports_parameter() throws Exception {
+    try {
+      script.call()
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'stashedTestReports param'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_no_testResults() throws Exception {
+    try {
+      script.call(stashedTestReports: [:])
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'testResults param'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_without_id() throws Exception {
+    script.call(stashedTestReports: [:], testResults: '*.xml')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('junit', 'testResults=*.xml'))
+    assertTrue(assertMethodCallContainsPattern('stash', 'includes=*.xml, allowEmpty=true, name=uncategorized-'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_id() throws Exception {
+    script.call(stashedTestReports: [:], testResults: '*.xml', id: 'acme')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('junit', 'testResults=*.xml'))
+    assertTrue(assertMethodCallContainsPattern('stash', 'includes=*.xml, allowEmpty=true, name=acme-'))
+    assertJobStatusSuccess()
+  }
+}

--- a/src/test/groovy/RunbldStepTests.groovy
+++ b/src/test/groovy/RunbldStepTests.groovy
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class RunbldStepTests extends ApmBasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/runbld.groovy')
+    env.BASE_DIR = 'src'
+    helper.registerAllowedMethod('isPR', [], { true })
+  }
+
+  @Test
+  void test_no_project() throws Exception {
+    try {
+      script.call()
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'project param'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_no_stashedTestReports_parameter() throws Exception {
+    try {
+      script.call(project: 'acme')
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'stashedTestReports param'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_with_empty_stashed_reports() throws Exception {
+    script.call(stashedTestReports: [:], project: 'acme')
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', '--job-name'))
+    assertTrue(assertMethodCallContainsPattern('log', 'stashedTestReports is empty'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_pr() throws Exception {
+    script.call(stashedTestReports: ['foo': 'bar'], project: 'acme')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', '--job-name elastic+acme+pull-request'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_branch() throws Exception {
+    helper.registerAllowedMethod('isPR', [], { false })
+    script.call(stashedTestReports: ['foo': 'bar'], project: 'acme')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', '--job-name elastic+acme'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_windows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { false })
+    try {
+      script.call()
+    } catch(e){
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'runbld: windows is not supported yet'))
+    assertJobStatusFailure()
+  }
+}

--- a/src/test/resources/jobs/runbld.dsl
+++ b/src/test/resources/jobs/runbld.dsl
@@ -1,0 +1,37 @@
+NAME = 'it/log'
+DSL = '''
+import groovy.transform.Field
+@Field def stashedTestReports = [:]
+pipeline {
+  agent any
+  environment {
+      BASE_DIR = 'src'
+  }
+  stages {
+    stage('test-1') {
+      steps {
+        writeFile file: 'junit-1.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo" name="bar"><error message="error"/><system-out><![CDATA[hookid: foo]]></system-out></testcase></testsuite>'
+        junitAndStore(stashedTestReports: stashedTestReports, id: 'test-1', testResults: 'junit-1.xml')
+      }
+    }
+    stage('test-2') {
+      steps {
+        writeFile file: 'junit-2.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo" name="bar"><error message="error"/><system-out><![CDATA[hookid: foo]]></system-out></testcase></testsuite>'
+        junitAndStore(stashedTestReports: stashedTestReports, testResults: 'junit-2.xml')
+      }
+    }
+  }
+  post {
+    always {
+      runbld(stashedTestReports: stashedTestReports, project: 'acme')
+    }
+  }
+}'''
+
+pipelineJob(NAME) {
+  definition {
+    cps {
+      script(DSL.stripIndent())
+    }
+  }
+}

--- a/src/test/resources/jobs/runbld.dsl
+++ b/src/test/resources/jobs/runbld.dsl
@@ -1,4 +1,4 @@
-NAME = 'it/log'
+NAME = 'it/runbld'
 DSL = '''
 import groovy.transform.Field
 @Field def stashedTestReports = [:]
@@ -10,13 +10,13 @@ pipeline {
   stages {
     stage('test-1') {
       steps {
-        writeFile file: 'junit-1.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo" name="bar"><error message="error"/><system-out><![CDATA[hookid: foo]]></system-out></testcase></testsuite>'
+        writeFile file: 'junit-1.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo-1" name="bar-1"><error message="error"/><system-out><![CDATA[hookid: foo-1]]></system-out></testcase></testsuite>'
         junitAndStore(stashedTestReports: stashedTestReports, id: 'test-1', testResults: 'junit-1.xml')
       }
     }
     stage('test-2') {
       steps {
-        writeFile file: 'junit-2.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo" name="bar"><error message="error"/><system-out><![CDATA[hookid: foo]]></system-out></testcase></testsuite>'
+        writeFile file: 'junit-2.xml', text: '<?xml version="1.0" encoding="UTF-8"?><testsuite><testcase classname="foo-2" name="bar-2"><error message="error"/><system-out><![CDATA[hookid: foo-2]]></system-out></testcase></testsuite>'
         junitAndStore(stashedTestReports: stashedTestReports, testResults: 'junit-2.xml')
       }
     }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1199,6 +1199,40 @@ Whether the architecture is a x86 based using the `nodeArch` step
     }
 ```
 
+## junitAndStore
+Wrap the junit built-in step to archive the test reports that are going to be
+populated later on with the runbld post build step.
+
+```
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports, id: 'test-stage-foo', ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+```
+
+* *stashedTestReports*: list of stashed reports that was used by junitAndStore. Mandatory
+* *id*: the unique id, normally the stage name. Optional
+* *testResults*: from the `junit` step. Mandatory
+* *allowEmptyResults*: from the `junit` step. Optional
+* *keepLongStdio*: from the `junit` step. Optional
+
+
+**NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments
+
 ## licenseScan
 Scan the repository for third-party dependencies and report the results.
 
@@ -1543,6 +1577,38 @@ rubygemsLogin.withApi(secret: 'secret/team/ci/secret-name') {
 ```
 
 * secret: Vault secret where the user, password or apiKey are stored.
+
+## runbld
+Populate the test output using the runbld approach. It depends on the *junitAndStore* step.
+
+```
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports)
+                    }
+                }
+            }
+        }
+        post {
+            always {
+                // Process stashed test reports
+                runbld(stashedTestReports: stashedTestReports, project: env.REPO)
+            }
+        }
+    }
+```
+
+* *project*: the project id, normally the repo name. Mandatory
+* *stashedTestReports*: list of stashed reports that was used by junitAndStore. Mandatory
 
 ## sendBenchmarks
 Send the benchmarks to the cloud service or run the script and prepare the environment

--- a/vars/junitAndStore.groovy
+++ b/vars/junitAndStore.groovy
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Wrap the junit built-in step to archive the test reports that are going to be
+populated later on with the runbld post build step.
+
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports, id: 'test-stage-foo', ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+*/
+def call(Map args = [:]) {
+  def stashedTestReports = args.containsKey('stashedTestReports') ? args.stashedTestReports : error('junitAndStore: stashedTestReports param is required')
+  def testResults = args.containsKey('testResults') ? args.testResults : error('junitAndStore: testResults param is required')
+  junit(args)
+  // args.id could be null in some cases, so let's use the currentmilliseconds
+  def suffix = new java.util.Date().getTime()
+  def stageName = args.id ? "${args.id?.replaceAll('[\\W]|_', '-')}-${suffix}" : "uncategorized-${suffix}"
+  stash(includes: testResults, allowEmpty: true, name: stageName, useDefaultExcludes: true)
+  stashedTestReports[stageName] = stageName
+}

--- a/vars/junitAndStore.txt
+++ b/vars/junitAndStore.txt
@@ -1,0 +1,32 @@
+Wrap the junit built-in step to archive the test reports that are going to be
+populated later on with the runbld post build step.
+
+```
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports, id: 'test-stage-foo', ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+```
+
+* *stashedTestReports*: list of stashed reports that was used by junitAndStore. Mandatory
+* *id*: the unique id, normally the stage name. Optional
+* *testResults*: from the `junit` step. Mandatory
+* *allowEmptyResults*: from the `junit` step. Optional
+* *keepLongStdio*: from the `junit` step. Optional
+
+
+**NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments

--- a/vars/runbld.groovy
+++ b/vars/runbld.groovy
@@ -43,12 +43,12 @@
     }
 */
 def call(Map args = [:]) {
-  def project = args.containsKey('project') ? args.project : error('runbld: project param is required')
-  def stashedTestReports = args.containsKey('stashedTestReports') ? args.stashedTestReports : error('runbld: stashedTestReports param is required')
-
   if(!isUnix()){
     error('runbld: windows is not supported yet.')
   }
+  def project = args.containsKey('project') ? args.project : error('runbld: project param is required')
+  def stashedTestReports = args.containsKey('stashedTestReports') ? args.stashedTestReports : error('runbld: stashedTestReports param is required')
+
   catchError(buildResult: 'SUCCESS', message: 'runbld post build action failed.') {
     if (stashedTestReports) {
       def jobName = isPR() ? "elastic+${project}+pull-request" : "elastic+${project}"

--- a/vars/runbld.groovy
+++ b/vars/runbld.groovy
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ Populate the test output using the runbld approach.
+
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports)
+                    }
+                }
+            }
+        }
+        post {
+            always {
+                // Process stashed test reports
+                runbld(stashedTestReports: stashedTestReports, project: env.REPO)
+            }
+        }
+    }
+*/
+def call(Map args = [:]) {
+  def project = args.containsKey('project') ? args.project : error('runbld: project param is required')
+  def stashedTestReports = args.containsKey('stashedTestReports') ? args.stashedTestReports : error('runbld: stashedTestReports param is required')
+
+  if(!isUnix()){
+    error('runbld: windows is not supported yet.')
+  }
+  catchError(buildResult: 'SUCCESS', message: 'runbld post build action failed.') {
+    if (stashedTestReports) {
+      def jobName = isPR() ? "elastic+${project}+pull-request" : "elastic+${project}"
+      dir("${env.BASE_DIR}") {
+        stashedTestReports.each { k, v ->
+          dir(k) {
+            unstash(v)
+          }
+        }
+      }
+      sh(label: 'Process JUnit reports with runbld',
+        script: """\
+        cat >./runbld-test-reports <<EOF
+        echo "Processing JUnit reports with runbld..."
+        EOF
+        /usr/local/bin/runbld ./runbld-test-reports --job-name ${jobName}
+        """.stripIndent())  // stripIdent() requires '''/
+    } else {
+      log(level: 'WARN', text: 'runbld: stashedTestReports is empty.')
+    }
+  }
+}

--- a/vars/runbld.txt
+++ b/vars/runbld.txt
@@ -1,0 +1,30 @@
+Populate the test output using the runbld approach. It depends on the *junitAndStore* step.
+
+```
+    // This is required to store the stashed id with the test results to be digested with runbld
+    import groovy.transform.Field
+    @Field def stashedTestReports = [:]
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit with stashed reports
+                        junitAndStore(stashedTestReports: stashedTestReports)
+                    }
+                }
+            }
+        }
+        post {
+            always {
+                // Process stashed test reports
+                runbld(stashedTestReports: stashedTestReports, project: env.REPO)
+            }
+        }
+    }
+```
+
+* *project*: the project id, normally the repo name. Mandatory
+* *stashedTestReports*: list of stashed reports that was used by junitAndStore. Mandatory


### PR DESCRIPTION
## What does this PR do?

Add functions that were created in the beats repo to support the `runbld` reporting that exposes the JUnit reporting in `Elasticsearch`.

## Why is it important?

Refactor the beats pipeline to keep it simple

## Tasks

- [x] UTs
- [x] ITs

## Related issues

Caused by https://github.com/elastic/beats/pull/18037

## Tests

### ITs

![image](https://user-images.githubusercontent.com/2871786/94032333-c4c04980-fdb7-11ea-81d8-cab70c298e17.png)

runbld binary is not available in the local workers

### Production tests

- [build](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-21256/3/)

![image](https://user-images.githubusercontent.com/2871786/94136290-a3656900-fe5c-11ea-93ef-8ac6141776d7.png)

![image](https://user-images.githubusercontent.com/2871786/94135855-f2f76500-fe5b-11ea-82ac-12a289df47ee.png)

![image](https://user-images.githubusercontent.com/2871786/94136220-829d1380-fe5c-11ea-8937-ae9cb5ee6a2d.png)

