### PR TITLE
Add certain latency to access to the google storage

### DIFF
--- a/vars/googleStorageUpload.groovy
+++ b/vars/googleStorageUpload.groovy
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  As long as we got some concurrency issues let's add some sleeps
+  
+  See https://github.com/jenkinsci/google-storage-plugin/issues/61
+
+  googleStorageUpload(args)
+*/
+def call(args) {
+  log(level: 'INFO', text: 'Override default googleStorageUpload with some sleep')
+  sleep randomNumber(min: 10, max: 100)
+  return steps.googleStorageUpload(args)
+}

--- a/vars/googleStorageUpload.txt
+++ b/vars/googleStorageUpload.txt
@@ -1,0 +1,5 @@
+As long as we got some concurrency issues
+
+```
+googleStorageUpload(args)
+```


### PR DESCRIPTION
## What does this PR do?


Try to reduce the number of concurrency calls for the same step that causes some issues


## Why is it important?

See if we can mitigate the environmental issue as long as no new release of the plugins is released

I'm not 100% sure whether this particular workaround will reduce the number of times we face that issue, but it should be pretty much harmless in the worst case scenario, but adding certain sleep time.

## Related issues

Caused by https://github.com/jenkinsci/google-storage-plugin/issues/61

## Tests

Manually tried in my local instance:

![image](https://user-images.githubusercontent.com/2871786/99665828-0d1b8100-2a62-11eb-9635-1d7049d206be.png)
