### PR TITLE
[report] report one error signal if multiple

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -55,7 +55,7 @@
 <details><summary>Expand to view the tests failures</summary><p>
     ${(testsSummary?.failed > 10) ? '> Show only the first 10 test failures' : ''}
     <% testsErrors?.findAll{item -> item?.status == "FAILED"}?.take(10)?.each { test -> %>
-#### `${test?.name}`
+##### `${test?.name}`
 <% errorDetails = (test?.errorDetails && !test?.errorDetails?.equals('null')) ? "<details><summary>Expand to view the error details</summary><p>\n\n```\n ${test?.errorDetails} \n ```\n</p></details>" : '<li>no error details</li>'%>
 <% errorStackTrace = (test?.errorStackTrace && !test?.errorStackTrace?.equals('null')) ? "<details><summary>Expand to view the stacktrace</summary><p>\n\n```\n ${test?.errorStackTrace} \n ```\n</p></details>" : '<li>no stacktrace</li>'%>
 <ul>
@@ -66,19 +66,22 @@ ${errorStackTrace}
 </p></details>
 <%}%>
 
-<!-- STEPS ERRORS IF ANY-->
+<!-- STEPS ERRORS IF ANY -->
 <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
+<% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>
+<% stepsErrors = stepsErrors?.findAll{ !it?.displayName?.contains('Error signal') } %>
+<% if (errorSignal) { stepsErrors = stepsErrors << errorSignal }%>
 <% if (stepsErrors?.size() != 0) {%>
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)
   <details><summary>Expand to view the steps failures</summary>
   <p>
 
   ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
-  <% stepsErrors?.take(10)?.each{ c -> %>
+  <% stepsErrors?.takeRight(10)?.each{ c -> %>
   <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "<li>Description: <code>${c?.displayDescription}</code></l1>" : ''%>
   <% duration = (c?.durationInMillis >= 0 ) ? "Took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec" : ''%>
   <% url = (c?.url && c?.url != 'null') ? ". View more details on <a href=\"${c?.url}/?start=0\">here</a>" : ''%>
-#### `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}`
+##### `${c?.displayName && c?.displayName != 'null' ? c?.displayName : ''}`
 <ul>
 <li>${duration} ${url}</li>
 ${description}

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -585,4 +585,12 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       call.methodName == methodName
     }.size() == compare
   }
+
+  def assertMethodCallPatternOccurrences(String methodName, String pattern, int compare) {
+    return helper.callStack.findAll { call ->
+      call.methodName == methodName
+    }.any { call ->
+      (callArgsToString(call) =~ pattern).count  == compare
+    }
+  }
 }

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -336,6 +336,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Show only the first 10 steps failures'))
+    assertTrue(assertMethodCallPatternOccurrences('githubPrComment', 'Error signal', 1))
     assertJobStatusSuccess()
   }
 

--- a/src/test/resources/steps-errors-with-multiple.json
+++ b/src/test/resources/steps-errors-with-multiple.json
@@ -1,5 +1,29 @@
 [
   {
+    "displayDescription": "Error 'hudson.AbortException: script returned exit code 2'",
+    "displayName": "Error signal",
+    "durationInMillis": 14,
+    "id": "4473",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2019-05-29T12:08:57.040+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22495/runs/6/steps/4473/log"
+  },
+  {
+    "displayDescription": "Error 'hudson.AbortException: script returned exit code 2'",
+    "displayName": "Error signal",
+    "durationInMillis": 14,
+    "id": "4473",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2019-05-29T12:08:57.040+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22495/runs/6/steps/4473/log"
+  },
+  {
     "_class": "io.jenkins.blueocean.rest.impl.pipeline.PipelineStepImpl",
     "_links": {
       "self": {


### PR DESCRIPTION
## What does this PR do?

Reduce the number of steps failures that are related to the `Error signal` to just one.
Use header4 for the test and step failures.

## Why is it important?

`Error signal` does not provide any details but a generic message. Therefore it might mislead the end user in case the are more than 10 failed steps since it's filtered up to 10 steps to be shown.

For instance, the below screenshot shows a bit more of how it's the current issue with too many error signal steps

![image](https://user-images.githubusercontent.com/2871786/101155407-feff6000-361e-11eb-9431-9e73c74a0683.png)
