### PR TITLE
cosmetic change slack comment

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -6,7 +6,7 @@
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.url && changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
 <% stepsMessage = (steps?.size()!= 0) ? "`${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : 0%>
-*Build*: ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
+*Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changesMessage}
-*Tests*: ${(testsSummary?.failed) ?: 0} test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)
+*Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)
 *Steps failures*: ${stepsMessage}


### PR DESCRIPTION
## What does this PR do?

- Highlight test errors
- Explicitly add the job name

## Why is it important?

When notifying in a common channel then the build refererence to the job was not included, therefore it was not easy to debug what's the pipeline unless clicking on the links.

See. 
![image](https://user-images.githubusercontent.com/2871786/95863579-458db800-0d5c-11eb-93f7-2b085c9f8725.png)


## Test

```
*Build*: `folder/mbp/master` <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/pipeline|#49> for branch `develop` got the status `ABORTED`
*Changes*: <https://github.com/elastic/apm-server/commit/8a2fd55f40dbcb279911e3f2237312baf1508019|fix 7.x changelog links (#2207)> (by `someone`)
*Tests*: `0` test/s failed out of 121 (click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/tests|here> for further details)
*Steps failures*: `3` (click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/artifacts|here> and open `build.md` for further details)
```


See `folder/mbp/master` and `*Tests*: 0`

## Related issues
Closes #ISSUE