### PR TITLE
[local] remove resources limitations in docker

### DIFF
--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -29,14 +29,6 @@ services:
     ports:
       - "18080:8080"
       - "50000:50000"
-    deploy:
-      resources:
-        limits:
-          cpus: 0.50
-          memory: 250M
-        reservations:
-          cpus: 0.25
-          memory: 100M
     networks:
       apm-pipeline-library:
 


### PR DESCRIPTION
## What does this PR do?

Avoid slowness in the docker instance

## Why is it important?

It is really, really really slow. It seems previous versions of docker didn't have that particular impact, most likely those configuration details were not used for some reason.
