### PR TITLE
Grant running access for the dependabot user

### DIFF
--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -96,7 +96,7 @@ def hasWritePermission(token, repo, user){
   Check if the PR come from a bot and if the bot is authorized.
 */
 def isAuthorizedBot(login, type){
-  def authorizedBots = ['greenkeeper[bot]']
+  def authorizedBots = ['greenkeeper[bot]', 'dependabot']
   log(level: 'DEBUG', text: "githubPrCheckApproved: User: ${login}, Type: ${type}")
   def ret = false;
   if('bot'.equalsIgnoreCase(type)){


### PR DESCRIPTION
## What does this PR do?

Grant access to the CI for PRs that are generated by the `bot` dependabot.

## Why is it important?

To support dependabot for security bumps

## Related issues

Notifies https://github.com/elastic/apm-pipeline-library/pull/766   
