### PR TITLE
GH comment with links to the the entire logs and cosmetic changes

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -57,12 +57,11 @@
     ${(testsSummary?.failed > 10) ? '> Show only the first 10 test failures' : ''}
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
 * **Name**: `${test?.name}`
+<% age = "* Age: ${test?.age}"%>
 <% duration = (test?.duration >= 0 ) ? "(took ${Math.round(test.duration/1000/60)} min ${Math.round(test.duration/1000)%60} sec)" : ''%>
-<% errorDetails = (test?.errorDetails?.trim() && !test?.errorDetails.equals('null')) ? "* Error Details: ${test?.errorDetails}" : ''%>
-<% errorStackTrace = (test?.errorStackTrace?.trim() && !test?.errorStackTrace.equals('null')) ? "* Error Stacktrace: ${test?.errorStackTrace}" : ''%>
-  * Age: ${test?.age} ${duration}
-  ${errorDetails}
-  ${errorStackTrace}
+<% errorDetails = (test?.errorDetails?.trim() && !test?.errorDetails.equals('null')) ? "\n  * Error Details: ${test?.errorDetails}" : ''%>
+<% errorStackTrace = (test?.errorStackTrace?.trim() && !test?.errorStackTrace.equals('null')) ? "\n  * Error Stacktrace: ${test?.errorStackTrace}" : ''%>
+  ${age} ${duration} ${errorDetails} ${errorStackTrace}
     <%}%>
   </p>
   </details>
@@ -76,7 +75,7 @@
   <p>
   ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
   <% stepsErrors?.take(10)?.each{ c -> %>
-  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "* Description: ${c?.displayDescription}" : ''%>
+  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "* Description: `${c?.displayDescription}`" : ''%>
   <% duration = (c?.durationInMillis >= 0 ) ? "(took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec)" : ''%>
   <% url = (c?.url && c?.url != 'null') ? ". View log details on [here](${c?.url}/?start=0)" : ''%>
   * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}` ${duration} ${url}

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -58,7 +58,7 @@
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
 * **Name**: `${test?.name}`
 <% age = "* Age: ${test?.age}"%>
-<% duration = (test?.duration >= 0 ) ? "(took ${Math.round(test.duration/1000/60)} min ${Math.round(test.duration/1000)%60} sec)" : ''%>
+<% duration = (test?.duration >= 0 ) ? "(took ${test.duration} sec)" : ''%>
 <% errorDetails = (test?.errorDetails?.trim() && !test?.errorDetails.equals('null')) ? "\n  * Error Details: ${test?.errorDetails}" : ''%>
 <% errorStackTrace = (test?.errorStackTrace?.trim() && !test?.errorStackTrace.equals('null')) ? "\n  * Error Stacktrace: ${test?.errorStackTrace}" : ''%>
   ${age} ${duration} ${errorDetails} ${errorStackTrace}

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -57,9 +57,12 @@
     ${(testsSummary?.failed > 10) ? '> Show only the first 10 test failures' : ''}
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
 * **Name**: `${test?.name}`
-  * Age: ${test?.age}
-  * Duration: ${test?.duration}
-  * Error Details: ${test?.errorDetails}
+<% duration = (test?.duration >= 0 ) ? "(took ${Math.round(test.duration/1000/60)} min ${Math.round(test.duration/1000)%60} sec)" : ''%>
+<% errorDetails = (test?.errorDetails?.trim() && !test?.errorDetails.equals('null')) ? "* Error Details: ${test?.errorDetails}" : ''%>
+<% errorStackTrace = (test?.errorStackTrace?.trim() && !test?.errorStackTrace.equals('null')) ? "* Error Stacktrace: ${test?.errorStackTrace}" : ''%>
+  * Age: ${test?.age} ${duration}
+  ${errorDetails}
+  ${errorStackTrace}
     <%}%>
   </p>
   </details>
@@ -73,15 +76,11 @@
   <p>
   ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
   <% stepsErrors?.take(10)?.each{ c -> %>
-  * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}`
-    * Description: ${c?.displayDescription && c?.displayDescription != 'null' ? c?.displayDescription : ''}
-    <% if(c?.durationInMillis >= 0) {%>
-    * Duration: ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec
-    <%}%>
-    * Start Time: ${c?.startTime && c?.startTime != 'null' ? c?.startTime : ''}
-    <% if(c?.url && c?.url != 'null') {%>
-    * [log](${c?.url})
-    <%}%>
+  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "* Description: ${c?.displayDescription}" : ''%>
+  <% duration = (c?.durationInMillis >= 0 ) ? "(took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec)" : ''%>
+  <% url = (c?.url && c?.url != 'null') ? ". View log details on [here](${c?.url}/?start=0)" : ''%>
+  * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}` ${duration} ${url}
+    ${description}
   <%}%>
   </p>
   </details>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -57,12 +57,9 @@
     ${(testsSummary?.failed > 10) ? '> Show only the first 10 test failures' : ''}
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
 * **Name**: `${test?.name}`
-<% duration = (test?.duration >= 0 ) ? "(took ${Math.round(test.duration/1000/60)} min ${Math.round(test.duration/1000)%60} sec)" : ''%>
-<% errorDetails = (test?.errorDetails?.trim() && !test?.errorDetails.equals('null')) ? "* Error Details: ${test?.errorDetails}" : ''%>
-<% errorStackTrace = (test?.errorStackTrace?.trim() && !test?.errorStackTrace.equals('null')) ? "* Error Stacktrace: ${test?.errorStackTrace}" : ''%>
-  * Age: ${test?.age} ${duration}
-  ${errorDetails}
-  ${errorStackTrace}
+  * Age: ${test?.age}
+  * Duration: ${test?.duration}
+  * Error Details: ${test?.errorDetails}
     <%}%>
   </p>
   </details>
@@ -76,11 +73,15 @@
   <p>
   ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
   <% stepsErrors?.take(10)?.each{ c -> %>
-  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "* Description: ${c?.displayDescription}" : ''%>
-  <% duration = (c?.durationInMillis >= 0 ) ? "(took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec)" : ''%>
-  <% url = (c?.url && c?.url != 'null') ? ". View log details on [here](${c?.url}/?start=0)" : ''%>
-  * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}` ${duration} ${url}
-    ${description}
+  * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}`
+    * Description: ${c?.displayDescription && c?.displayDescription != 'null' ? c?.displayDescription : ''}
+    <% if(c?.durationInMillis >= 0) {%>
+    * Duration: ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec
+    <%}%>
+    * Start Time: ${c?.startTime && c?.startTime != 'null' ? c?.startTime : ''}
+    <% if(c?.url && c?.url != 'null') {%>
+    * [log](${c?.url})
+    <%}%>
   <%}%>
   </p>
   </details>


### PR DESCRIPTION
## What does this PR do?

- BO links don't show all the logs for a given step if the logs are massive, for such it's required to use `/?start=0`
- On the other hand, I took the chance to aggregate the duration, logs within the name section.
- Add `errorStackTrace` for the failed tests.
- Remove `startTime` for the failed steps.
- Remove empty lines when fields are empty. 

## Why is it important?

People should not use the CI UI by default, but the BO links.
@SergeyKleyman reported this issue

## Screenshots

- Using the UI tests

| PROPOSAL | CURRENT |
|------------|------------|
|![image](https://user-images.githubusercontent.com/2871786/97857729-17b1e880-1cf6-11eb-9ac0-b1051bc9e238.png)|![image](https://user-images.githubusercontent.com/2871786/97858146-a0c91f80-1cf6-11eb-94e2-778c5b091c64.png)


