### PR TITLE
If no GH Issues then use flaky test details

### DIFF
--- a/vars/lookForGitHubIssues.groovy
+++ b/vars/lookForGitHubIssues.groovy
@@ -44,6 +44,9 @@ def call(Map args = [:]) {
             output[testName] = ''
           }
         }
+      } else {
+        // no issues could be found, let's report the list of test failures without any issue details.
+        flakyList.each { output.put(it, '') }
       }
     } catch (err) {
       // no issues could be found, let's report the list of test failures without any issue details.


### PR DESCRIPTION
## What does this PR do?

Add default flaky tests if no issues to query, so far it was only enabled if something bad happened with the step, but what if no issues are retrieved without any failures?

## Why is it important?

Add more coverage to report flakiness even if no issues have been fetched.

