### PR TITLE
feat: support passing a comma-separated list of slack channels

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -275,9 +275,9 @@ def notifySlack(Map args = [:]) {
     def testsErrors = args.containsKey('testsErrors') ? args.testsErrors : []
     def testsSummary = args.containsKey('testsSummary') ? args.testsSummary : null
     def enabled = args.get('enabled', false)
-    def channel = args.containsKey('channel') ? args.channel : error('notifySlack: channel parameter is not required')
+    def channel = args.containsKey('channel') ? args.channel : error('notifySlack: channel parameter is required')
     def header = args.containsKey('header') ? args.header : ''
-    def credentialId = args.containsKey('credentialId') ? args.credentialId : error('notifySlack: credentialId parameter is not required')
+    def credentialId = args.containsKey('credentialId') ? args.credentialId : error('notifySlack: credentialId parameter is required')
 
     if (enabled) {
       catchError(buildResult: 'SUCCESS', message: 'notifySlack: Error with the slack comment') {

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -302,8 +302,10 @@ def notifySlack(Map args = [:]) {
         ])
         def color = (buildStatus == "SUCCESS") ? 'good' : 'warning'
         channel.split(',').each { chan ->
-          chan = chan?.trim()
-          slackSend(channel: chan, color: color, message: "${body}", tokenCredentialId: credentialId)
+          if (chan?.trim()) {
+            // only send to slack when the channel is valid
+            slackSend(channel: chan?.trim(), color: color, message: "${body}", tokenCredentialId: credentialId)
+          }
         }
       }
     }

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -301,7 +301,10 @@ def notifySlack(Map args = [:]) {
           "testsSummary": testsSummary
         ])
         def color = (buildStatus == "SUCCESS") ? 'good' : 'warning'
-        slackSend(channel: channel, color: color, message: "${body}", tokenCredentialId: credentialId)
+        channel.split(',').each { chan ->
+          chan = chan?.trim()
+          slackSend(channel: chan, color: color, message: "${body}", tokenCredentialId: credentialId)
+        }
       }
     }
 }

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -451,6 +451,50 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_without_build() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        buildStatus: "ABORTED",
+        changeSet: readJSON(file: "changeSet-info.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        channel: 'test',
+        credentialId: 'test',
+        enabled: true
+      )
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'notifySlack: build parameter it is not valid'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_notify_slack_without_build_status() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        build: readJSON(file: "build-info.json"),
+        changeSet: readJSON(file: "changeSet-info.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        channel: 'test',
+        credentialId: 'test',
+        enabled: true
+      )
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'notifySlack: buildStatus parameter is not valid'))
+    assertJobStatusFailure()
+  }
+
+  @Test
   void test_notify_slack_without_channel() throws Exception {
     def script = loadScript(scriptName)
     try {

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -498,6 +498,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('log', 'notifySlack: Error with the slack comment'))
+    assertTrue(assertMethodCallOccurrences('slackSend', 0))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -451,6 +451,50 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_without_channel() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        build: readJSON(file: "build-info.json"),
+        buildStatus: "ABORTED",
+        changeSet: readJSON(file: "changeSet-info.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        credentialId: 'test',
+        enabled: true
+      )
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'notifySlack: channel parameter is required'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_notify_slack_without_credentialId() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        build: readJSON(file: "build-info.json"),
+        buildStatus: "ABORTED",
+        changeSet: readJSON(file: "changeSet-info.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        channel: 'test',
+        enabled: true
+      )
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'notifySlack: credentialId parameter is required'))
+    assertJobStatusFailure()
+  }
+
+  @Test
   void test_analyzeFlakey_in_prs_without_flaky_tests() throws Exception {
     def script = loadScript(scriptName)
     helper.registerAllowedMethod(

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -451,6 +451,33 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_with_multiple_channels() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        build: readJSON(file: "build-info-manual.json"),
+        buildStatus: "SUCCESS",
+        changeSet: readJSON(file: "changeSet-info-manual.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        channel: 'foo, bar, baaz',
+        credentialId: 'test',
+        enabled: true
+      )
+    }
+    catch(e) {
+      println e
+    }
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('log', 'notifySlack: Error with the slack comment'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=foo'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=bar'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=baaz'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_slack_without_build() throws Exception {
     def script = loadScript(scriptName)
     try {

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -478,6 +478,30 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_with_multiple_wrong_channels() throws Exception {
+    def script = loadScript(scriptName)
+    try {
+      script.notifySlack(
+        build: readJSON(file: "build-info-manual.json"),
+        buildStatus: "SUCCESS",
+        changeSet: readJSON(file: "changeSet-info-manual.json"),
+        stepsErrors: readJSON(file: "steps-errors.json"),
+        testsErrors: readJSON(file: "tests-errors.json"),
+        testsSummary: readJSON(file: "tests-summary.json"),
+        channel: ',', // valid for the iterator but not for valid channels
+        credentialId: 'test',
+        enabled: true
+      )
+    }
+    catch(e) {
+      println e
+    }
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('log', 'notifySlack: Error with the slack comment'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_slack_without_build() throws Exception {
     def script = loadScript(scriptName)
     try {

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -33,6 +33,9 @@ the flakey test analyser.
   // Notify build status for a PR as a GitHub comment, and send slack message if build failed
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel')
 
+  // Notify build status for a PR as a GitHub comment, and send slack message to multiple channels if build failed
+  notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel, #other-channel')
+ 
   // Notify build status for a PR as a GitHub comment, and send slack message with custom header
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel', slackHeader: '*Header*: this is a header')
 

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -15,6 +15,9 @@ the flakey test analyser.
   // Notify build status for a PR as a GitHub comment, and send slack message if build failed
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel')
 
+  // Notify build status for a PR as a GitHub comment, and send slack message to multiple channels if build failed
+  notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel, #other-channel')
+
   // Notify build status for a PR as a GitHub comment, and send slack message with custom header
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel', slackHeader: '*Header*: this is a header')
 


### PR DESCRIPTION
## What does this PR do?
It adds support for receiving a comma-separated list of slack channels in the `channel` attribute of the `notifyBuildResult` step.

It also increases the code coverage, adding tests checking for the existence of certain attributes of the notifyToSlack method.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It will allow client pipelines to send messages to multiple channels if desired.

We avoided using `log` in tests, but checking that `slackSend` was invoked. This is important in the sense that we discovered an internal conflict with the `log` step, which seems a reserved key in the unit test library used for mocking Jenkins.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #793