### PR TITLE
[index] create a new index

### DIFF
--- a/resources/ci-tests-mapping.json
+++ b/resources/ci-tests-mapping.json
@@ -241,6 +241,35 @@
           }
         }
       },
+      "test" : {
+        "properties" : {
+          "age" : {
+            "type" : "long"
+          },
+          "duration" : {
+            "type" : "long"
+          },
+          "id" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "name" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "status" : {
+            "type" : "keyword"
+          }
+        }
+      },
       "test_summary" : {
         "properties" : {
           "existingFailed" : {

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -30,7 +30,8 @@ STATUS=0
 ARTIFACTS_INFO="artifacts-info.json"
 BUILD_INFO="build-info.json"
 BUILD_REPORT="build-report.json"
-BUILD_BULK_REPORT="build-report-bulk.json"
+CI_TEST_BULK_REPORT="ci-test-report-bulk.json"
+CI_BUILD_REPORT="ci-build-report.json"
 CHANGESET_INFO="changeSet-info.json"
 ENV_INFO="env-info.json"
 JOB_INFO="job-info.json"
@@ -423,13 +424,19 @@ fetchAndPrepareBuildInfo "${BUILD_INFO}" "${BO_BUILD_URL}/" "build" "${DEFAULT_H
 prepareEnvInfo "${ENV_INFO}" "env"
 echo '}' >> "${BUILD_REPORT}"
 
+## Create specific files to store the test failures in individual
+## docs and overal build data.
+### Create a bulk with the build data and tests
 ### For each entry in the test map then create a flatten document
 N=0
 jq -c '.test = (.test[])' "${BUILD_REPORT}" |
 while read -r json ; do
   N=$((N+1))
-  echo "{ \"index\":{} }" >> "${BUILD_BULK_REPORT}"
-  echo "${json}" >> "${BUILD_BULK_REPORT}"
+  echo "{ \"index\":{} }" >> "${CI_TEST_BULK_REPORT}"
+  echo "${json}" >> "${CI_TEST_BULK_REPORT}"
 done
+
+### Create a document with the overall build data. (aka no tests)
+jq 'del(.test)' "${BUILD_REPORT}" > "${CI_BUILD_REPORT}"
 
 exit $STATUS

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -141,7 +141,7 @@ class GenerateBuildDataIntegrationTests {
     assertFalse(obj.isEmpty())
     assertFalse(obj.get("job").isEmpty())
     assertFalse(obj.get("test_summary").isEmpty())
-    assertTrue(obj.get("test").isEmpty())
+    assertNull(obj.get("test"))
   }
 
   @Test

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -128,13 +128,20 @@ class GenerateBuildDataIntegrationTests {
     assertNull(obj.get("build.pullRequest"))
 
     // Then a flatten test in the bulk file
-    new File("target/${targetFolder}/build-report-bulk.json").eachLine { line ->
+    new File("target/${targetFolder}/ci-test-report-bulk.json").eachLine { line ->
       obj = JSONSerializer.toJSON(line)
       assertNotNull("There are some entries in the bulk file.", obj)
       if (obj?.test?.age) {
         assertEquals("Only one test entry that matches 1 age.", 1, obj.test.age)
       }
     }
+
+    // Then a build report without test
+    obj = JSONSerializer.toJSON(new File("target/${targetFolder}/ci-build-report.json").text)
+    assertFalse(obj.isEmpty())
+    assertFalse(obj.get("job").isEmpty())
+    assertFalse(obj.get("test_summary").isEmpty())
+    assertTrue(obj.get("test").isEmpty())
   }
 
   @Test
@@ -215,7 +222,7 @@ class GenerateBuildDataIntegrationTests {
     assertEquals("Process did finish successfully", 0, process.waitFor())
 
     // Then a flatten test in the bulk file
-    new File("target/${targetFolder}/build-report-bulk.json").eachLine { line ->
+    new File("target/${targetFolder}/ci-test-report-bulk.json").eachLine { line ->
       def obj = JSONSerializer.toJSON(line)
       assertNotNull("There are some entries in the bulk file.", obj)
       if (obj?.test?.age) {

--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -39,7 +39,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod("getVaultSecret", [Map.class], {
       return [data: [user: "admin", password: "admin123"]]
     })
-    helper.registerAllowedMethod('fileExists', [String.class], { return !it.contains('bulk') })
+    helper.registerAllowedMethod('fileExists', [String.class], { return !it.contains('ci-') })
     helper.registerAllowedMethod("readFile", [Map.class], { return '{"field": "value"}' })
 
     co.elastic.NotificationManager.metaClass.notifyEmail{ Map m -> 'OK' }

--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -351,13 +351,13 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
   void test_bulk_update() throws Exception {
     // When PR and there is a builk file
     helper.registerAllowedMethod('isPR', { return true })
-    helper.registerAllowedMethod('fileExists', [String.class], { return it.contains('bulk') })
+    helper.registerAllowedMethod('fileExists', [String.class], { return true })
 
     def script = loadScript(scriptName)
     script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
     printCallStack()
 
-    // Then sendDataToElasticsearch happens twice
-    assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 2))
+    // Then sendDataToElasticsearch happens three times
+    assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 3))
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -138,12 +138,19 @@ def call(Map args = [:]) {
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
         timeout(5) {
+          // Deprecated index
           def datafile = readFile(file: 'build-report.json')
           sendDataToElasticsearch(es: es, secret: secret, data: datafile)
-          def bulkFile = 'build-report-bulk.json'
+
+          // New indexes
+          def bulkFile = 'ci-test-report-bulk.json'
           if (fileExists(bulkFile)) {
             datafile = readFile(file: bulkFile)
-            sendDataToElasticsearch(es: es, secret: secret, data: datafile, restCall: '/ci-builds/_bulk/')
+            sendDataToElasticsearch(es: es, secret: secret, data: datafile, restCall: '/ci-tests/_bulk/')
+          }
+          datafile = 'ci-build-report.json'
+          if (fileExists(datafile)) {
+            sendDataToElasticsearch(es: es, secret: secret, restCall: '/ci-builds/_doc/', data: readFile(file: datafile))
           }
         }
       }


### PR DESCRIPTION
## What does this PR do?

Split indexes in two:
* One index will contain as many docs as tests are executed per build.
* Other index will contain one doc per build.

## Why is it important?

It will be easy to create simple dashboards for overall build status versus specific ones regarding test failures.
