### PR TITLE
Support API calls without caching

### DIFF
--- a/src/test/groovy/GithubApiCallStepTests.groovy
+++ b/src/test/groovy/GithubApiCallStepTests.groovy
@@ -171,6 +171,18 @@ class GithubApiCallStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_noCache() throws Exception {
+    helper.registerAllowedMethod("httpRequest", [Map.class], shInterceptor)
+    def script = loadScript(scriptName)
+    def ret0 = script.call(url: "dummy", token: "dummy")
+    def ret1 = script.call(url: "dummy", token: "dummy", noCache: true)
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('log', 'githubApiCall: get the JSON from GitHub.'))
+    assertFalse(assertMethodCallContainsPattern('log', 'githubApiCall: get the JSON from cache.'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void testResponseNull() throws Exception {
     helper.registerAllowedMethod("httpRequest", [Map.class], {
       return null

--- a/vars/README.md
+++ b/vars/README.md
@@ -683,6 +683,7 @@ Make a REST API call to Github. It manage to hide the call and the token in the 
 * allowEmptyResponse: whether to allow empty responses. Default false.
 * method: what kind of request. Default 'POST' when using the data parameter. Optional.
 * data: Data to post to the API. Pass as a Map.
+* noCache: whether to force the API call without the already cached data if any. Default false.
 
 [Github REST API](https://developer.github.com/v3/)
 

--- a/vars/githubApiCall.groovy
+++ b/vars/githubApiCall.groovy
@@ -35,6 +35,7 @@ def call(Map params = [:]){
   def headers = ["Authorization": "token ${token}",
                  "User-Agent": "Elastic-Jenkins-APM"]
   def dryRun = params?.data
+  def noCache = params?.get('noCache', false)
 
   log(level: 'DEBUG', text: "githubApiCall: REST API call ${url}")
   wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [
@@ -43,7 +44,7 @@ def call(Map params = [:]){
     def json = "{}"
     try {
       def key = "${token}#${url}"
-      if(cache["${key}"] == null){
+      if(cache["${key}"] == null || noCache){
         log(level: 'DEBUG', text: "githubApiCall: get the JSON from GitHub.")
         if(data) {
           log(level: 'DEBUG', text: "gitHubApiCall: found data param. Switching to ${method}")

--- a/vars/githubApiCall.txt
+++ b/vars/githubApiCall.txt
@@ -10,5 +10,6 @@ Make a REST API call to Github. It manage to hide the call and the token in the 
 * allowEmptyResponse: whether to allow empty responses. Default false.
 * method: what kind of request. Default 'POST' when using the data parameter. Optional.
 * data: Data to post to the API. Pass as a Map.
+* noCache: whether to force the API call without the already cached data if any. Default false.
 
 [Github REST API](https://developer.github.com/v3/)

--- a/vars/githubPrLatestComment.groovy
+++ b/vars/githubPrLatestComment.groovy
@@ -29,7 +29,7 @@ def call(Map args = [:]){
   if (isPR()) {
     def token = getGithubToken()
     def url = "https://api.github.com/repos/${env.ORG_NAME}/${env.REPO_NAME}/issues/${env.CHANGE_ID}/comments"
-    def comments = githubApiCall(token: token, url: url)
+    def comments = githubApiCall(token: token, url: url, noCache: true)
     return comments.reverse().find { comment ->
       if (users) {
         users.find { it == comment.user.login } && comment.body =~ "${pattern}"


### PR DESCRIPTION
## What does this PR do?

Add noCache for API calls when using the GitHub PR comment

## Why is it important?

This will allow us to generate multiple GH comments 

Otherwise

![image](https://user-images.githubusercontent.com/2871786/96261378-4884e480-0fb8-11eb-893f-fa7f82de153f.png)

And the call happens once and the archive twice reusing the same file

![image](https://user-images.githubusercontent.com/2871786/96261416-56d30080-0fb8-11eb-9b60-a06d268507d9.png)


```bash
$ curl -s https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-21853/3/artifact/flaky.id/\*view\*/                                                                                                
709473180%                                                                                                                                                                                                                                                                                         $ curl -s https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-21853/3/artifact/comment.id/\*view\*/
709473180%   
```
