### PR TITLE
[notification] skip steps comment in slack if none

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -5,9 +5,9 @@
 <% pipelineUrl = String.format("<%spipeline|#%s>", jobUrl, build?.id ?: 'build')%>
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.url && changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
-<% stepsMessage = (steps?.size()!= 0) ? "`${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : 0%>
+<% stepsMessage = (steps?.size()!= 0) ? "*Steps failures*: `${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : ""%>
 <% if (header?.trim()) {%>${header}<%}%>
 *Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
 *Changes*: ${changesMessage}
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)
-*Steps failures*: ${stepsMessage}
+${stepsMessage}

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -411,6 +411,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('slackSend', 'ABORTED'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'Steps failures'))
     assertJobStatusSuccess()
   }
 
@@ -519,6 +520,27 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('log', 'notifySlack: Error with the slack comment'))
     assertTrue(assertMethodCallOccurrences('slackSend', 0))
+    assertJobStatusSuccess()
+  }
+
+
+  @Test
+  void test_notify_slack_without_steps_failures() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifySlack(
+      build: readJSON(file: "build-info-manual.json"),
+      buildStatus: "SUCCESS",
+      changeSet: [],
+      stepsErrors: [],
+      testsErrors: readJSON(file: "tests-errors.json"),
+      testsSummary: readJSON(file: "tests-summary.json"),
+      channel: 'test',
+      credentialId: 'test',
+      enabled: true
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'Build'))
+    assertFalse(assertMethodCallContainsPattern('slackSend', 'Steps failures'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Skip steps failures if no steps failures

## Why is it important?

It does not add any value

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/790