### PR TITLE
[test-infra] gh not validated on Windows

### DIFF
--- a/test-infra/apm-ci/test_windows.py
+++ b/test-infra/apm-ci/test_windows.py
@@ -1,5 +1,4 @@
 import testinfra
-import pytest
 
 def test_dotnet_installed(host):
   cmd = host.run("dotnet --info")
@@ -12,10 +11,3 @@ def test_python_installed(host):
 def test_tar_installed(host):
   cmd = host.run("tar --version")
   assert cmd.rc == 0, "it is required for the stashV2 and unstashV2 steps"
-
-def test_gh_installed(host):
-  if host.environment().get('ProgramFiles(x86)') :
-    cmd = host.run("gh --version")
-    assert cmd.rc == 0, "it is required for the notifyBuildReport"
-  else :
-    pytest.skip("unsupported configuration")

--- a/test-infra/apm-ci/test_windows.py
+++ b/test-infra/apm-ci/test_windows.py
@@ -14,7 +14,7 @@ def test_tar_installed(host):
   assert cmd.rc == 0, "it is required for the stashV2 and unstashV2 steps"
 
 def test_gh_installed(host):
-  if host.system_info.arch == "x86_64" :
+  if host.environment().get('ProgramFiles(x86)') :
     cmd = host.run("gh --version")
     assert cmd.rc == 0, "it is required for the notifyBuildReport"
   else :

--- a/test-infra/beats-ci/test_beats_windows.py
+++ b/test-infra/beats-ci/test_beats_windows.py
@@ -2,7 +2,7 @@ import testinfra
 import pytest
 
 def test_gh_installed(host):
-  if host.system_info.arch == "x86_64" :
+  if host.environment().get('ProgramFiles(x86)') :
     cmd = host.run("gh --version")
     assert cmd.rc == 0, "it is required for the notifyBuildReport"
   else :

--- a/test-infra/beats-ci/test_beats_windows.py
+++ b/test-infra/beats-ci/test_beats_windows.py
@@ -1,12 +1,4 @@
 import testinfra
-import pytest
-
-def test_gh_installed(host):
-  if host.environment().get('ProgramFiles(x86)') :
-    cmd = host.run("gh --version")
-    assert cmd.rc == 0, "it is required for the notifyBuildReport"
-  else :
-    pytest.skip("unsupported configuration")
 
 def test_make_installed(host):
   cmd = host.run("make --version")


### PR DESCRIPTION
## What does this PR do?

Avoid running gh validation on Windows since we don't need it for the `notifyBuildResult`


## Obsoleted

Initially though to support it with test-infra way of doing, but windows is a kind of special though 

```
[2020-10-22T10:55:00.024Z]     def test_gh_installed(host):
[2020-10-22T10:55:00.024Z] >     if host.system_info.arch == "x86_64" :
[2020-10-22T10:55:00.024Z] E     AttributeError: 'SystemInfo' object has no attribute 'arch'
```

`environment` for windows

```
[2020-10-22T12:19:32.356Z]     def __call__(self):
[2020-10-22T12:19:32.356Z]         ret_val = dict(
[2020-10-22T12:19:32.356Z] >           i.split('=', 1) for i in self.check_output('env -0').split(
[2020-10-22T12:19:32.356Z]                 '\x00') if i
[2020-10-22T12:19:32.356Z]         )
[2020-10-22T12:19:32.356Z] E       AssertionError: Unexpected exit code 1 for CommandResult(command='env -0', exit_status=1, stdout=None, stderr="'env' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n")
[2020-10-22T12:19:32.356Z] E       assert 1 == 0
[2020-10-22T12:19:32.356Z] E         -1
[2020-10-22T12:19:32.356Z] E         +0
```