### PR TITLE
Resilience when test-summary is not accessible.

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -49,7 +49,7 @@
 </details>
 
 <!-- TEST RESULTS IF ANY-->
-<% if(testsErrors != null && testsErrors instanceof List && testsErrors?.any{item -> item?.status == "FAILED"}) {%>
+<% if(testsErrors?.any{item -> item?.status == "FAILED"}) {%>
   ### Test errors
   <details><summary>Expand to view the tests failures</summary>
   <p>

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -165,12 +165,12 @@ function fetchAndPrepareTestSummaryReport() {
     if [ ! -e "${file}" ] ; then
         if [ -e "${testsFile}" ] ; then
             {
-                echo "["
+                echo "{"
                 echo "\"total\": $(jq '. | length' "${testsFile}"),"
                 echo "\"passed\": $(jq 'map(select(.status |contains("PASSED"))) | length' "${testsFile}"),"
                 echo "\"failed\": $(jq 'map(select(.status |contains("FAILED"))) | length' "${testsFile}"),"
-                echo "\"skipped\": $(jq 'map(select(.status |contains("SKIPPED"))) | length' "${testsFile}"),"
-                echo "]"
+                echo "\"skipped\": $(jq 'map(select(.status |contains("SKIPPED"))) | length' "${testsFile}")"
+                echo "}"
             } > "${file}"
         else
             echo "${default}" > "${file}"


### PR DESCRIPTION
## What does this PR do?

Beats-CI got some issues when the test-summary BO entrypoint is returning 500. 

![image](https://user-images.githubusercontent.com/2871786/95077661-c240e680-070b-11eb-8a18-42730af9a3b8.png)

## Why is it important?

Even the tests that are failing are reported the overall summary of tests executions is not shown correctly.
