### PR TITLE
[CI] runbld is now deprecated

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -40,7 +40,7 @@ pipeline {
     stage('Top failing Beats tests - last 7 days') {
       steps {
         setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
-        runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'victor.martinez@elastic.co')
+        runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Caused by https://github.com/elastic/beats/pull/22862

## Why is it important?

Move to the new ES index
