### PR TITLE
isBranch and isTag helpers

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -428,14 +428,22 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       def script = loadScript('vars/installTools.groovy')
       return script.call(l)
     })
+    helper.registerAllowedMethod('isBranch', {
+      def script = loadScript('vars/isBranch.groovy')
+      return script.call()
+    })
     helper.registerAllowedMethod('isCommentTrigger', { return false })
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m ->
+      def script = loadScript('vars/isInstalled.groovy')
+      return script.call(m)
+    })
     helper.registerAllowedMethod('isPR', {
       def script = loadScript('vars/isPR.groovy')
       return script.call()
     })
-    helper.registerAllowedMethod('isInstalled', [Map.class], { m ->
-      def script = loadScript('vars/isInstalled.groovy')
-      return script.call(m)
+    helper.registerAllowedMethod('isTag', {
+      def script = loadScript('vars/isTag.groovy')
+      return script.call()
     })
     helper.registerAllowedMethod('isUpstreamTrigger', { return false })
     helper.registerAllowedMethod('isUserTrigger', { return false })

--- a/src/test/groovy/IsBranchStepTests.groovy
+++ b/src/test/groovy/IsBranchStepTests.groovy
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import co.elastic.mock.RawBuildMock
+import hudson.model.Cause
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsBranchStepTests extends ApmBasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isBranch.groovy')
+  }
+
+  @Test
+  void test_isBranch() throws Exception {
+    env.BRANCH_NAME = 'master'
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_isBranch_in_pr() throws Exception {
+    env.BRANCH_NAME = 'PR-1'
+    env.CHANGE_ID = '1'
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_isBranch_in_tag() throws Exception {
+    env.TAG_NAME = 'my-tag'
+    env.remove('BRANCH_NAME')
+    env.remove('CHANGE_ID')
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+}

--- a/src/test/groovy/IsTagStepTests.groovy
+++ b/src/test/groovy/IsTagStepTests.groovy
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import co.elastic.mock.RawBuildMock
+import hudson.model.Cause
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsTagStepTests extends ApmBasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isTag.groovy')
+  }
+
+  @Test
+  void test_isTag() throws Exception {
+    env.TAG_NAME = 'my-tag'
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_isTag_in_pr() throws Exception {
+    env.BRANCH_NAME = 'PR-1'
+    env.CHANGE_ID = '1'
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_isTag_in_branch() throws Exception {
+    env.BRANCH_NAME = 'master'
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1111,15 +1111,15 @@ Whether the architecture is an arm based using the `nodeArch` step
 ```
 
 ## isBranch
-Whether the build is based on a Pull Request or no
+Whether the build is based on a Branch or no
 
 ```
   // Assign to a variable
-  def pr = isPR())
+  def branch = isBranch())
 
   // Use whenTrue condition
-  whenTrue(isPR()) {
-    echo "I'm a Pull Request"
+  whenTrue(isBranch()) {
+    echo "I'm a Branch"
   }
 ```
 

--- a/vars/README.md
+++ b/vars/README.md
@@ -1110,6 +1110,19 @@ Whether the architecture is an arm based using the `nodeArch` step
     }
 ```
 
+## isBranch
+Whether the build is based on a Pull Request or no
+
+```
+  // Assign to a variable
+  def pr = isPR())
+
+  // Use whenTrue condition
+  whenTrue(isPR()) {
+    echo "I'm a Pull Request"
+  }
+```
+
 ## isBranchIndexTrigger
 Check it the build was triggered by a Branch index.
 
@@ -1224,6 +1237,19 @@ Whether the build is based on a Pull Request or no
   // Use whenTrue condition
   whenTrue(isPR()) {
     echo "I'm a Pull Request"
+  }
+```
+
+## isTag
+Whether the build is based on a Tag Request or no
+
+```
+  // Assign to a variable
+  def tag = isTag())
+
+  // Use whenTrue condition
+  whenTrue(isTag()) {
+    echo "I'm a Tag"
   }
 ```
 

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -47,7 +47,7 @@ Boolean call(Map args = [:]){
 }
 
 private Boolean whenBranches(Map args = [:]) {
-  if (!isPR() && env.BRANCH_NAME?.trim() && args.content?.get('branches')) {
+  if (isBranch() && args.content?.get('branches')) {
     markdownReason(project: args.project, reason: '* ✅ Branch is enabled .')
     return true
   }

--- a/vars/isBranch.groovy
+++ b/vars/isBranch.groovy
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Whether the build is based on a Branch
+
+  whenTrue(isBranch()) {
+    echo "I'm a Branch"
+  }
+*/
+def call(){
+  return (!isPR() && env.BRANCH_NAME?.trim())
+}

--- a/vars/isBranch.txt
+++ b/vars/isBranch.txt
@@ -1,0 +1,11 @@
+Whether the build is based on a Pull Request or no
+
+```
+  // Assign to a variable
+  def pr = isPR())
+
+  // Use whenTrue condition
+  whenTrue(isPR()) {
+    echo "I'm a Pull Request"
+  }
+```

--- a/vars/isBranch.txt
+++ b/vars/isBranch.txt
@@ -1,11 +1,11 @@
-Whether the build is based on a Pull Request or no
+Whether the build is based on a Branch or no
 
 ```
   // Assign to a variable
-  def pr = isPR())
+  def branch = isBranch())
 
   // Use whenTrue condition
-  whenTrue(isPR()) {
-    echo "I'm a Pull Request"
+  whenTrue(isBranch()) {
+    echo "I'm a Branch"
   }
 ```

--- a/vars/isTag.groovy
+++ b/vars/isTag.groovy
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Whether the build is based on a Tag Request or no
+
+  whenTrue(isTag()) {
+    echo "I'm a Tag"
+  }
+*/
+def call(){
+  return env?.TAG_NAME ? true : false
+}

--- a/vars/isTag.txt
+++ b/vars/isTag.txt
@@ -1,0 +1,11 @@
+Whether the build is based on a Tag Request or no
+
+```
+  // Assign to a variable
+  def tag = isTag())
+
+  // Use whenTrue condition
+  whenTrue(isTag()) {
+    echo "I'm a Tag"
+  }
+```


### PR DESCRIPTION
## What does this PR do?

Provide steps to query if the MBP was running for a branch or a tag.

## Why


Avoid to access to env variables to know what kind of build.

## Related issues

Caused by https://github.com/elastic/apm-agent-php/pull/204