### PR TITLE
Fix 500 http errors in BO

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -80,10 +80,7 @@ function sedCommand() {
 }
 
 function curlCommand() {
-    ## Avoid 500 server side errors
-    if [ "$(curl -LI "$2" -o /dev/null -w '%{http_code}\n' -s)" != "500" ]; then
-        curl --silent --max-time 600 --connect-timeout 30 -o "$1" "$2"
-    fi
+    curl --silent --max-time 600 --connect-timeout 30 -o "$1" "$2" --fail
 }
 
 function fetch() {

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -80,7 +80,10 @@ function sedCommand() {
 }
 
 function curlCommand() {
-    curl --silent --max-time 600 --connect-timeout 30 -o "$1" "$2"
+    ## Avoid 500 server side errors
+    if [ "$(curl -LI "$2" -o /dev/null -w '%{http_code}\n' -s)" != "500" ]; then
+        curl --silent --max-time 600 --connect-timeout 30 -o "$1" "$2"
+    fi
 }
 
 function fetch() {

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -53,7 +53,7 @@ class GenerateBuildDataIntegrationTests {
     String jobUrl = this.URL + "/abort/"
     Process process = runCommand(jobUrl, jobUrl + "runs/1", "ABORTED", "1")
     printStdout(process)
-    assertEquals("Process did finish successfully", 0, process.waitFor())
+    assertEquals("Process did finish successfully", 1, process.waitFor())
 
     // Tests were not executed
     JSONObject obj = JSONSerializer.toJSON(new File("target/tests-info.json").text)

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -49,17 +49,18 @@ class GenerateBuildDataIntegrationTests {
   private final String URL = "http://localhost:18081/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles"
 
   @Test
-  public void abortBuild() {
+  public void abortBuild_without_tests() {
+    String targetFolder = "abortBuild_without_tests"
     String jobUrl = this.URL + "/abort/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "ABORTED", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "ABORTED", "1")
     printStdout(process)
-    assertEquals("Process did finish successfully", 1, process.waitFor())
+    assertEquals("Process did finish unsuccessfully", 1, process.waitFor())
 
     // Tests were not executed
-    JSONObject obj = JSONSerializer.toJSON(new File("target/tests-info.json").text)
+    JSONObject obj = JSONSerializer.toJSON(new File("target/${targetFolder}/tests-info.json").text)
     assertTrue(obj.isEmpty())
 
-    obj = JSONSerializer.toJSON(new File("target/build-report.json").text)
+    obj = JSONSerializer.toJSON(new File("target/${targetFolder}/build-report.json").text)
     assertFalse(obj.isEmpty())
     assertFalse(obj.get("job").isEmpty())
     assertFalse(obj.get("test_summary").isEmpty())
@@ -70,17 +71,18 @@ class GenerateBuildDataIntegrationTests {
   }
 
   @Test
-  public void successBuild() {
+  public void successBuild_without_tests() {
+    String targetFolder = "successBuild_without_tests"
     String jobUrl = this.URL + "/success/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "SUCCESS", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "SUCCESS", "1")
     printStdout(process)
-    assertEquals("Process did finish successfully", 0, process.waitFor())
+    assertEquals("Process did finish unsuccessfully", 1, process.waitFor())
 
     // Tests were not executed
-    JSONObject obj = JSONSerializer.toJSON(new File("target/tests-info.json").text)
+    JSONObject obj = JSONSerializer.toJSON(new File("target/${targetFolder}/tests-info.json").text)
     assertTrue(obj.isEmpty())
 
-    obj = JSONSerializer.toJSON(new File("target/build-report.json").text)
+    obj = JSONSerializer.toJSON(new File("target/${targetFolder}/build-report.json").text)
     assertFalse(obj.isEmpty())
     assertFalse(obj.get("job").isEmpty())
     assertFalse(obj.get("test_summary").isEmpty())
@@ -92,16 +94,17 @@ class GenerateBuildDataIntegrationTests {
 
   @Test
   public void unstableBuild() {
+    String targetFolder = "unstableBuild"
     String jobUrl = this.URL + "/unstable/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
     printStdout(process)
     assertEquals("Process did finish successfully", 0, process.waitFor())
 
     // Tests were executed
-    JSONObject obj = JSONSerializer.toJSON(new File("target/tests-info.json").text)
+    JSONObject obj = JSONSerializer.toJSON(new File("target/${targetFolder}/tests-info.json").text)
     assertFalse(obj.isEmpty())
 
-    obj = JSONSerializer.toJSON(new File("target/build-report.json").text)
+    obj = JSONSerializer.toJSON(new File("target/${targetFolder}/build-report.json").text)
     assertFalse(obj.isEmpty())
     assertFalse(obj.get("job").isEmpty())
     assertFalse(obj.get("test_summary").isEmpty())
@@ -113,16 +116,17 @@ class GenerateBuildDataIntegrationTests {
 
   @Test
   public void errorBuild() {
+    String targetFolder = "errorBuild"
     String jobUrl = this.URL + "/error/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
     printStdout(process)
-    assertEquals("Process did finish successfully", 0, process.waitFor())
+    assertEquals("Process did finish unsuccessfully", 1, process.waitFor())
 
     // Tests were not executed
-    JSONObject obj = JSONSerializer.toJSON(new File("target/tests-info.json").text)
+    JSONObject obj = JSONSerializer.toJSON(new File("target/${targetFolder}/tests-info.json").text)
     assertTrue(obj.isEmpty())
 
-    JSONArray errors = JSONSerializer.toJSON(new File("target/steps-errors.json").text)
+    JSONArray errors = JSONSerializer.toJSON(new File("target/${targetFolder}/steps-errors.json").text)
     assertFalse("There are steps errors", errors.isEmpty())
     obj = errors.get(0)
     assertEquals("Log transformation happens successfully", "foo", obj.get("displayDescription"))
@@ -131,13 +135,14 @@ class GenerateBuildDataIntegrationTests {
 
   @Test
   public void unstableBuild_with_tests_normalisation() {
+    String targetFolder = "unstableBuild_with_tests_normalisation"
     String jobUrl = this.URL + "/unstable/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
     printStdout(process)
     assertEquals("Process did finish successfully", 0, process.waitFor())
 
     // Tests were executed
-    JSONArray tests = JSONSerializer.toJSON(new File("target/tests-info.json").text)
+    JSONArray tests = JSONSerializer.toJSON(new File("target/${targetFolder}/tests-info.json").text)
     assertFalse("There are tests", tests.isEmpty())
     JSONObject obj = tests.get(0)
     assertNull("No _links object", obj.get("_links"))
@@ -149,12 +154,13 @@ class GenerateBuildDataIntegrationTests {
 
   @Test
   public void errorBuild_with_steps_normalisation() {
+    String targetFolder = "errorBuild_with_steps_normalisation"
     String jobUrl = this.URL + "/error/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "UNSTABLE", "1")
     printStdout(process)
-    assertEquals("Process did finish successfully", 0, process.waitFor())
+    assertEquals("Process did finish unsuccessfully", 1, process.waitFor())
 
-    JSONArray errors = JSONSerializer.toJSON(new File("target/steps-errors.json").text)
+    JSONArray errors = JSONSerializer.toJSON(new File("target/${targetFolder}/steps-errors.json").text)
     assertFalse("There are steps errors", errors.isEmpty())
     JSONObject obj = errors.get(0)
     assertNull("No _class object", obj.get("_class"))
@@ -165,21 +171,22 @@ class GenerateBuildDataIntegrationTests {
 
   @Test
   public void emptyBuild_with_default_manipulation() {
+    String targetFolder = "emptyBuild_with_default_manipulation"
     String jobUrl = this.URL + "/empty/"
-    Process process = runCommand(jobUrl, jobUrl + "runs/1", "SUCCESS", "1")
+    Process process = runCommand(targetFolder, jobUrl, jobUrl + "runs/1", "SUCCESS", "1")
     printStdout(process)
     assertEquals("Process did finish successfully", 0, process.waitFor())
 
-    def content = new File("target/job-info.json").text
+    def content = new File("target/${targetFolder}/job-info.json").text
     assertFalse(content.isEmpty())
     JSONObject info = JSONSerializer.toJSON(content)
     assertTrue(info.isEmpty())
   }
 
-  Process runCommand(String jobUrl, String buildUrl, String status, String runTime) {
+  Process runCommand(String targetFolder, String jobUrl, String buildUrl, String status, String runTime) {
     //Build command
     List<String> commands = new ArrayList<String>()
-    commands.add("../resources/scripts/generate-build-data.sh")
+    commands.add("../../resources/scripts/generate-build-data.sh")
     commands.add(jobUrl)
     commands.add(buildUrl)
     commands.add(status)
@@ -189,7 +196,9 @@ class GenerateBuildDataIntegrationTests {
     Map<String, String> env = pb.environment()
     env.put('JENKINS_URL', 'http://localhost:18081/')
     env.put('PIPELINE_LOG_LEVEL', 'INFO')
-    pb.directory(new File("target"))
+    File location = new File("target/${targetFolder}")
+    location.mkdirs()
+    pb.directory(location)
     pb.redirectErrorStream(true)
     Process process = pb.start()
 


### PR DESCRIPTION
## What does this PR do?

BO returns 500 in some cases let's avoid fetching an html page instead a json one, let's use `--fail` even though 404 might happen but it should behave as no file to be processed. 

`--fail` does not require to tweak the ITs, while the other approach required to use wireshark to fetch `HEAD` requests.

## Why is it important?

Avoid fetching wrong data.

## See

![image](https://user-images.githubusercontent.com/2871786/94821582-a088ec00-03f9-11eb-9f82-cac5c3b7fbc5.png)

```
curl -LI https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats/7.x/runs/382/blueTestSummary/ -o /dev/null -w '%{http_code}\n' -s
500
```

```
$ curl https://beats-ci.elastic.co/blue/rest/organizations/jenkins/pipelines/Beats/beats/7.x/runs/382/blueTestSummary/ --fail -o file.txt1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0ca
curl: (22) The requested URL returned error: 500 Server Error
$ cat file.txt1        
cat: file.txt1: No such file or directory

```