### PR TITLE
[cosmetic] simplify UI for steps

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -72,13 +72,17 @@ ${errorStackTrace}
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)
   <details><summary>Expand to view the steps failures</summary>
   <p>
+
   ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
   <% stepsErrors?.take(10)?.each{ c -> %>
-  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "* Description: `${c?.displayDescription}`" : ''%>
-  <% duration = (c?.durationInMillis >= 0 ) ? "(took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec)" : ''%>
-  <% url = (c?.url && c?.url != 'null') ? ". View log details on [here](${c?.url}/?start=0)" : ''%>
-  * **Name**: `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}` ${duration} ${url}
-    ${description}
+  <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "<li>Description: <code>${c?.displayDescription}</code></l1>" : ''%>
+  <% duration = (c?.durationInMillis >= 0 ) ? "Took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec" : ''%>
+  <% url = (c?.url && c?.url != 'null') ? ". View more details on <a href=\"${c?.url}/?start=0\">here</a>" : ''%>
+#### `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}`
+<ul>
+<li>${duration} ${url}</li>
+${description}
+</ul>
   <%}%>
   </p>
   </details>


### PR DESCRIPTION
## What does this PR do?

Use html formatting to solve some cosmetic issues with the sublists in markdown format, since the last element of the list somehow is closer to the next element in the list. 

## Screenshots
Using the output from `mvn clean test -Dtest=NotificationManagerStepTests#test_notify_pr_with_unstable_and_multiple_steps_failures -Pdebug`

|proposal|used to be|
|--------|-----------|
|![image](https://user-images.githubusercontent.com/2871786/98566603-de095080-22a6-11eb-8308-acdd0d631536.png)|![image](https://user-images.githubusercontent.com/2871786/98566801-1e68ce80-22a7-11eb-83d2-845a9717464c.png)|


The reason is to solve some cosmetic weirdness such as the below screenshot, that got long commands and description details

![image](https://user-images.githubusercontent.com/2871786/98566908-3f312400-22a7-11eb-81af-d241fd375014.png)

