### PR TITLE
[flaky] enable if no aborted

### DIFF
--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -268,4 +268,32 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('unstash', 'bar'))
     assertTrue(assertMethodCallContainsPattern('unstash', 'builder'))
   }
+
+  @Test
+  void test_no_flakey_when_aborted() throws Exception {
+    // When aborted
+    binding.getVariable('currentBuild').result = "ABORTED"
+    binding.getVariable('currentBuild').currentResult = "ABORTED"
+
+    def script = loadScript(scriptName)
+    script.call(analyzeFlakey: true)
+    printCallStack()
+
+    // Then no flakey test analysis
+    assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Generating flakey test analysis'))
+  }
+
+  @Test
+  void test_flakey_when_unstable() throws Exception {
+    // When unstable
+    binding.getVariable('currentBuild').result = "UNSTABLE"
+    binding.getVariable('currentBuild').currentResult = "UNSTABLE"
+
+    def script = loadScript(scriptName)
+    script.call(analyzeFlakey: true)
+    printCallStack()
+
+    // Then flakey test analysis
+    assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Generating flakey test analysis'))
+  }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -77,8 +77,8 @@ def call(Map args = [:]) {
           }
         }
 
-        // Should analyze flakey
-        if(analyzeFlakey) {
+        // Should analyze flakey but exclude it when aborted
+        if(analyzeFlakey && currentBuild.currentResult != 'ABORTED') {
           data['es'] = es
           data['es_secret'] = secret
           data['flakyReportIdx'] = flakyReportIdx


### PR DESCRIPTION
## What does this PR do?

Builds that got aborted (normally a new build with new changes are in place) then no flaky test analyser should happen since there might not be tests to be analysed.

## Why is it important?

Avoid any kind of misleading 

For instance 

![image](https://user-images.githubusercontent.com/2871786/96140050-6b02f900-0ef7-11eb-9dfa-630d2b96a510.png)

![image](https://user-images.githubusercontent.com/2871786/96140065-6e968000-0ef7-11eb-9c92-b54f7056728f.png)


## Related issues
Closes #ISSUE