### PR TITLE
[flaky] report genuine test failures

### DIFF
--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -1,7 +1,7 @@
-<% if(tests) {%>
+<% if(flakyTests) {%>
 ## :bug: Flaky test report
 :snowflake: The following tests failed but also have a history of flakiness and may not be related to this change: 
-    <% tests?.each{ k,v -> %>
+    <% flakyTests?.each{ k,v -> %>
 * **Name**: `${k}` ${ (v?.trim()) ? "reported in the issue #" + v : 'has not been reported yet.'}<%}%>
 <%} else if (testsSummary?.failed > 0) {%>
 ## :bug: Flaky test report
@@ -14,6 +14,9 @@ Tests succeeded.
 No test was executed to be analysed.
 <%}%>
 <% if(testsSummary?.total > 0) {%>
+<!-- BUILD SUMMARY-->
+<details><summary>Expand to view the summary</summary>
+<p>
 ### Test stats :test_tube:
 | Test         | Results                         |
 | ------------ | :-----------------------------: |
@@ -22,3 +25,12 @@ No test was executed to be analysed.
 | Skipped      | ${(testsSummary?.skipped) ?: 0} |
 | Total        | ${(testsSummary?.total) ?: 0}   |
 <%}%>
+
+<% if(!testsErrors?.isEmpty()) {%>
+### Genuine test errors [![${testsErrors?.size()}](https://img.shields.io/badge/${testsErrors?.size()}%20-red)](${jobUrl}/tests)
+:broken_heart: There are test failures but not known flaky tests, most likely a genuine test failure.
+<%   testsErrors?.each {%>* **Name**: `${it}`<%}%>
+<%}%>
+
+</p>
+</details>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -462,11 +462,12 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     script.analyzeFlakey(
       flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
       es: "https://fake_url",
-      testsErrors: readJSON(file: 'flake-tests-errors.json'),
+      testsErrors: readJSON(file: 'flake-tests-errors-without-match.json'),
       testsSummary: readJSON(file: 'flake-tests-summary.json')
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are test failures but not known flaky tests."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "Genuine test errors [![1]"))
     assertJobStatusSuccess()
   }
 

--- a/src/test/resources/flake-tests-errors-without-match.json
+++ b/src/test/resources/flake-tests-errors-without-match.json
@@ -1,0 +1,12 @@
+[
+    {
+      "age": 1,
+      "duration": 0,
+      "errorDetails": "collection failure",
+      "errorStackTrace": "My superduper stacktrace",
+      "id": "io.jenkins.blueocean.service.embedded.rest.junit.BlueJUnitTestResult:%3Ajunit%2F(root)%2F(empty)%2FTest___Python_python_3_7_2___",
+      "name": "Test / windows-3.6-none / test_send - notfound",
+      "status": "FAILED"
+    }
+]
+  


### PR DESCRIPTION
## What does this PR do?

Collapse further reporting.
Report `genuine` test failures, aka those failures that were not reported as flaky

## Why is it important?

Help to categorise

## Test

For instance, the below comment when no flaky tests but test failures
```
## :bug: Flaky test report
:grey_exclamation: There are test failures but not known flaky tests.


<!-- BUILD SUMMARY-->
<details><summary>Expand to view the summary</summary>
<p>
### Test stats :test_tube:
| Test         | Results                         |
| ------------ | :-----------------------------: |
| Failed       | 1  |
| Passed       | 120  |
| Skipped      | 0 |
| Total        | 121   |



### Genuine test errors [![1](https://img.shields.io/badge/1%20-red)](http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1//tests)
:broken_heart: There are test failures but not known flaky tests, most likely a genuine test failure.
* **Name**: `Test / windows-3.6-none / test_send - notfound`


</p>
</details}
```