### PR TITLE
feat: support client code to prepend a custom header in slack message

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -6,7 +6,7 @@
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.url && changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
 <% stepsMessage = (steps?.size()!= 0) ? "`${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : 0%>
-<% if (header?.trim()) out.print "${header}" %>
+<% if (header?.trim()) {%>${header}<%}%>
 *Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changesMessage}
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)

--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -6,7 +6,7 @@
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.url && changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
 <% stepsMessage = (steps?.size()!= 0) ? "`${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : 0%>
-<% if (header != "") out.print "${header}" %>
+<% if (header?.trim()) out.print "${header}" %>
 *Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changesMessage}
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)

--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -6,6 +6,7 @@
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.url && changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
 <% stepsMessage = (steps?.size()!= 0) ? "`${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : 0%>
+<% if (header != "") out.print "${header}" %>
 *Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changesMessage}
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -239,6 +239,7 @@ def notifyPR(Map params = [:]) {
  * @param changeSet list of change set, see src/test/resources/changeSet-info.json
  * @param docsUrl URL with the preview docs
  * @param log String that contains the log
+ * @param header String that contains a custom header for the message (optional)
  * @param statsUrl URL to access to the stats
  * @param stepsErrors list of steps failed, see src/test/resources/steps-errors.json
  * @param testsErrors list of test failed, see src/test/resources/tests-errors.json
@@ -256,6 +257,7 @@ def notifySlack(Map args = [:]) {
     def testsSummary = args.containsKey('testsSummary') ? args.testsSummary : null
     def enabled = args.get('enabled', false)
     def channel = args.containsKey('channel') ? args.channel : error('notifySlack: channel parameter is not required')
+    def header = args.containsKey('header') ? args.header : ''
     def credentialId = args.containsKey('credentialId') ? args.credentialId : error('notifySlack: credentialId parameter is not required')
 
     if (enabled) {
@@ -263,6 +265,7 @@ def notifySlack(Map args = [:]) {
         def statusSuccess = (buildStatus == "SUCCESS")
         def boURL = getBlueoceanDisplayURL()
         def body = buildTemplate([
+          "header": header,
           "template": 'slack-markdown.template',
           "build": build,
           "buildStatus": buildStatus,

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -431,6 +431,26 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_with_header() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifySlack(
+      build: readJSON(file: "build-info-manual.json"),
+      buildStatus: "SUCCESS",
+      changeSet: readJSON(file: "changeSet-info-manual.json"),
+      stepsErrors: readJSON(file: "steps-errors.json"),
+      testsErrors: readJSON(file: "tests-errors.json"),
+      testsSummary: readJSON(file: "tests-summary.json"),
+      header: '*Header*: this is a header',
+      channel: 'test',
+      credentialId: 'test',
+      enabled: true
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('slackSend', '*Header*: this is a header'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_analyzeFlakey_in_prs_without_flaky_tests() throws Exception {
     def script = loadScript(scriptName)
     helper.registerAllowedMethod(

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -33,6 +33,9 @@ the flakey test analyser.
   // Notify build status for a PR as a GitHub comment, and send slack message if build failed
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel')
 
+  // Notify build status for a PR as a GitHub comment, and send slack message with custom header
+  notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel', slackHeader: '*Header*: this is a header')
+
 **/
 
 import co.elastic.BuildException
@@ -56,6 +59,7 @@ def call(Map args = [:]) {
       def to = args.containsKey('to') ? args.to : customisedEmail(env.NOTIFY_TO)
       def statsURL = args.containsKey('statsURL') ? args.statsURL : "https://ela.st/observabtl-ci-stats"
       def shouldNotify = args.containsKey('shouldNotify') ? args.shouldNotify : !isPR() && currentBuild.currentResult != "SUCCESS"
+      def slackHeader = args.containsKey('slackHeader') ? args.slackHeader : ''
       def slackChannel = args.containsKey('slackChannel') ? args.slackChannel : env.SLACK_CHANNEL
       def slackNotify = args.containsKey('slackNotify') ? args.slackNotify : !isPR() && currentBuild.currentResult != "SUCCESS"
       def slackCredentials = args.containsKey('slackCredentials') ? args.slackCredentials : 'jenkins-slack-integration-token'
@@ -96,6 +100,7 @@ def call(Map args = [:]) {
 
         // Should notify in slack if it's enabled
         if(notifySlackComment) {
+          data['header'] = slackHeader
           data['channel'] = slackChannel
           data['credentialId'] = slackCredentials
           data['enabled'] = slackNotify

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -15,6 +15,9 @@ the flakey test analyser.
   // Notify build status for a PR as a GitHub comment, and send slack message if build failed
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel')
 
+  // Notify build status for a PR as a GitHub comment, and send slack message with custom header
+  notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel', slackHeader: '*Header*: this is a header')
+
 ```
 * es: Elasticserach URL to send the report.
 * secret: vault secret used to access to Elasticsearch, it should have `user` and `password` fields.
@@ -24,6 +27,7 @@ the flakey test analyser.
 emails on Failed builds that are not pull request.
 * prComment: Whether to add a comment in the PR with the build summary as a comment. Default: `true`.
 * slackComment: Whether to send a message in slack with the build summary as a comment. Default: `false`.
+* slackHeader: What header to be added before the default comment. Default value uses ``.
 * slackChannel: What slack channel. Default value uses `env.SLACK_CHANNEL`.
 * slackCredentials: What slack credentials to be used. Default value uses `jenkins-slack-integration-token`.
 * slackNotify: Whether to send or not the slack notifications, by default it sends notifications on Failed builds that are not pull request.


### PR DESCRIPTION
## What does this PR do?
It adds a `slackHeader` parameter to the `notifyBuildResult`, creating a unit test verifying that the template engine renders the header if it's passed to the script.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It will allow client code to add a custom header to a Slack message

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #783

## Security concerns
Could an attacker inject a string that will be rendered to display secrets, like environment? I'd like to hear your voice before merging it