### PR TITLE
[cosmetic] simplify test errors report

### DIFF
--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -31,8 +31,8 @@ No test was executed to be analysed.
 <% if(!testsErrors?.isEmpty()) {%>
 ### Genuine test errors [![${testsErrors?.size()}](https://img.shields.io/badge/${testsErrors?.size()}%20-red)](${jobUrl}/tests)
 :broken_heart: There are test failures but not known flaky tests, most likely a genuine test failure.
-<%   testsErrors?.each {%>
-        * **Name**: `${it}`<%}%>
+<%testsErrors?.each {%>
+* **Name**: `${it}`<%}%>
 <%}%>
 
 </p>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -52,19 +52,18 @@
 <!-- TEST RESULTS IF ANY-->
 <% if(testsErrors?.any{item -> item?.status == "FAILED"}) {%>
   ### Test errors [![${testsSummary?.failed}](https://img.shields.io/badge/${testsSummary?.failed}%20-red)](${jobUrl}/tests)
-  <details><summary>Expand to view the tests failures</summary>
-  <p>
+<details><summary>Expand to view the tests failures</summary><p>
     ${(testsSummary?.failed > 10) ? '> Show only the first 10 test failures' : ''}
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
-* **Name**: `${test?.name}`
-<% age = "* Age: ${test?.age}"%>
-<% duration = (test?.duration >= 0 ) ? "(took ${test.duration} sec)" : ''%>
-<% errorDetails = (test?.errorDetails && !test?.errorDetails?.equals('null')) ? "\n  * Error Details: ```${test?.errorDetails}```" : ''%>
-<% errorStackTrace = (test?.errorStackTrace && !test?.errorStackTrace?.equals('null')) ? "\n  * Error Stacktrace:\n ```\n ${test?.errorStackTrace} \n ```" : ''%>
-  ${age} ${duration} ${errorDetails} ${errorStackTrace}
+#### `${test?.name}`
+<% errorDetails = (test?.errorDetails && !test?.errorDetails?.equals('null')) ? "<details><summary>Expand to view the error details</summary><p>\n\n```\n ${test?.errorDetails} \n ```\n</p></details>" : '<li>no error details</li>'%>
+<% errorStackTrace = (test?.errorStackTrace && !test?.errorStackTrace?.equals('null')) ? "<details><summary>Expand to view the stacktrace</summary><p>\n\n```\n ${test?.errorStackTrace} \n ```\n</p></details>" : '<li>no stacktrace</li>'%>
+<ul>
+${errorDetails}
+${errorStackTrace}
+</ul>
     <%}%>
-  </p>
-  </details>
+</p></details>
 <%}%>
 
 <!-- STEPS ERRORS IF ANY-->

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -352,12 +352,10 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: readJSON(file: 'tests-summary.json')
     )
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', '* Error Details: ```'))
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', '''* Error Stacktrace:
- ```'''))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Expand to view the error details'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Expand to view the stacktrace'))
     // When one of the fields is empty/null then it should not be shown
-    assertFalse(assertMethodCallContainsPattern('githubPrComment', ''''* Age: 1 (took 0.1 sec) 
-  * Error Details: ```'''))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', '<li>no error details</li>'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Collapse the error details and stacktrace.
Remove the age/took section for the failed tests, since it seems we don't need it.

## Screenshots

- Test errors comment

|used-to-be|proposal|
|-----------|---------|
|![image](https://user-images.githubusercontent.com/2871786/98549354-92e54280-2292-11eb-93ef-3e7158609463.png)|![image](https://user-images.githubusercontent.com/2871786/98549312-8365f980-2292-11eb-95b8-8b6eb87e8a7a.png)|

- Flaky comment

|used-to-be|proposal|
|-----------|---------|
|![image](https://user-images.githubusercontent.com/2871786/98549629-f96a6080-2292-11eb-87b4-7c7bda2ef402.png)|![image](https://user-images.githubusercontent.com/2871786/98549441-b3150180-2292-11eb-8a13-ffd255910d66.png)|
