### PR TITLE
chore: simplify RUM JS image

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -199,7 +199,7 @@ pipeline {
             def nodejsVersion = readFile("./dev-utils/.node-version").trim()
             def tasks = [:]
             libraries.each { library ->
-              tasks["${library}-${version}"] = {
+              tasks["${library}-${nodejsVersion}"] = {
                 node('ubuntu-18 && immutable && docker'){
                   dockerLoginElasticRegistry()
                   buildDockerImage(

--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -195,24 +195,20 @@ pipeline {
           git 'https://github.com/elastic/apm-agent-rum-js.git'
           script {
             def imagesConfiguration = readYaml(file: '.ci/.jenkins_rum.yml')
-            def nodeVersions = imagesConfiguration['NODEJS_VERSION']
             def libraries = imagesConfiguration['TEST_LIBRARIES']
+            def nodejsVersion = readFile("./dev-utils/.node-version").trim()
             def tasks = [:]
             libraries.each { library ->
-              nodeVersions.each { version ->
-                // Versions are double quoted
-                def nodejsVersion = version.replaceFirst('"', '')
-                tasks["${library}-${version}"] = {
-                  node('ubuntu-18 && immutable && docker'){
-                    dockerLoginElasticRegistry()
-                    buildDockerImage(
-                      repo: 'https://github.com/elastic/apm-agent-rum-js.git',
-                      tag: "node-${library}",
-                      version: "${nodejsVersion}",
-                      folder: ".ci/docker/node-${library}",
-                      options: "--build-arg NODEJS_VERSION='${nodejsVersion}'",
-                      push: true)
-                  }
+              tasks["${library}-${version}"] = {
+                node('ubuntu-18 && immutable && docker'){
+                  dockerLoginElasticRegistry()
+                  buildDockerImage(
+                    repo: 'https://github.com/elastic/apm-agent-rum-js.git',
+                    tag: "node-${library}",
+                    version: "${nodejsVersion}",
+                    folder: ".ci/docker/node-${library}",
+                    options: "--build-arg NODEJS_VERSION='${nodejsVersion}'",
+                    push: true)
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do?
It simply reads the `.node-version` file in the RUM agent workspace, instead of iterating through multiple versions of Node (which is not done at this moment)

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
There is only one NodeJS version, defined in one single file

>YAGNI

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Depends on https://github.com/elastic/apm-agent-rum-js/pull/935