### PR TITLE
buildStatus HTTP handling

### DIFF
--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -56,7 +56,7 @@ private static String makeRequest(URL url) throws IOException {
 private static URL constructURL(String host, ArrayList job) throws Exception {
     String delim = "%2F"
     String job_path = job.join(delim)
-    String uri = "http://${host}/buildStatus/text?job=${job_path}"
+    String uri = "https://${host}/buildStatus/text?job=${job_path}"
     URL url = new URL(uri)
     return url
 }


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where this module doesn't correctly follow HTTP 301s. Instead of more sophisticated handling of HTTP, it's easier just to point at the hosts as they are currently configured. :) 

## Why is it important?
Corrects a potential failure in downstream users of this module, as as the release job for the APM Java Agent team.

## Related issues
None. Discovered while debugging other issues.
