### PR TITLE
Exclude GH Notifies and JUnit from reported failed steps

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -64,7 +64,7 @@
 <%}%>
 
 <!-- STEPS ERRORS IF ANY-->
-<% stepsErrors = stepsErrors?.findAll{item -> item?.result == "FAILURE"}%>
+<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
 <% if (stepsErrors?.size() != 0) {%>
 ### Steps errors
 

--- a/resources/groovy-html-custom.template
+++ b/resources/groovy-html-custom.template
@@ -174,7 +174,7 @@
         </td>
       </tr>
       <!--TABLE_CHANGES-->
-      <% stepsErrors = stepsErrors?.findAll{item -> item?.result == "FAILURE"}%>
+      <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
       <tr>
         <td colspan="7" style="height: 32px;${ stepsErrors?.size() != 0 ? '' : 'display: none;' }"></td>
       </tr>


### PR DESCRIPTION
## What does this PR do?

PRComment reports the steps that failed, some of those steps are not important but some wrappers.

## Why is it important?

JUnit reporting failed if tests were not executed for instance.
GH notify fails if the closure failed, aka another step.  


For instance

![image](https://user-images.githubusercontent.com/2871786/94907546-3ecb8f00-0498-11eb-9c86-6f5e3ab9af4f.png)

