### PR TITLE
Support skip-ci-build label for beatsWhen

### DIFF
--- a/src/test/groovy/BeatsWhenStepTests.groovy
+++ b/src/test/groovy/BeatsWhenStepTests.groovy
@@ -334,4 +334,39 @@ class BeatsWhenStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(ret)
   }
+
+  @Test
+  void test_isSkipCiBuildLabel_without_content() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('matchesPrLabel', [Map.class], { false })
+    def ret = script.isSkipCiBuildLabel(content: [:])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_isSkipCiBuildLabel_with_label_enabled_and_pr_without_label_match() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('matchesPrLabel', [Map.class], { false })
+    def ret = script.isSkipCiBuildLabel(content: [ 'skip-ci-build-label': true ])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_isSkipCiBuildLabel_with_label_enabled_and_pr_with_label_match() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('matchesPrLabel', [Map.class], { true })
+    def ret = script.isSkipCiBuildLabel(content: [ 'skip-ci-build-label': true ])
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_isSkipCiBuildLabel_with_label_disabled() throws Exception {
+    def script = loadScript(scriptName)
+    def ret = script.isSkipCiBuildLabel(content: [ 'skip-ci-build-label': false ])
+    printCallStack()
+    assertFalse(ret)
+  }
 }

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -26,7 +26,7 @@ Boolean call(Map args = [:]){
   def ret = false
 
   markdownReason(project: project, reason: "## Build reasons for `${project} ${description}`")
-  if (whenEnabled(args)) {
+  if (whenEnabled(args) || !isSkipCiBuildLabel(args)) {
     markdownReason(project: project, reason: "<details><summary>Expand to view the reasons</summary><p>\n")
     if (whenBranches(args)) { ret = true }
     if (whenChangeset(args)) { ret = true }
@@ -164,6 +164,20 @@ private Boolean whenTags(Map args = [:]) {
     return true
   }
   markdownReason(project: args.project, reason: '* ❕Tag is `disabled`.')
+  return false
+}
+
+private boolean isSkipCiBuildLabel(Map args = [:]) {
+  def gitHubLabel = 'skip-ci-build'
+  if (args.content?.get('skip-ci-build-label', false)) {
+    if (matchesPrLabel(label: gitHubLabel) ) {
+      markdownReason(project: args.project, reason: "* ✅ skip-ci-build-label is `enabled` and matches with the pattern `${gitHubLabel}`.")
+      return true
+    }
+    markdownReason(project: args.project, reason: "* skip-ci-build-label is `enabled` and does **NOT** match with the pattern `${gitHubLabel}`.")
+  } else {
+    markdownReason(project: args.project, reason: '* ❕skip-ci-build-label label is `disabled`.')
+  }
   return false
 }
 


### PR DESCRIPTION
## What does this PR do?

Support the scenario:

```
As a contributor I want my PR to be skipped in the CI when I configured it with a github label.
```

## Important

Talking more precisely for `Beats` this change won't affect the `Lint` stage since it runs always before the `mono-repo` stage dynamic generation that happens when using `beatsWhen` and `beatsStages`

## Why is it important?

Provide fine granularity to configure the builds based on the user expectations too

## Related issues
Caused by https://github.com/elastic/beats/pull/20104