### PR TITLE
[index] bulk format and remove certain unused fields

### DIFF
--- a/resources/ci-builds-mapping.json
+++ b/resources/ci-builds-mapping.json
@@ -27,32 +27,26 @@
           "causes": {
             "properties": {
               "shortDescription": {
-                "shortDescription" : {
-                  "type" : "keyword",
-                  "fields" : {
-                    "analyzed" : {
-                      "type" : "text"
-                    }
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
                   }
                 }
               },
               "userId": {
-                "shortDescription" : {
-                  "type" : "keyword",
-                  "fields" : {
-                    "analyzed" : {
-                      "type" : "text"
-                    }
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
                   }
                 }
               },
               "userName": {
-                "shortDescription" : {
-                  "type" : "keyword",
-                  "fields" : {
-                    "analyzed" : {
-                      "type" : "text"
-                    }
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
                   }
                 }
               }

--- a/resources/ci-builds-mapping.json
+++ b/resources/ci-builds-mapping.json
@@ -24,13 +24,35 @@
               }
             }
           },
-          "causes" : {
-            "properties" : {
-              "shortDescription" : {
-                "type" : "keyword",
-                "fields" : {
-                  "analyzed" : {
-                    "type" : "text"
+          "causes": {
+            "properties": {
+              "shortDescription": {
+                "shortDescription" : {
+                  "type" : "keyword",
+                  "fields" : {
+                    "analyzed" : {
+                      "type" : "text"
+                    }
+                  }
+                }
+              },
+              "userId": {
+                "shortDescription" : {
+                  "type" : "keyword",
+                  "fields" : {
+                    "analyzed" : {
+                      "type" : "text"
+                    }
+                  }
+                }
+              },
+              "userName": {
+                "shortDescription" : {
+                  "type" : "keyword",
+                  "fields" : {
+                    "analyzed" : {
+                      "type" : "text"
+                    }
                   }
                 }
               }

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -424,7 +424,7 @@ jq -c '.test = (.test[])' "${BUILD_REPORT}" |
 while read -r json ; do
   N=$((N+1))
   echo "{ \"index\":{} }" >> "${BUILD_BULK_REPORT}"
-  echo "{ \"doc\": ${json} }" >> "${BUILD_BULK_REPORT}"
+  echo "${json}" >> "${BUILD_BULK_REPORT}"
 done
 
 exit $STATUS

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -235,6 +235,7 @@ function normaliseBuild() {
     jqEdit '.state = "FINISHED"' "${file}"
     jqEdit 'del(._links)' "${file}"
     jqEdit 'del(._class)' "${file}"
+    jqEdit 'del(.actions)' "${file}"
     ## This is already duplicated, the responsible is the job
     jqEdit 'del(.branch)' "${file}"
     ## This is already duplicated, the responsible is the changeset
@@ -243,6 +244,9 @@ function normaliseBuild() {
     jqEdit 'del(.pullRequest)' "${file}"
     jqEdit 'del(.causes[]._class)' "${file}"
     jqEdit 'del(.replayable)' "${file}"
+    ## Lets flatten the causes by only getting the first entry.
+    ## There is two causes by default in the way CI builds run at the moment.
+    jqEdit '.causes = (.causes[0])' "${file}"
 
     ## Transform relative path to absolute URL
     artifactsZipFile=$(jq -r '.artifactsZipFile' "${file}")
@@ -254,6 +258,7 @@ function normaliseBuildReport() {
     file=$1
     jqEdit 'del(._links)' "${file}"
     jqEdit 'del(._class)' "${file}"
+    jqEdit 'del(.actions)' "${file}"
     jqEdit 'del(.latestRun)' "${file}"
     jqEdit 'del(.permissions)' "${file}"
     jqEdit 'del(.parameters)' "${file}"

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -129,8 +129,8 @@ class GenerateBuildDataIntegrationTests {
     new File("target/${targetFolder}/build-report-bulk.json").eachLine { line ->
       obj = JSONSerializer.toJSON(line)
       assertNotNull("There are some entries in the bulk file.", obj)
-      if (obj?.doc?.test?.age) {
-        assertEquals("Only one test entry that matches 1 age.", 1, obj.doc.test.age)
+      if (obj?.test?.age) {
+        assertEquals("Only one test entry that matches 1 age.", 1, obj.test.age)
       }
     }
   }
@@ -216,8 +216,8 @@ class GenerateBuildDataIntegrationTests {
     new File("target/${targetFolder}/build-report-bulk.json").eachLine { line ->
       def obj = JSONSerializer.toJSON(line)
       assertNotNull("There are some entries in the bulk file.", obj)
-      if (obj?.doc?.test?.age) {
-        assertEquals("Only one test entry that matches 1 age.", 1, obj.doc.test.age)
+      if (obj?.test?.age) {
+        assertEquals("Only one test entry that matches 1 age.", 1, obj.test.age)
       }
     }
   }

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -114,9 +114,11 @@ class GenerateBuildDataIntegrationTests {
     assertFalse(obj.get("artifacts").isEmpty())
     assertFalse(obj.get("test").isEmpty())
     assertFalse(obj.get("build").isEmpty())
+    assertNotNull(obj.get("build").causes.shortDescription)
     assertFalse(obj.get("env").isEmpty())
 
     // Then metadata is removed
+    assertNull(obj.get("build").actions)
     assertNull(obj.get("changeSet")[0].author?._class)
     assertNull(obj.get("changeSet")[0].author?._links)
 


### PR DESCRIPTION
## What does this PR do?

- Fix the bulk format (since doc is for updating and caused a top level field)
- Remove `actions` since they are empty anyway
- Flatten the `cause` and pick up the first entry, I don't see toomany cases where the cause will have more than one entry.

## Why is it important?

Fixes the existing index.
