### PR TITLE
Fix cache for GH comments

### DIFF
--- a/vars/githubPrComment.groovy
+++ b/vars/githubPrComment.groovy
@@ -83,7 +83,7 @@ def addComment(String details) {
     def comment = pullRequest.comment(details)
     id = comment?.id
   } catch (err) {
-    log(level: 'DEBUG', text: "githubPrComment: pullRequest.comment failed with message: ${err.toString()}")
+    log(level: 'WARN', text: "githubPrComment: pullRequest.comment failed with message: ${err.toString()}")
     id = githubTraditionalPrComment(message: details)
   }
   return id

--- a/vars/githubTraditionalPrComment.groovy
+++ b/vars/githubTraditionalPrComment.groovy
@@ -47,7 +47,7 @@ def call(Map args = [:]){
     }
     // Ensure the data is transformed to Json and then toString.
     def transformedData = JsonOutput.toJson([ "body": "${message}" ])
-    def comment = githubApiCall(token: token, url: url, data: transformedData, method: method)
+    def comment = githubApiCall(token: token, url: url, data: transformedData, method: method, noCache: true)
     return comment.id
   } else {
     log(level: 'WARN', text: 'githubTraditionalPrComment: is only available for PRs.')


### PR DESCRIPTION
## What does this PR do?

Since today I suddenly see the GitHub comments for the elastic/beats.git to miss one of the comments for some reason :_(

Not sure if that's related to the recent beats-ci reboot or upgrade of the plugins

## Root cause

The `pr` object failed when creating the comment and therefore it fall back to the traditional GH comment approach using the API calls which doesn't use the `noCache` flag 

```
18:06:21  [DEBUG] githubPrComment: pullRequest.comment failed with message: java.io.UncheckedIOException: org.eclipse.egit.github.core.client.RequestException: Resource not accessible by integration (403)
```

## Why is it important?

To restart the GH PR comments as used to be

## Related issues

https://github.com/elastic/apm-pipeline-library/pull/776 fixed one of the use cases and it worked until sometime today :/ . So my guess is something has changed with the last night restart of `beats-ci`

See https://github.com/elastic/beats/pull/22240 where the Build status comments is not shown (the screenshot represents the view of the above-mentioned PR)

![image](https://user-images.githubusercontent.com/2871786/97486296-2776a900-1953-11eb-8e80-efe0be0da988.png)

