### PR TITLE
Flaky causes NPE

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -79,8 +79,8 @@ def analyzeFlakey(Map args = [:]) {
       // Intesection what tests are failing and also scored as flaky.
       // Subset of genuine test failures, aka, those failures that were not scored as flaky previously.
       def testFailures = testsErrors.collect { it.name }
-      def testFlaky = flakeyTestsParsed['hits']['hits'].collect { it['_source']['test_name'] }
-      def foundFlakyList = testFailures.intersect(testFlaky)
+      def testFlaky = flakeyTestsParsed?.hits?.hits?.collect { it['_source']['test_name'] }
+      def foundFlakyList = testFlaky?.size() > 0 ? testFailures.intersect(testFlaky) : []
       genuineTestFailures = testFailures.minus(foundFlakyList)
       log(level: 'DEBUG', text: "analyzeFlakey: Flaky tests raw: ${flakeyTestsRaw}")
       log(level: 'DEBUG', text: "analyzeFlakey: Flaky matched tests: ${foundFlakyList.join('\n')}")

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -654,6 +654,23 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_analyzeFlakey_in_prs_with_empty_flaky_tests() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: 'flake-empty-results.json')})
+    helper.registerAllowedMethod('isPR', { return true })
+    script.analyzeFlakey(
+      flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
+      es: "https://fake_url",
+      testsErrors: readJSON(file: 'flake-tests-errors-without-match.json'),
+      testsSummary: readJSON(file: 'flake-tests-summary.json')
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "There are test failures but not known flaky tests."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "Genuine test errors [![1]"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_analyzeFlakey_in_prs_without_flaky_tests() throws Exception {
     def script = loadScript(scriptName)
     helper.registerAllowedMethod(

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -785,6 +785,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: [ "failed": 0, "passed": 120, "skipped": 0, "total": 120 ]
     )
     printCallStack()
+    assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 0))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', "Tests succeeded."))
     assertJobStatusSuccess()
   }

--- a/src/test/resources/flake-empty-results.json
+++ b/src/test/resources/flake-empty-results.json
@@ -1,0 +1,10 @@
+{
+    "took" : 3,
+    "timed_out" : false,
+    "_shards" : {
+      "total" : 1,
+      "successful" : 1,
+      "skipped" : 0,
+      "failed" : 0
+    }
+  }


### PR DESCRIPTION
## What does this PR do?

- Skip flaky analysis if no test failures
- Fix NPE

```
17:46:09  ERROR: There were some failures when generating flakey test results
17:46:09  java.lang.NullPointerException: Cannot get property 'hits' on null object
17:46:09  	at org.codehaus.groovy.runtime.NullObject.getProperty(NullObject.java:60)
17:46:09  	at org.codehaus.groovy.runtime.InvokerHelper.getProperty(InvokerHelper.java:174)
17:46:09  	at org.codehaus.groovy.runtime.DefaultGroovyMethods.getAt(DefaultGroovyMethods.java:257)
17:46:09  	at org.codehaus.groovy.runtime.dgm$242.doMethodInvoke(Unknown Source)
17:46:09  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213)
17:46:09  	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
17:46:09  	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
17:46:09  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
17:46:09  	at org.codehaus.groovy.runtime.callsite.NullCallSite.call(NullCallSite.java:35)
17:46:09  	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
17:46:09  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
17:46:09  	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
17:46:09  	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.getArray(DefaultInvoker.java:57)
17:46:09  	at com.cloudbees.groovy.cps.impl.ArrayAccessBlock.rawGet(ArrayAccessBlock.java:21)
17:46:09  	at co.elastic.NotificationManager.analyzeFlakey(NotificationManager.groovy:75)
17:46:09  	at notifyBuildResult.call(notifyBuildResult.groovy:110)
```

## Why is it important?

Fixes issues in the apm-pipeline-library

![image](https://user-images.githubusercontent.com/2871786/99311353-5dbd8f00-2854-11eb-9d28-2b74b31560c2.png)

