### PR TITLE
Fix beatsWhen on PR basis

### DIFF
--- a/src/test/groovy/BeatsWhenStepTests.groovy
+++ b/src/test/groovy/BeatsWhenStepTests.groovy
@@ -93,6 +93,16 @@ class BeatsWhenStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_whenBranches_and_environment_variable_with_data_and_prs() throws Exception {
+    def script = loadScript(scriptName)
+    env.BRANCH_NAME = 'branch'
+    env.CHANGE_ID = 'PR-1'
+    def ret = script.whenBranches(content: [ branches: true])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
   void test_whenChangeset_and_no_data() throws Exception {
     def script = loadScript(scriptName)
     def ret = script.whenChangeset()

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -47,7 +47,7 @@ Boolean call(Map args = [:]){
 }
 
 private Boolean whenBranches(Map args = [:]) {
-  if (env.BRANCH_NAME?.trim() && args.content?.get('branches')) {
+  if (!isPR() && env.BRANCH_NAME?.trim() && args.content?.get('branches')) {
     markdownReason(project: args.project, reason: '* ✅ Branch is enabled .')
     return true
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug

## Why

PRs in beats-ci are building in all the platforms


## Further details


```
BRANCH_NAME
For a multibranch project, this will be set to the name of the branch being built, for example in case you wish to deploy to production from master but not from feature branches; if corresponding to some kind of change request, the name is generally arbitrary (refer to CHANGE_ID and CHANGE_TARGET).
```