### PR TITLE
[local] docker instance with fixed version

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/infra/jenkins
+FROM docker.elastic.co/infra/jenkins:202010021728.bc28cd532cad
 
 COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
## What does this PR do?

Fix the version to the latest stable docker image that matches the existing production jenkins instnace

## Why is it important?

Latest cannot be used as long as the producers don't run some validations.

```
$ docker run --rm -ti -p 8080:8080 docker.elastic.co/infra/jenkins:latest
...
2020-11-11 09:33:07.640+0000 [id=31]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading plugin Pipeline: Basic Steps v2.23 (workflow-basic-steps)
java.io.IOException: Failed to load: Pipeline: Basic Steps (2.23)
 - Jenkins (2.263) or higher required
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:952)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:549)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1131)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
```

So as a consequence we will force to bump the version when a new upgrade happens in production. Unless the testability of those docker images are included in the process of building/ pushing those images in the producers side.