### PR TITLE
Add docker build for bandstand orch

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -58,6 +58,7 @@ pipeline {
     booleanParam(name: 'testPlans', defaultValue: "false", description: "Test Plans app")
     booleanParam(name: 'heartbeat', defaultValue: "false", description: "Heartbeat to monitor Jenkins jobs")
     booleanParam(name: 'apm_proxy', defaultValue: "false", description: "APM proxy [https://github.com/elastic/observability-dev/tree/master/tools/apm-proxy]")
+    booleanParam(name: 'load_orch', defaultValue: "false", description: "Load testing orchestrator [https://github.com/elastic/observability-dev/tree/master/apps/automation/bandstand]")
   }
   stages {
     stage('Cache Weblogic Docker Image'){
@@ -368,6 +369,26 @@ pipeline {
           tag: "apm-proxy-be",
           version: "latest",
           folder: "tools/apm_proxy/backend",
+          push: true
+        )
+      }
+    }
+    stage('Build load-test orchestrator'){
+      options {
+        skipDefaultCheckout()
+      }
+      when{
+        beforeAgent true
+        expression { return params.load_orch}
+      }
+      steps{
+        deleteDir()
+        dockerLoginElasticRegistry()
+        buildDockerImage(
+          repo: 'https://github.com/elastic/observability-dev',
+          tag: "bandstand",
+          version: "latest",
+          folder: "apps/automation/bandstand",
           push: true
         )
       }


### PR DESCRIPTION
## What does this PR do?

Adds the ability to build and push a Docker image for the [Bandstand project](https://github.com/elastic/observability-dev/tree/master/apps/automation/bandstand) which orchestrates load tests for APM agents.
## Why is it important?

Part of the deployment which will live in Elastic Apps.

## Related issues
Refs: https://github.com/elastic/observability-robots/issues/255
