### PR TITLE
[cosmetic] less verbose test and step failures in the slack message

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -1,14 +1,10 @@
 <% changes = changeSet?.find { true }%>
 <% steps = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
-<% pipelineUrl = String.format("<%spipeline|%s>", jobUrl, build?.id ?: 'build')%>
+<% artifactsUrl = String.format("<%sartifacts|here>", jobUrl)%>
 <% commitUrl = String.format("<%s|%s>", changes?.url, changes?.msg)%>
+<% pipelineUrl = String.format("<%spipeline|%s>", jobUrl, build?.id ?: 'build')%>
+<% testsUrl = String.format("<%stests|here>", jobUrl)%>
 *Build*: ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
-*Changes*: ${changes?.commitId} has been merged (see ${commitUrl}) (PR owner `${changes?.author?.id}`)
-*Tests(Total/Passed/Failed/Skipped)*: `${(testsSummary?.total) ?: 0}/${(testsSummary?.passed) ?: 0}/${(testsSummary?.failed) ?: 0}/${(testsSummary?.skipped) ?: 0}`
-<% if(testsErrors != null && testsErrors instanceof List && testsErrors?.any{item -> item?.status == "FAILED"}) {%>
-    <% testsErrors?.findAll{it?.status == "FAILED"}.each{ %>
-    * *Name*: `${it?.name}` for the last ${it?.age} builds<%}%>
-<%}%>
-*Steps failures*: ${(steps?.size()!= 0) ? steps?.size() : 0}
-<% steps.each{ it -> %> <% stepUrl = (it?.url && it?.url != 'null') ? String.format("(<%s|see logs>)", it.url) : ''%>
-* *Name*: `${(it?.displayDescription && it?.displayDescription != 'null') ? it?.displayDescription : it?.displayName}` ${stepUrl} <%}%>
+*Changes*: ${changes?.commitId?.length() > 7 ? changes?.commitId.substring(0, 7) : changes?.commitId} has been merged (see ${commitUrl}) (PR owner `${changes?.author?.id}`)
+*Tests(Total/Passed/Failed/Skipped)*: ${(testsSummary?.passed) ?: 0} passed of ${(testsSummary?.total) ?: 0} with `${(testsSummary?.failed) ?: 0}` failure/s (Click ${testsUrl} for further details)
+*Steps failures*: ${(steps?.size()!= 0) ? steps?.size() : 0} (Click ${artifactsUrl} and open `build.md` for further details)

--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -6,5 +6,5 @@
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 *Build*: ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changes?.commitId?.length() > 7 ? changes?.commitId.substring(0, 7) : changes?.commitId} has been merged (see ${commitUrl}) (PR owner `${changes?.author?.id}`)
-*Tests(Total/Passed/Failed/Skipped)*: ${(testsSummary?.passed) ?: 0} passed of ${(testsSummary?.total) ?: 0} with `${(testsSummary?.failed) ?: 0}` failure/s (Click ${testsUrl} for further details)
+*Tests*: ${(testsSummary?.passed) ?: 0} passed out of ${(testsSummary?.total) ?: 0} with `${(testsSummary?.failed) ?: 0}` failure/s (Click ${testsUrl} for further details)
 *Steps failures*: ${(steps?.size()!= 0) ? steps?.size() : 0} (Click ${artifactsUrl} and open `build.md` for further details)


### PR DESCRIPTION
## What does this PR do?

List only the number of failures and a link where to look for further details.
Cosmetic changes in the format

## Why is it important?

Avoid massive slack messages

for instance with a few test failures

![image](https://user-images.githubusercontent.com/2871786/94926701-156f2b00-04b9-11eb-8b44-8fb8f2f80776.png)

and a few steps failures:

![image](https://user-images.githubusercontent.com/2871786/94926730-1f912980-04b9-11eb-9f48-9ec5e3bdf155.png)


## Test

See the raw message as an example of the outcome from the ITs
```
*Build*: <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/pipeline|49> for branch `develop` got the status `ABORTED`
*Changes*: 8a2fd55 has been merged (see <https://github.com/elastic/apm-server/commit/8a2fd55f40dbcb279911e3f2237312baf1508019|fix 7.x changelog links (#2207)>) (PR owner `someone`)
*Tests*: 121 passed of 121 with `0` failure/s (Click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/tests|here> for further details)
*Steps failures*: 3 (Click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/artifacts|here> and open `build.md` for further details)
```

![image](https://user-images.githubusercontent.com/2871786/94927593-6895ad80-04ba-11eb-9b8c-028da7dd8df0.png)

