### PR TITLE
Add env variable to easily search in the future

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -128,9 +128,15 @@ function fetchAndPrepareBuildInfo() {
 }
 
 function fetchAndPrepareBuildReport() {
-    fetchAndPrepare "$1" "$2" "$3" "$4" "${BUILD_REPORT}"
+    file=$1
+    url=$2
+    key=$3
+    default=$4
 
+    fetchAndDefault "${file}" "${url}" "${default}"
     normaliseBuildReport "${file}"
+    normaliseArtifacts "${file}"
+    echo "\"${key}\": $(cat "${file}")," >> "${BUILD_REPORT}"
 }
 
 function fetchAndPrepareTestsInfo() {
@@ -163,6 +169,7 @@ function fetchAndPrepareTestSummaryReport() {
 
     echo "INFO: fetchAndPrepareTestSummaryReport (see ${file})"
     fetch "$file" "$url"
+    normaliseTestsSummary "$file"
 
     ## BlueOcean might return 500 in some scenarios. If so, let's parse the tests entrypoint
     if [ ! -e "${file}" ] ; then
@@ -248,6 +255,12 @@ function normaliseTestsWithoutStacktrace() {
     ## This will help to tidy up the file size quite a lot.
     ## It might be useful to export it but lets go step by step
     jqEdit 'map(del(.errorStackTrace))' "${file}"
+}
+
+function normaliseTestsSummary() {
+    file=$1
+    jqEdit 'del(._links)' "${file}"
+    jqEdit 'del(._class)' "${file}"
 }
 
 function normaliseSteps() {

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -31,6 +31,7 @@ ARTIFACTS_INFO="artifacts-info.json"
 BUILD_INFO="build-info.json"
 BUILD_REPORT="build-report.json"
 CHANGESET_INFO="changeSet-info.json"
+ENV_INFO="env-info.json"
 JOB_INFO="job-info.json"
 PIPELINE_LOG="pipeline-log.txt"
 STEPS_ERRORS="steps-errors.json"
@@ -123,7 +124,7 @@ function fetchAndPrepareBuildInfo() {
 
     normaliseBuild "${file}"
 
-    echo "\"${key}\": $(cat "${file}")" >> "${BUILD_REPORT}"
+    echo "\"${key}\": $(cat "${file}")," >> "${BUILD_REPORT}"
 }
 
 function fetchAndPrepareBuildReport() {
@@ -328,6 +329,35 @@ function jqAppend() {
     jq --arg a "${argument}" "${query}" "${file}" > "$tmp" && mv "$tmp" "${file}"
 }
 
+function prepareEnvInfo() {
+    file=$1
+    key=$2
+
+    {
+        echo "{"
+        echo "  \"BRANCH_NAME\": \"${BRANCH_NAME}\","
+        echo "  \"BUILD_DISPLAY_NAME\": \"${BUILD_DISPLAY_NAME}\","
+        echo "  \"BUILD_ID\": \"${BUILD_ID}\","
+        echo "  \"BUILD_NUMBER\": \"${BUILD_NUMBER}\","
+        echo "  \"BUILD_TAG\": \"${BUILD_TAG}\","
+        echo "  \"BUILD_URL\": \"${BUILD_URL}\","
+        echo "  \"GIT_BASE_COMMIT\": \"${GIT_BASE_COMMIT}\","
+        echo "  \"GIT_COMMIT\": \"${GIT_COMMIT}\","
+        echo "  \"GIT_PREVIOUS_COMMIT\": \"${GIT_PREVIOUS_COMMIT}\","
+        echo "  \"GIT_PREVIOUS_SUCCESSFUL_COMMIT\": \"${GIT_PREVIOUS_SUCCESSFUL_COMMIT}\","
+        echo "  \"JOB_BASE_NAME\": \"${JOB_BASE_NAME}\","
+        echo "  \"JOB_DISPLAY_URL\": \"${JOB_DISPLAY_URL}\","
+        echo "  \"JOB_NAME\": \"${JOB_NAME}\","
+        echo "  \"JOB_URL\": \"${JOB_URL}\","
+        echo "  \"ORG_NAME\": \"${ORG_NAME}\","
+        echo "  \"REPO_NAME\": \"${REPO_NAME}\""
+        echo "}"
+    } > "${file}"
+
+    ## This is the last entry in the BUILD_REPORT therefore no , is required
+    echo "\"${key}\": $(cat "${file}")" >> "${BUILD_REPORT}"
+}
+
 ### Fetch some artifacts that won't be attached to the data to be sent to ElasticSearch
 fetchAndDefaultStepsInfo "${STEPS_INFO}" "${BO_BUILD_URL}/steps/?limit=10000" "${DEFAULT_HASH}"
 fetchAndDefaultTestsErrors "${TESTS_ERRORS}" "${BO_BUILD_URL}/tests/?status=FAILED" "${DEFAULT_LIST}"
@@ -347,6 +377,8 @@ fetchAndPrepareTestsInfo "${TESTS_INFO}" "${BO_BUILD_URL}/tests/?limit=10000000"
 ### fetchAndPrepareTestSummaryReport should run after fetchAndPrepareTestsInfo
 fetchAndPrepareTestSummaryReport "${TESTS_SUMMARY}" "${BO_BUILD_URL}/blueTestSummary/" "test_summary" "${DEFAULT_LIST}" "${TESTS_INFO}"
 fetchAndPrepareBuildInfo "${BUILD_INFO}" "${BO_BUILD_URL}/" "build" "${DEFAULT_HASH}"
+### prepareEnvInfo should run the last one since it's the last field to be added
+prepareEnvInfo "${ENV_INFO}" "env"
 echo '}' >> "${BUILD_REPORT}"
 
 exit $STATUS

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -90,6 +90,7 @@ class GenerateBuildDataIntegrationTests {
     assertFalse(obj.get("artifacts").isEmpty())
     assertTrue(obj.get("test").isEmpty())
     assertFalse(obj.get("build").isEmpty())
+    assertFalse(obj.get("env").isEmpty())
   }
 
   @Test
@@ -112,6 +113,7 @@ class GenerateBuildDataIntegrationTests {
     assertFalse(obj.get("artifacts").isEmpty())
     assertFalse(obj.get("test").isEmpty())
     assertFalse(obj.get("build").isEmpty())
+    assertFalse(obj.get("env").isEmpty())
   }
 
   @Test
@@ -196,6 +198,21 @@ class GenerateBuildDataIntegrationTests {
     Map<String, String> env = pb.environment()
     env.put('JENKINS_URL', 'http://localhost:18081/')
     env.put('PIPELINE_LOG_LEVEL', 'INFO')
+    env.put('BRANCH_NAME', 'main')
+    env.put('BUILD_DISPLAY_NAME', '#1')
+    env.put('BUILD_ID', '1')
+    env.put('BUILD_NUMBER', '1')
+    env.put('BUILD_TAG', 'jenkins-project-main-1')
+    env.put('BUILD_URL', 'http://localhost:18081/job/project/job/main/1/')
+    env.put('GIT_COMMIT', '4f0aea0e892678e46d62fd0a156f9c9c4b670995')
+    env.put('GIT_PREVIOUS_COMMIT', '4f0aea0e892678e46d62fd0a156f9c9c4b670995')
+    env.put('GIT_PREVIOUS_SUCCESSFUL_COMMIT', '4f0aea0e892678e46d62fd0a156f9c9c4b670995')
+    env.put('JOB_BASE_NAME', 'main')
+    env.put('JOB_DISPLAY_URL', 'http://localhost:18081/job/project/job/main/display/redirect')
+    env.put('JOB_NAME', 'project/main')
+    env.put('JOB_URL', 'http://localhost:18081/job/project/job/main/')
+    env.put('ORG_NAME', 'acme')
+    env.put('REPO_NAME', 'project')
     File location = new File("target/${targetFolder}")
     location.mkdirs()
     pb.directory(location)

--- a/src/test/resources/env-info.json
+++ b/src/test/resources/env-info.json
@@ -1,0 +1,17 @@
+{
+  "BRANCH_NAME": "main",
+  "BUILD_DISPLAY_NAME": "#1",
+  "BUILD_ID": "1",
+  "BUILD_NUMBER": "1",
+  "BUILD_TAG": "jenkins-project-main-1",
+  "BUILD_URL": "http://localhost:18081/job/project/job/main/1/",
+  "GIT_COMMIT": "4f0aea0e892678e46d62fd0a156f9c9c4b670995",
+  "GIT_PREVIOUS_COMMIT": "4f0aea0e892678e46d62fd0a156f9c9c4b670995",
+  "GIT_PREVIOUS_SUCCESSFUL_COMMIT": "4f0aea0e892678e46d62fd0a156f9c9c4b670995",
+  "JOB_BASE_NAME": "main",
+  "JOB_DISPLAY_URL": "http://localhost:18081/job/project/job/main/display/redirect",
+  "JOB_NAME": "project/main",
+  "JOB_URL": "http://localhost:18081/job/project/job/main/",
+  "ORG_NAME": "acme",
+  "REPO_NAME": "project"
+}


### PR DESCRIPTION
## What does this PR do?

Populate some CI env variables and remove some metadata

## Why is it important?

This will help us to simplify our queries to the ES


For instance,

The below query could be simplified:

```
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "build.branch.isPrimary": "true"
          }
        },
        {
          "match_phrase": {
            "job.branch.url": "https://github.com/elastic/beats"
          }
        },
        {
          "match_phrase": {
            "build.artifactsZipFile": "/job/Beats/job/beats/"
          }
        },
        }
      ]
    }
  }
```


```
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "build.branch.isPrimary": "true"
          }
        },
        {
          "term": {
            "env.REPO_NAME": "beats"
          }
        }
        }
      ]
    }
  }
```