### PR TITLE
Avoid warning in JUnit when using args that are not defined

### DIFF
--- a/src/test/groovy/JunitAndStoreStepTests.groovy
+++ b/src/test/groovy/JunitAndStoreStepTests.groovy
@@ -17,6 +17,7 @@
 
 import org.junit.Before
 import org.junit.Test
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
 class JunitAndStoreStepTests extends ApmBasePipelineTest {
@@ -68,6 +69,8 @@ class JunitAndStoreStepTests extends ApmBasePipelineTest {
     script.call(stashedTestReports: [:], testResults: '*.xml', id: 'acme')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('junit', 'testResults=*.xml'))
+    assertFalse(assertMethodCallContainsPattern('junit', 'id'))
+    assertFalse(assertMethodCallContainsPattern('junit', 'stashedTestReports'))
     assertTrue(assertMethodCallContainsPattern('stash', 'includes=*.xml, allowEmpty=true, name=acme-'))
     assertJobStatusSuccess()
   }

--- a/vars/junitAndStore.groovy
+++ b/vars/junitAndStore.groovy
@@ -41,7 +41,8 @@ populated later on with the runbld post build step.
 def call(Map args = [:]) {
   def stashedTestReports = args.containsKey('stashedTestReports') ? args.stashedTestReports : error('junitAndStore: stashedTestReports param is required')
   def testResults = args.containsKey('testResults') ? args.testResults : error('junitAndStore: testResults param is required')
-  junit(args)
+  def junitArgs = args.findAll { k,v -> !(k.equals('id') || k.equals('stashedTestReports')) }
+  junit(junitArgs)
   // args.id could be null in some cases, so let's use the currentmilliseconds
   def suffix = new java.util.Date().getTime()
   def stageName = args.id ? "${args.id?.replaceAll('[\\W]|_', '-')}-${suffix}" : "uncategorized-${suffix}"


### PR DESCRIPTION
## What does this PR do?

Fix warning when using args that are not defined

```
[2020-10-13T16:50:43.188Z] [Pipeline] junit
[2020-10-13T16:50:43.188Z] WARNING: Unknown parameter(s) found for class type 'hudson.tasks.junit.pipeline.JUnitResultsStep': id,stashedTestReports
[2020-10-13T16:50:43.192Z] Recording test results
[2020-10-13T16:50:43.618Z] None of the test reports contained any result
```

## Why is it important?

Let's see if that could be the reason with the BO issues and corrupted data.

## Related issues

Relates to https://github.com/elastic/beats/pull/21888