### PR TITLE
[flaky] categorise comments in failed or not failed tests

### DIFF
--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -1,14 +1,17 @@
-## :bug: Flaky test report
 <% if(tests) {%>
+## :bug: Flaky test report
 :snowflake: The following tests failed but also have a history of flakiness and may not be related to this change: 
     <% tests?.each{ k,v -> %>
 * **Name**: `${k}` ${ (v?.trim()) ? "reported in the issue #" + v : 'has not been reported yet.'}<%}%>
 <%} else if (testsSummary?.failed > 0) {%>
+## :bug: Flaky test report
 :grey_exclamation: There are test failures but not known flaky tests.
 <%} else if(testsSummary?.total > 0) {%>
-:green_heart: Tests succeeded.
+## :green_heart: Flaky test report
+Tests succeeded.
 <%} else {%>
-:grey_exclamation: No test was executed to be analysed.
+## :grey_exclamation: Flaky test report
+No test was executed to be analysed.
 <%}%>
 <% if(testsSummary?.total > 0) {%>
 ### Test stats :test_tube:

--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -3,10 +3,14 @@
 :snowflake: The following tests failed but also have a history of flakiness and may not be related to this change: 
     <% tests?.each{ k,v -> %>
 * **Name**: `${k}` ${ (v?.trim()) ? "reported in the issue #" + v : 'has not been reported yet.'}<%}%>
-<%}else {%>
-:grey_exclamation: There are not known flaky tests.
+<%} else if (testsSummary?.failed > 0) {%>
+:grey_exclamation: There are tests failures but not known flaky tests.
+<%} else if(testsSummary?.total > 0) {%>
+:green_heart: Tests Succeeded.
+<%} else {%>
+:grey_exclamation: There are not executed tests to be evaluated.
 <%}%>
-<% if(testsSummary?.total != 0) {%>
+<% if(testsSummary?.total > 0) {%>
 ### Test stats :test_tube:
 | Test         | Results                         |
 | ------------ | :-----------------------------: |

--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -4,11 +4,11 @@
     <% tests?.each{ k,v -> %>
 * **Name**: `${k}` ${ (v?.trim()) ? "reported in the issue #" + v : 'has not been reported yet.'}<%}%>
 <%} else if (testsSummary?.failed > 0) {%>
-:grey_exclamation: There are tests failures but not known flaky tests.
+:grey_exclamation: There are test failures but not known flaky tests.
 <%} else if(testsSummary?.total > 0) {%>
 :green_heart: Tests Succeeded.
 <%} else {%>
-:grey_exclamation: There are not executed tests to be analysed.
+:grey_exclamation: No test was executed to be analysed.
 <%}%>
 <% if(testsSummary?.total > 0) {%>
 ### Test stats :test_tube:

--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -8,7 +8,7 @@
 <%} else if(testsSummary?.total > 0) {%>
 :green_heart: Tests Succeeded.
 <%} else {%>
-:grey_exclamation: There are not executed tests to be evaluated.
+:grey_exclamation: There are not executed tests to be analysed.
 <%}%>
 <% if(testsSummary?.total > 0) {%>
 ### Test stats :test_tube:

--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -6,7 +6,7 @@
 <%} else if (testsSummary?.failed > 0) {%>
 :grey_exclamation: There are test failures but not known flaky tests.
 <%} else if(testsSummary?.total > 0) {%>
-:green_heart: Tests Succeeded.
+:green_heart: Tests succeeded.
 <%} else {%>
 :grey_exclamation: No test was executed to be analysed.
 <%}%>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -578,7 +578,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: [:]
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are not executed tests to be evaluated."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are not executed tests to be analysed."))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -446,7 +446,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: readJSON(file: 'flake-tests-summary.json')
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are tests failures but not known flaky tests."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are test failures but not known flaky tests."))
     assertJobStatusSuccess()
   }
 
@@ -578,7 +578,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: [:]
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are not executed tests to be analysed."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "No test was executed to be analysed."))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -561,7 +561,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: [ "failed": 0, "passed": 120, "skipped": 0, "total": 120 ]
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', "Tests Succeeded."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "Tests succeeded."))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -446,7 +446,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: readJSON(file: 'flake-tests-summary.json')
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are not known flaky tests"))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are tests failures but not known flaky tests."))
     assertJobStatusSuccess()
   }
 
@@ -545,6 +545,40 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-c"))
     assertFalse(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** test-d"))
     assertTrue(assertMethodCallContainsPattern('log', "'Flaky Test [test-d]'"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_analyzeFlakey_in_prs_without_failed_tests() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: "flake-results.json")})
+    helper.registerAllowedMethod('lookForGitHubIssues', [Map.class], { return [:] } )
+    helper.registerAllowedMethod('isPR', { return true })
+    script.analyzeFlakey(
+      flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
+      es: "https://fake_url",
+      testsErrors: [:],
+      testsSummary: [ "failed": 0, "passed": 120, "skipped": 0, "total": 120 ]
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "Tests Succeeded."))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_analyzeFlakey_in_prs_without_executed_tests() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: "flake-results.json")})
+    helper.registerAllowedMethod('lookForGitHubIssues', [Map.class], { return [:] } )
+    helper.registerAllowedMethod('isPR', { return true })
+    script.analyzeFlakey(
+      flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
+      es: "https://fake_url",
+      testsErrors: [:],
+      testsSummary: [:]
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are not executed tests to be evaluated."))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Add more comment categories for the flaky test analysis GitHub comments, such as: when there are known test failures and known flaky failures, versus non executed tests builds and builds without any test failures

## Why is it important?

To ensure the message got enough context about what it happened

## Questions

- @elastic/observablt-robots , what do you think if the icon 🐛 💚 and ❕ are moved to the main header? For instance

<img src="https://user-images.githubusercontent.com/2871786/96575564-cf8fd080-12c8-11eb-91cb-83ab89852f92.png" width="200" height="200">
 vs
<img src="https://user-images.githubusercontent.com/2871786/96575606-ddddec80-12c8-11eb-922f-664a4ecd2203.png" width="200" height="220">

## Related issues
Closes #ISSUE

## Screenshots

- No executed tests

<img src="https://user-images.githubusercontent.com/2871786/96575337-86d81780-12c8-11eb-94d4-06cbd377345c.png" width="200" height="100">

- No failed tests

<img src="https://user-images.githubusercontent.com/2871786/96575472-aec77b00-12c8-11eb-81c7-5f8f3bb09246.png" width="150" height="260">

- With failed tests

<img src="https://user-images.githubusercontent.com/2871786/96575639-edf5cc00-12c8-11eb-843c-1189a2329ce0.png" width="500" height="350">


