### PR TITLE
[dependabot] Enable for maven and docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+---
+version: 2
+updates:
+  # Enable version updates for maven
+  - package-ecosystem: "maven"
+    # Look for `pom.xml` file in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.ci/docker/apache-ant"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.ci/docker/codecov"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.ci/docker/gren"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.ci/docker/shellcheck"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.ci/docker/yammlint"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/local"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots"


### PR DESCRIPTION
## What does this PR do?

Enable dependabot on a weekly basis to monitor maven and docker dependencies

## Why is it important?

Dependabot is now an official service from GitHub.

See https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-dependabot-version-updates