### PR TITLE
[index] populate only test failures

### DIFF
--- a/resources/ci-tests-mapping.json
+++ b/resources/ci-tests-mapping.json
@@ -257,6 +257,14 @@
               }
             }
           },
+          "errorDetails" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
           "name" : {
             "type" : "keyword",
             "fields" : {

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -424,12 +424,14 @@ fetchAndPrepareBuildInfo "${BUILD_INFO}" "${BO_BUILD_URL}/" "build" "${DEFAULT_H
 prepareEnvInfo "${ENV_INFO}" "env"
 echo '}' >> "${BUILD_REPORT}"
 
-## Create specific files to store the test failures in individual
-## docs and overal build data.
+## Create specific files to store the failed tests in individual
+## docs and overal build data. Excluded passed and skipped tests
+## since it requires some other strategy to bulk update instead
+## calling the entrypoint.
 ### Create a bulk with the build data and tests
 ### For each entry in the test map then create a flatten document
 N=0
-jq -c '.test = (.test[])' "${BUILD_REPORT}" |
+jq -c 'del( .test[] | select( .status != "FAILED" )) | .test = (.test[])' "${BUILD_REPORT}" |
 while read -r json ; do
   N=$((N+1))
   echo "{ \"index\":{} }" >> "${CI_TEST_BULK_REPORT}"


### PR DESCRIPTION
## What does this PR do?

Reduce the ndjson files for the bulk from 100mbs in Beats to a few kbs in the new indexes, so we won't loose any data yet since we still have the deprecated index with a multinested doc fields.

## Why is it important?

Need to sacrifice those details otherwise the 100mbs data causes issues with the `_bulk` entrypoint.

![image](https://user-images.githubusercontent.com/2871786/100263157-0d75b980-2f45-11eb-8209-87832e37029c.png)

