### PR TITLE
Enable dependabot[bot]

### DIFF
--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -96,7 +96,7 @@ def hasWritePermission(token, repo, user){
   Check if the PR come from a bot and if the bot is authorized.
 */
 def isAuthorizedBot(login, type){
-  def authorizedBots = ['greenkeeper[bot]', 'dependabot']
+  def authorizedBots = ['greenkeeper[bot]', 'dependabot[bot]']
   log(level: 'DEBUG', text: "githubPrCheckApproved: User: ${login}, Type: ${type}")
   def ret = false;
   if('bot'.equalsIgnoreCase(type)){


### PR DESCRIPTION
## What does this PR do?

Use `dependabot[bot]`

![image](https://user-images.githubusercontent.com/2871786/95974263-ab397d00-0e0c-11eb-9885-37c7fcff2209.png)


## Why is it important?

Otherwise the user does not match

## Related issues

See https://github.com/elastic/apm-pipeline-library/pull/769