### PR TITLE
Avoid using windows immutable workers

### DIFF
--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -49,7 +49,7 @@ def call(Map args = [:]) {
   def flakyReportIdx = args.containsKey('flakyReportIdx') ? args.flakyReportIdx : ""
   def flakyThreshold = args.containsKey('flakyThreshold') ? args.flakyThreshold : 0.0
 
-  node('master || metal || immutable'){
+  node('master || metal || linux'){
     stage('Reporting build status'){
       def secret = args.containsKey('secret') ? args.secret : 'secret/observability-team/ci/jenkins-stats-cloud'
       def es = args.containsKey('es') ? args.es : getVaultSecret(secret: secret)?.data.url


### PR DESCRIPTION
## What does this PR do?

Use linux workers rather than the generic immutable label that might also include the windows workers.

## Why is it important?

Sometimes the post build step runs in windows and don't notify the status.

See [this](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats/detail/PR-21857/1/pipeline)

![image](https://user-images.githubusercontent.com/2871786/96236363-dc908500-0f93-11eb-8b08-fba621ff68ca.png)

![image](https://user-images.githubusercontent.com/2871786/96236317-cf739600-0f93-11eb-9617-592db8cdee77.png)

## Further details

- [linux](https://apm-ci.elastic.co/label/linux/) for the apm-ci
- [linux](https://beats-ci.elastic.co/label/linux/) for the beats-ci

Although it seems `gobld doesn't support master||immutable label ` so not sure the reason why it worked in this case... so this PR fixes our issue now