### PR TITLE
Fix git diff for first builds in branches

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -300,6 +300,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('powershell', [Map.class], null)
     helper.registerAllowedMethod('powershell', [String.class], null)
     helper.registerAllowedMethod('pwd', [Map.class], { 'folder' })
+    helper.registerAllowedMethod('readFile', [String.class], { '' })
     helper.registerAllowedMethod('readFile', [Map.class], { '' })
     helper.registerAllowedMethod('readJSON', [Map.class], { m ->
       return readJSON(m)

--- a/src/test/groovy/BeatsWhenStepTests.groovy
+++ b/src/test/groovy/BeatsWhenStepTests.groovy
@@ -195,6 +195,20 @@ class BeatsWhenStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_whenChangeset_branch_first_build() throws Exception {
+    env.remove('GIT_PREVIOUS_COMMIT')
+    env.remove('CHANGE_TARGET')
+    env.GIT_BASE_COMMIT = 'bar'
+    def script = loadScript(scriptName)
+    def changeset = 'Jenkinsfile'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenChangeset(content: [ changeset: ['^Jenkinsfile']])
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('sh', 'bar...bar'))
+  }
+
+  @Test
   void test_whenComments_and_no_environment_variable() throws Exception {
     def script = loadScript(scriptName)
     def ret = script.whenComments()

--- a/src/test/groovy/GetGitMatchingGroupStepTests.groovy
+++ b/src/test/groovy/GetGitMatchingGroupStepTests.groovy
@@ -67,6 +67,8 @@ metricbeat/module/zookeeper/server/_meta/docs.asciidoc'''.stripMargin().stripInd
     def script = loadScript(scriptName)
     def result = true
     env.remove('CHANGE_TARGET')
+    env.remove('GIT_PREVIOUS_COMMIT')
+    env.remove('GIT_BASE_COMMIT')
     def module = script.call(pattern: 'foo')
     printCallStack()
     assertEquals('', module)
@@ -177,8 +179,10 @@ bar/foo/subfolder'''.stripMargin().stripIndent()
   }
 
   @Test
-  void test_with_empty_change_target_env_variable() throws Exception {
+  void test_with_empty_change_target_env_variable_use_git_base_commit() throws Exception {
     env.CHANGE_TARGET = " "
+    env.GIT_PREVIOUS_COMMIT = " "
+    env.GIT_BASE_COMMIT = 'bar'
     def script = loadScript(scriptName)
     def changeset = 'foo/anotherfolder/file.txt'
     helper.registerAllowedMethod('readFile', [String.class], { return changeset })
@@ -187,7 +191,7 @@ bar/foo/subfolder'''.stripMargin().stripIndent()
     })
     def module = script.call(pattern: 'foo')
     printCallStack()
-    assertEquals('', module)
+    assertTrue(assertMethodCallContainsPattern('sh', 'bar...bar'))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/GetGitMatchingGroupStepTests.groovy
+++ b/src/test/groovy/GetGitMatchingGroupStepTests.groovy
@@ -524,4 +524,18 @@ x-pack/auditbeat/module/system/fields.go'''.stripMargin().stripIndent()
     def directoryExclussion = "((?!^${transformedDirectory}\\/).)*\$"
     return "^(${directoryExclussion}|((?!\\/module\\/).)*\$|.*\\.asciidoc|.*\\.png)"
   }
+
+  @Test
+  void test_branch_first_build() throws Exception {
+    env.remove('GIT_PREVIOUS_COMMIT')
+    env.remove('CHANGE_TARGET')
+    env.GIT_BASE_COMMIT = 'bar'
+    def script = loadScript(scriptName)
+    def changeset = 'foo/bar/file.txt'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def module = script.call(pattern: '([^\\/]+)\\/.*')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'bar...bar'))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/groovy/IsGitRegionMatchStepTests.groovy
+++ b/src/test/groovy/IsGitRegionMatchStepTests.groovy
@@ -62,10 +62,22 @@ class IsGitRegionMatchStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     def result = true
     env.remove('CHANGE_TARGET')
+    env.remove('GIT_BASE_COMMIT')
     result = script.call(patterns: [ 'foo' ])
     printCallStack()
     assertFalse(result)
     assertTrue(assertMethodCallContainsPattern('echo', 'isGitRegionMatch: CHANGE_TARGET or GIT_PREVIOUS_COMMIT and GIT_BASE_COMMIT env variables are required to evaluate the changes.'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_without_change_target_use_git_base_commit() throws Exception {
+    def script = loadScript(scriptName)
+    env.GIT_BASE_COMMIT = 'bar'
+    env.remove('CHANGE_TARGET')
+    script.call(patterns: [ 'foo' ])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'bar...bar'))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/IsGitRegionMatchStepTests.groovy
+++ b/src/test/groovy/IsGitRegionMatchStepTests.groovy
@@ -303,4 +303,20 @@ class IsGitRegionMatchStepTests extends ApmBasePipelineTest {
     assertTrue(result)
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_branch_first_build() throws Exception {
+    env.remove('GIT_PREVIOUS_COMMIT')
+    env.remove('CHANGE_TARGET')
+    env.GIT_BASE_COMMIT = 'bar'
+    def script = loadScript(scriptName)
+    def changeset = 'file.txt'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def result = false
+    result = script.call(patterns: [ '^file.txt' ])
+    printCallStack()
+    assertTrue(result)
+    assertTrue(assertMethodCallContainsPattern('sh', 'bar...bar'))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -467,7 +467,7 @@ evaluates the change list and returns the module name.
 
 * pattern: the regex pattern with the group to look for. Mandatory
 * exclude: the regex pattern with the files to be excluded from the search. Optional
-* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET} otherwise env.GIT_PREVIOUS_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET} otherwise env.GIT_PREVIOUS_COMMIT or GIT_BASE_COMMMIT if the very first build
 * to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
 
 **NOTE**: This particular implementation requires to checkout with the step `gitCheckout`
@@ -1229,7 +1229,7 @@ evaluates the change list with the pattern list:
 
 * patterns: list of patterns to be matched. Mandatory
 * shouldMatchAll: whether all the elements in the patterns should match with all the elements in the changeset. Default: false. Optional
-* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT or GIT_BASE_COMMMIT if the very first build
 * to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
 
 NOTE: This particular implementation requires to checkout with the step gitCheckout
@@ -1605,6 +1605,9 @@ the flakey test analyser.
 
   // Notify build status for a PR as a GitHub comment, and send slack message if build failed
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel')
+
+  // Notify build status for a PR as a GitHub comment, and send slack message to multiple channels if build failed
+  notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel, #other-channel')
 
   // Notify build status for a PR as a GitHub comment, and send slack message with custom header
   notifyBuildResult(prComment: true, slackComment: true, slackChannel: '#my-channel', slackHeader: '*Header*: this is a header')

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -98,7 +98,8 @@ private Boolean whenChangeset(Map args = [:]) {
 
     // Gather the diff between the target branch and the current commit.
     def gitDiffFile = 'git-diff.txt'
-    def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT
+    // On branches with a very first build then GIT_PREVIOUS_COMMIT is empty, let's fallback to the GIT_BASE_COMMIT
+    def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
     sh(script: "git diff --name-only ${from}...${env.GIT_BASE_COMMIT} > ${gitDiffFile}", returnStdout: true)
 
     // Search for any pattern that matches that particular

--- a/vars/getGitMatchingGroup.groovy
+++ b/vars/getGitMatchingGroup.groovy
@@ -37,7 +37,7 @@
 def call(Map params = [:]) {
   def pattern = params.containsKey('pattern') ? params.pattern : error('getGitMatchingGroup: Missing pattern argument.')
   def exclude = params.get('exclude', '')
-  def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)
+  def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}")
   def to = params.get('to', env.GIT_BASE_COMMIT)
 
   def gitDiffFile = 'git-diff.txt'

--- a/vars/getGitMatchingGroup.txt
+++ b/vars/getGitMatchingGroup.txt
@@ -18,7 +18,7 @@ evaluates the change list and returns the module name.
 
 * pattern: the regex pattern with the group to look for. Mandatory
 * exclude: the regex pattern with the files to be excluded from the search. Optional
-* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET} otherwise env.GIT_PREVIOUS_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET} otherwise env.GIT_PREVIOUS_COMMIT or GIT_BASE_COMMMIT if the very first build
 * to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
 
 **NOTE**: This particular implementation requires to checkout with the step `gitCheckout`

