### PR TITLE
reduce build reasons i/o accesses with global variables

### DIFF
--- a/src/test/resources/jobs/beats/beatsWhen.dsl
+++ b/src/test/resources/jobs/beats/beatsWhen.dsl
@@ -63,6 +63,9 @@ when:
       environment { TAG_NAME = 'foo' }
       steps { verify('tags.yaml') }
     }
+    stage('markdown') {
+      steps { archiveArtifacts(allowEmptyArchive: false, artifacts: 'build-reasons/*.*') }
+    }
   }
 }
 

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -15,6 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import groovy.transform.Field
+
+
+@Field def buildReasons = []
+
 /**
 * Given the YAML definition and the changeset global macros
 * then it verifies if the project or stage should be enabled.
@@ -37,7 +42,7 @@ Boolean call(Map args = [:]){
     markdownReason(project: project, reason: "</p></details>")
   }
   markdownReason(project: project, reason: "#### Stages for `${project} ${description}` have been ${ret ? '✅ enabled' : '❕disabled'}\n")
-
+  flushBuildReason()
   return ret
 }
 
@@ -168,13 +173,17 @@ private Boolean whenTags(Map args = [:]) {
 }
 
 private void markdownReason(Map args = [:]) {
+  buildReasons << args.reason
+}
+
+private void flushBuildReason() {
   dir('build-reasons') {
     def fileName = 'build.md'
     def data = ''
     if(fileExists(fileName)) {
       data = readFile(file: "${fileName}")
     }
-    def content = "${data}\r\n${args.reason}"
+    def content = "${data}\r\n${buildReasons.join('\n')}"
     writeFile(file: fileName, text: "${content}")
   }
 }


### PR DESCRIPTION
## What does this PR do?

Use [global variables](https://www.jenkins.io/doc/book/pipeline/shared-libraries/#defining-global-variables) to reduce the read/write accesses to the build reasons.

## Why is it important?

Faster builds approx 10x less i/o accesses

## ITs

From 149 accesses to the `build.md` file (`99` i/o calls + `50` fileExists calls) in the ITs

![image](https://user-images.githubusercontent.com/2871786/94452263-4264ca80-01a7-11eb-9b82-1e64ef626410.png)

To 14 accesses to the `build.md` file (`9` i/o calls + `5` fileExists calls) in the ITs 

![image](https://user-images.githubusercontent.com/2871786/94450525-4c85c980-01a5-11eb-862e-f430067e394c.png)

Generates the same markdown file


![image](https://user-images.githubusercontent.com/2871786/94450306-0466a700-01a5-11eb-9546-e2027e2aed69.png)
