### PR TITLE
[beats] flaky weekly email per branch

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -42,6 +42,7 @@ pipeline {
         setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
         runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "[master] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
         runWatcher(watcher: '3a509751-f9e6-4381-91a7-2e6f44cd9734', subject: "[7.x] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
+        runWatcher(watcher: 'report-beats-top-failing-tests-weekly-7-release', subject: "[7-release] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
       }
     }
   }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -40,7 +40,8 @@ pipeline {
     stage('Top failing Beats tests - last 7 days') {
       steps {
         setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
-        runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
+        runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "[master] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
+        runWatcher(watcher: '3a509751-f9e6-4381-91a7-2e6f44cd9734', subject: "[7.x] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
       }
     }
   }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -40,8 +40,8 @@ pipeline {
     stage('Top failing Beats tests - last 7 days') {
       steps {
         setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
-        runWatcher(watcher: '17635395-61cd-439a-963d-8e7bb6ab22b7', subject: "[master] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
-        runWatcher(watcher: '3a509751-f9e6-4381-91a7-2e6f44cd9734', subject: "[7.x] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
+        runWatcher(watcher: 'report-beats-top-failing-tests-weekly-master', subject: "[master] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
+        runWatcher(watcher: 'report-beats-top-failing-tests-weekly-7.x', subject: "[7.x] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
         runWatcher(watcher: 'report-beats-top-failing-tests-weekly-7-release', subject: "[7-release] ${env.YYYY_MM_DD}: Top failing Beats tests - last 7 days", sendEmail: true, to: 'beats-contrib@elastic.co')
       }
     }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: check-executables-have-shebangs
         exclude: (.+.bat$|.+.ps1$|^target/)
     -   id: check-json
-        exclude: ^target/
+        exclude: (resources/flaky-watcher.json$|^target/)
     -   id: check-merge-conflict
         exclude: ^target/
     -   id: check-yaml

--- a/resources/flaky-watcher.json
+++ b/resources/flaky-watcher.json
@@ -1,0 +1,131 @@
+{
+    "trigger": {
+      "schedule": {
+        "cron": "0 30 16 ? * MON"
+      }
+    },
+    "input": {
+      "search": {
+        "request": {
+          "search_type": "query_then_fetch",
+          "indices": [
+            "ci-tests"
+          ],
+          "rest_total_hits_as_int": true,
+          "body": {
+            "size": 0,
+            "query": {
+              "bool": {
+                "filter": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "match_phrase": {
+                                  "env.REPO_NAME": "beats"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "bool": {
+                            "filter": [
+                              {
+                                "bool": {
+                                  "should": [
+                                    {
+                                      "match_phrase": {
+                                        "env.BRANCH_NAME": "master"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "should": [
+                                    {
+                                      "range": {
+                                        "test_summary.failed": {
+                                          "gt": 0
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "range": {
+                      "build.startTime": {
+                        "gte": "now-7d"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "aggs": {
+              "top_failures": {
+                "terms": {
+                  "field": "test.name",
+                  "size": 10
+                },
+                "aggs": {
+                  "build_urls": {
+                    "terms": {
+                      "field": "env.REPO_NAME",
+                      "size": 10
+                    },
+                    "aggs": {
+                      "sample": {
+                        "top_hits": {
+                          "size": 1,
+                          "_source": {
+                            "includes": [
+                              "env.BUILD_URL",
+                              "test.errorDetails"
+                            ]
+                          },
+                          "sort": [
+                            {
+                              "build.startTime": {
+                                "order": "desc"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "condition": {
+      "script": {
+        "source": """ctx.vars.subject_date = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.ofInstant(ctx.execution_time.toInstant(), ctx.execution_time.getZone())); return true""",
+        "lang": "painless"
+      }
+    },
+    "actions": {
+      "log": {
+        "logging": {
+          "level": "info",
+          "text": """<p>Over the past 7 days, these are the top 10 failing tests:</p><table>{{#ctx.payload.aggregations.top_failures.buckets}}<tr><td colspan="2">{{key}}</td><td>failed {{doc_count}} times:</td></tr>{{#build_urls.buckets}}<tr><td>&nbsp;</td><td><a href="{{sample.hits.hits.0._source.env.BUILD_URL}}">{{key}}</a></td><td>failed {{doc_count}} times</td></tr>{{/build_urls.buckets}}</tr>{{/ctx.payload.aggregations.top_failures.buckets}}</table><p>Click on <a href="https://ela.st/beats-build-dashboard">dashboard</a> to see the overall build overview over the past 7 days</p>"""
+        }
+      }
+    }
+}


### PR DESCRIPTION
## What does this PR do?


Split report per active release branch:
* master
* 7.x
* 7-release -> `7.10` at the time of writing this.


## Why is it important?

It was requested by the beats team


## Notes

I have not found the way to configure a watcher when using the sendEsData step easily, so it requires to override the input field. So I've decided to leave that responsaiblity to the watcher and therefore when there is a minor upgrade (from 7.10 to 7.11) we will need to change the watcher report-beats-top-failing-tests-weekly-7-release to filter by `"env.BRANCH_NAME": "7.11"`