### PR TITLE
Error if single quotes when using githubCreatePullRequest

### DIFF
--- a/src/test/groovy/GithubCreatePullRequestStepTests.groovy
+++ b/src/test/groovy/GithubCreatePullRequestStepTests.groovy
@@ -152,4 +152,22 @@ class GithubCreatePullRequestStepTests extends ApmBasePipelineTest {
     assertTrue(ret.equals('https://github.com/acme/my-repo/pull/1'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_multiline_with_quotes() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sh', [Map.class], { s ->
+      return 'https://github.com/acme/my-repo/pull/1'
+    })
+    def actions = """
+        1. A single quote ' foo
+        1. Something else."""
+    try {
+      script.call(title: 'foo', description: "${actions}")
+    } catch(err) {
+      //NOOP
+    }
+    assertTrue(assertMethodCallContainsPattern('error', 'single quotes are not allowed'))
+    assertJobStatusFailure()
+  }
 }

--- a/vars/githubCreatePullRequest.groovy
+++ b/vars/githubCreatePullRequest.groovy
@@ -42,6 +42,12 @@ def call(Map args = [:]) {
   def draftFlag = draft ? '--draft' : ''
   def forceFlag = force ? '--force' : ''
   def output = ''
+
+  // Some corner cases with single quotes in the description or title
+  if (description?.contains("'") || title?.contains("'")) {
+    error('githubCreatePullRequest: single quotes are not allowed.')
+  }
+
   withCredentials([
     usernamePassword(credentialsId: "${credentialsId}", passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')
   ]) {

--- a/vars/githubCreatePullRequest.groovy
+++ b/vars/githubCreatePullRequest.groovy
@@ -28,8 +28,8 @@ def call(Map args = [:]) {
   if(!isUnix()) {
     error 'githubCreatePullRequest: windows is not supported yet.'
   }
-  def title = args.containsKey('title') ? """--message '${args.title}'""" : error('githubCreatePullRequest: title argument is required.')
-  def description = args.containsKey('description') ? """--message '${args.description}'""" : ''
+  def titleValue = args.containsKey('title') ? args.title : error('githubCreatePullRequest: title argument is required.')
+  def descriptionValue = args.get('description', '')
   def assign = args.containsKey('assign') ? "--assign ${args.assign}" : ''
   def reviewer = args.containsKey('reviewer') ? "--reviewer ${args.reviewer}" : ''
   def milestone = args.containsKey('milestone') ? "--milestone ${args.milestone}" : ''
@@ -38,13 +38,14 @@ def call(Map args = [:]) {
   def base = args.containsKey('base') ? "--base ${args.base}" : ''
   def credentialsId = args.get('credentialsId', '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken')
   def force = args.containsKey('force') ? args.force : false
+  def title = titleValue?.trim() ? """--message '${titleValue}'""" : ''
+  def description = descriptionValue?.trim() ? """--message '${descriptionValue}'""" : ''
 
   def draftFlag = draft ? '--draft' : ''
   def forceFlag = force ? '--force' : ''
   def output = ''
-
   // Some corner cases with single quotes in the description or title
-  if (description?.contains("'") || title?.contains("'")) {
+  if (descriptionValue.contains("'") || titleValue.contains("'")) {
     error('githubCreatePullRequest: single quotes are not allowed.')
   }
 


### PR DESCRIPTION
## What does this PR do?

Fail if there are single quotes in the title or description

## Why is it important?

Fail with more details

## Related issues

Caused by https://github.com/elastic/apm-agent-php/pull/289


To follow up with a fix to support more cases, probably using the -F

```
       -F, --file FILE
           Read the pull request title and description from FILE. Pass "-" to read from standard input instead. See --message for the formatting rules.
```

## Tests

ITs

![image](https://user-images.githubusercontent.com/2871786/98804461-23945d80-240e-11eb-98e7-408f8d73f289.png)
