### PR TITLE
[flaky] Control number of issues to be created

### DIFF
--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -506,6 +506,31 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_analyzeFlakey_in_prs_with_more_than_3_flaky_tests_not_reported_yet() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: "flake-results.json")})
+    helper.registerAllowedMethod('lookForGitHubIssues', [Map.class], {
+      return [ 'test-a': '', 'test-b': '', 'test-c': '', 'test-d': '' ]
+      }
+    )
+    helper.registerAllowedMethod('githubCreateIssue', [Map.class], { return '100' } )
+    helper.registerAllowedMethod('isPR', { return true })
+    script.analyzeFlakey(
+      flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
+      es: "https://fake_url",
+      testsErrors: readJSON(file: 'flake-tests-errors.json'),
+      testsSummary: readJSON(file: 'flake-tests-summary.json')
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-a"))
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-b"))
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-c"))
+    assertFalse(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-d"))
+    assertTrue(assertMethodCallContainsPattern('log', "'Flaky Test [test-d]'"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_analyzeFlakeyThreshold() throws Exception {
     def script = loadScript(scriptName)
     helper.registerAllowedMethod(


### PR DESCRIPTION
## What does this PR do?

No more than 3 issues will be created for flaky test failures that have not been reported yet per build.

## Why is it important?

If something bad happened with the PR and the flaky test analyser then avoid creating a bunch of GitHub issues.

