### PR TITLE
Remove field rather than maps

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -220,17 +220,17 @@ function normaliseBuild() {
     # shellcheck disable=SC2016
     jqAppend "${DURATION}" '.durationInMillis = ($a|tonumber)' "${file}"
     jqEdit '.state = "FINISHED"' "${file}"
-    jqEdit 'map(del(._links))' "${file}"
-    jqEdit 'map(del(._class))' "${file}"
+    jqEdit 'del(._links)' "${file}"
+    jqEdit 'del(._class)' "${file}"
 }
 
 function normaliseBuildReport() {
     file=$1
-    jqEdit 'map(del(._links))' "${file}"
-    jqEdit 'map(del(._class))' "${file}"
-    jqEdit 'map(del(.latestRun))' "${file}"
-    jqEdit 'map(del(.permissions))' "${file}"
-    jqEdit 'map(del(.parameters))' "${file}"
+    jqEdit 'del(._links)' "${file}"
+    jqEdit 'del(._class)' "${file}"
+    jqEdit 'del(.latestRun)' "${file}"
+    jqEdit 'del(.permissions)' "${file}"
+    jqEdit 'del(.parameters)' "${file}"
 }
 
 function normaliseTests() {


### PR DESCRIPTION
## What does this PR do?

Remove the right field

## Why is it important?

Otherwise

```bash

16:35:14  + jq 'map(del(._class))' job-info.json
16:35:14  jq: error (at job-info.json:0): Cannot index string with string "_class"
```

## Test

```bash
$ curl -s 'https://apm-ci.elastic.co/job/apm-shared/job/apm-pipeline-library-mbp/job/master/1194/artifact/job-info.json/\*view\*/' | jq 'del(.parameters)' | jq 'del(._links)' | jq 'del(._class)' | jq 'del(.latestRun)' | jq 'del(.permissions)'
{
  "actions": [],
  "disabled": false,
  "displayName": "master",
  "estimatedDurationInMillis": 407498,
  "fullDisplayName": "apm-shared/APM%20Pipeline%20Library/master",
  "fullName": "apm-shared/apm-pipeline-library-mbp/master",
  "name": "master",
  "organization": "jenkins",
  "weatherScore": 100,
  "branch": {
    "isPrimary": true,
    "issues": [],
    "url": "https://github.com/elastic/apm-pipeline-library/tree/master"
  }
}
```