--- a/vars/isGitRegionMatch.groovy
+++ b/vars/isGitRegionMatch.groovy
@@ -36,7 +36,7 @@ def call(Map params = [:]) {
   }
   def patterns = params.containsKey('patterns') ? params.patterns.toList() : error('isGitRegionMatch: Missing patterns argument.')
   def shouldMatchAll = params.get('shouldMatchAll', false)
-  def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : env.GIT_PREVIOUS_COMMIT)
+  def from = params.get('from', env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}")
   def to = params.get('to', env.GIT_BASE_COMMIT)
 
   if (patterns.isEmpty()) {

--- a/vars/isGitRegionMatch.txt
+++ b/vars/isGitRegionMatch.txt
@@ -28,7 +28,7 @@ evaluates the change list with the pattern list:
 
 * patterns: list of patterns to be matched. Mandatory
 * shouldMatchAll: whether all the elements in the patterns should match with all the elements in the changeset. Default: false. Optional
-* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT
+* from: to override the diff from sha. Optional. If MPB, and PR then origin/${env.CHANGE_TARGET otherwise env.GIT_PREVIOUS_COMMIT or GIT_BASE_COMMMIT if the very first build
 * to: to override the commit to. Optional. Default: env.GIT_BASE_COMMIT
 
 NOTE: This particular implementation requires to checkout with the step gitCheckout


### PR DESCRIPTION
## What does this PR do?

Fix a corner case with a branch running for the very first time since the env variables are unset

## Why is it important?

Otherwise it won't work

Fixes

![image](https://user-images.githubusercontent.com/2871786/98005607-275e2980-1de9-11eb-8864-84a3e31a038e.png)

![image](https://user-images.githubusercontent.com/2871786/98005635-2f1dce00-1de9-11eb-9868-439261261723.png)


[build](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats%2F6.8/detail/6.8/2/pipeline/147#step-70-log-1)

## Related issues
Relates https://github.com/elastic/apm-pipeline-library/pull/298