### PR TITLE
Fix docker-compose and JCasC

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -103,9 +103,9 @@ unclassified:
     globalConfigName: username
     globalConfigEmail: username@example.com
 jobs:
+  - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/beats.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/getBuildInfoJsonFiles.dsl"
-  - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/beats/beatsStages.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/beats/beatsWhen.dsl"
   - file: "/var/pipeline-library/src/test/resources/jobs/cancelPreviousRunningBuilds.dsl"

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -32,10 +32,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.50'
+          cpus: 0.50
           memory: 250M
         reservations:
-          cpus: '0.25'
+          cpus: 0.25
           memory: 100M
     networks:
       apm-pipeline-library:


### PR DESCRIPTION
## What does this PR do?

Folder definition in JCasC should run firstly.
Docker compose reports an error:
```
services.jenkins.deploy.resources.reservations.cpus contains an invalid type, it should be a number
```

## Why is it important?

Otherwise, make -C local <command> won't work


```
$ make -C local stop 
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.jenkins.deploy.resources.reservations.cpus contains an invalid type, it should be a number
make: *** [stop] Error 1
```
