### PR TITLE
Remove duplicated metadata

### DIFF
--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -114,6 +114,15 @@ class GenerateBuildDataIntegrationTests {
     assertFalse(obj.get("test").isEmpty())
     assertFalse(obj.get("build").isEmpty())
     assertFalse(obj.get("env").isEmpty())
+
+    // Then metadata is removed
+    assertNull(obj.get("changeSet")[0].author?._class)
+    assertNull(obj.get("changeSet")[0].author?._links)
+
+    // Then some duplicated entries don't exist anymore
+    assertNull(obj.get("build.branch"))
+    assertNull(obj.get("build.changeSet"))
+    assertNull(obj.get("build.pullRequest"))
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Remove some unused metadata such as:

- duplicated entries in build/jobs for the changeset branch and pull requests.
- remove _class and _links
- remove some metadata from the changeSet
- remove some metadata from the artifacts
- Append JENKINS_URL to the artifacts

## Why is it important?

Reduce the amount of unnecessary data
