### PR TITLE
Support Windows for withGoEnv

### DIFF
--- a/resources/scripts/install-tools.bat
+++ b/resources/scripts/install-tools.bat
@@ -1,0 +1,53 @@
+where /q curl
+IF ERRORLEVEL 1 (
+    choco install curl -y --no-progress --skipdownloadcache
+    IF ERRORLEVEL 1 (
+        REM curl installation has failed.
+        exit /b 1
+    )
+)
+mkdir %WORKSPACE%\bin
+
+IF EXIST "%PROGRAMFILES(X86)%" (
+    REM Force the gvm installation.
+    SET GVM_BIN=gvm.exe
+    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.4/gvm-windows-amd64.exe
+    IF ERRORLEVEL 1 (
+        REM gvm installation has failed.
+        exit /b 1
+    )
+) ELSE (
+    REM Windows 7 workers got a broken gvm installation.
+    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.4/gvm-windows-386.exe
+    IF ERRORLEVEL 1 (
+        REM gvm installation has failed.
+        exit /b 1
+    )
+)
+
+SET GVM_BIN=gvm.exe
+WHERE /q %GVM_BIN%
+%GVM_BIN% version
+
+REM Install the given go version
+%GVM_BIN% --debug install %GO_VERSION%
+
+REM Configure the given go version
+FOR /f "tokens=*" %%i IN ('"%GVM_BIN%" use %GO_VERSION% --format=batch') DO %%i
+
+go env
+IF ERRORLEVEL 1 (
+    REM go is not configured correctly.
+    exit /b 1
+)
+
+where /q gcc
+IF ERRORLEVEL 1 (
+    REM Install mingw 5.3.0
+    choco install mingw -y -r --no-progress --version 5.3.0
+    IF NOT ERRORLEVEL 0 (
+        exit /b 1
+    )
+)
+gcc --version
+where gcc

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -458,6 +458,10 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     })
     helper.registerAllowedMethod('isUpstreamTrigger', { return false })
     helper.registerAllowedMethod('isUserTrigger', { return false })
+    helper.registerAllowedMethod('is32', {
+      def script = loadScript('vars/is32.groovy')
+      return script.call()
+    })
     helper.registerAllowedMethod('is32arm', {
       def script = loadScript('vars/is32arm.groovy')
       return script.call()
@@ -513,11 +517,17 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], TestUtils.withCredentialsInterceptor)
     helper.registerAllowedMethod('withEnvMask', [Map.class, Closure.class], TestUtils.withEnvMaskInterceptor)
     helper.registerAllowedMethod('withEnvWrapper', [Closure.class], { closure -> closure.call() })
+    helper.registerAllowedMethod('withGithubNotify', [Map.class, Closure.class], null)
     helper.registerAllowedMethod('withGoEnv', [Map.class, Closure.class], { m, c ->
       def script = loadScript('vars/withGoEnv.groovy')
       return script.call(m, c)
     })
-    helper.registerAllowedMethod('withGithubNotify', [Map.class, Closure.class], null)
+    helper.registerAllowedMethod('withGoEnvUnix', [Map.class, Closure.class], { m, c ->
+      return true
+    })
+    helper.registerAllowedMethod('withGoEnvWindows', [Map.class, Closure.class], { m, c ->
+      return true
+    })
     helper.registerAllowedMethod('withMageEnv', [Closure.class], { c ->
       def script = loadScript('vars/withMageEnv.groovy')
       return script.call(c)

--- a/src/test/groovy/WithGoEnvStepTests.groovy
+++ b/src/test/groovy/WithGoEnvStepTests.groovy
@@ -20,128 +20,32 @@ import org.junit.Test
 import static org.junit.Assert.assertTrue
 
 class WithGoEnvStepTests extends ApmBasePipelineTest {
-  String scriptName = 'vars/withGoEnv.groovy'
+  def script
 
   @Override
   @Before
   void setUp() throws Exception {
     super.setUp()
-
-    env.PATH = '/foo/bin'
-    helper.registerAllowedMethod('retryWithSleep', [Map.class, Closure.class], { m, b -> b() })
+    script = loadScript('vars/withGoEnv.groovy')
   }
 
   @Test
-  void test() throws Exception {
-    def script = loadScript(scriptName)
-    helper.registerAllowedMethod('nodeOS', [], { "linux" })
-    def isOK = false
-    script.call(version: "1.12.2"){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-    }
+  void test_is_windows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { return false })
+    script.call(){}
     printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertTrue(assertMethodCallOccurrences('withGoEnvWindows', 1))
+    assertTrue(assertMethodCallOccurrences('withGoEnvUnix', 0))
     assertJobStatusSuccess()
   }
 
   @Test
-  void testGoVersion() throws Exception {
-    def script = loadScript(scriptName)
-    helper.registerAllowedMethod('nodeOS', [], { "linux" })
-    env.GO_VERSION = "1.12.2"
-    def isOK = false
-    script.call(){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-    }
+  void test_is_linux() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { return true })
+    script.call(){}
     printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertTrue(assertMethodCallOccurrences('withGoEnvWindows', 0))
+    assertTrue(assertMethodCallOccurrences('withGoEnvUnix', 1))
     assertJobStatusSuccess()
   }
-
-  @Test
-  void testOS() throws Exception {
-    def script = loadScript(scriptName)
-    helper.registerAllowedMethod('nodeOS', [], { "HAL9000" })
-    env.GO_VERSION = "1.12.2"
-    def isOK = false
-    script.call(){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.HAL9000.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.HAL9000.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
-    assertJobStatusSuccess()
-  }
-
-@Test
-void testOSArg() throws Exception {
-  def script = loadScript(scriptName)
-  env.GO_VERSION = "1.12.2"
-  def isOK = false
-
-  script.call(os: 'custom-os'){
-    if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.custom-os.amd64/bin:/foo/bin"
-      && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.custom-os.amd64"
-      && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-  }
-  printCallStack()
-  assertTrue(isOK)
-  assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
-  assertJobStatusSuccess()
-}
-
-  @Test
-  void testPkgs() throws Exception {
-    def script = loadScript(scriptName)
-    helper.registerAllowedMethod('nodeOS', [], { "linux" })
-    def isOK = false
-    script.call(version: "1.12.2", pkgs: [ "P1", "P2" ]){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
-    assertJobStatusSuccess()
-  }
-
-
-  @Test
-  void testDefaultGoVersion() throws Exception {
-    def script = loadScript(scriptName)
-    helper.registerAllowedMethod('nodeOS', [], { "linux" })
-    def isOK = false
-    script.call(){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.14.2.linux.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.14.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.14.2'))
-    assertJobStatusSuccess()
-  }
-
 }

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/withGoEnvUnix.groovy')
+    env.PATH = '/foo/bin'
+    helper.registerAllowedMethod('retryWithSleep', [Map.class, Closure.class], { m, b -> b() })
+  }
+
+  @Test
+  void test() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def isOK = false
+    script.call(version: "1.12.2"){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGoVersion() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    env.GO_VERSION = "1.12.2"
+    def isOK = false
+    script.call(){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testOS() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "HAL9000" })
+    env.GO_VERSION = "1.12.2"
+    def isOK = false
+    script.call(){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.HAL9000.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.HAL9000.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+@Test
+void testOSArg() throws Exception {
+  env.GO_VERSION = "1.12.2"
+  def isOK = false
+  script.call(os: 'custom-os'){
+    if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.custom-os.amd64/bin:/foo/bin"
+      && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.custom-os.amd64"
+      && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+  }
+  printCallStack()
+  assertTrue(isOK)
+  assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+  assertJobStatusSuccess()
+}
+
+  @Test
+  void testPkgs() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def isOK = false
+    script.call(version: "1.12.2", pkgs: [ "P1", "P2" ]){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testDefaultGoVersion() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def isOK = false
+    script.call(){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.14.2.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.14.2.linux.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.14.2'))
+    assertJobStatusSuccess()
+  }
+
+}

--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class WithGoEnvWindowsStepTests extends ApmBasePipelineTest {
+  def script
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/withGoEnvWindows.groovy')
+    env.PATH = '\\foo\\bin'
+    helper.registerAllowedMethod('is32', {return false})
+    helper.registerAllowedMethod('isUnix', [Closure.class], { return false })
+    helper.registerAllowedMethod('nodeOS', [], { "windows" })
+    helper.registerAllowedMethod('retryWithSleep', [Map.class, Closure.class], { m, b -> b() })
+  }
+
+  def definedVariables(version, suffix='windows') {
+    return (binding.getVariable("PATH") == "WS\\bin;WS\\.gvm\\versions\\go${version}.${suffix}.amd64\\bin;C:\\ProgramData\\chocolatey\\bin;C:\\tools\\mingw64\\bin;\\foo\\bin"
+      && binding.getVariable("GOROOT") == "WS\\.gvm\\versions\\go${version}.${suffix}.amd64"
+      && binding.getVariable("GOPATH") == "WS")
+  }
+
+  @Test
+  void test() throws Exception {
+    def isOK = false
+    script.call(version: '1.12.2'){
+      isOK = definedVariables('1.12.2', 'windows')
+      println isOK
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_GoVersion_env_variable() throws Exception {
+    env.GO_VERSION = '1.12.2'
+    def isOK = false
+    script.call(){
+      isOK = definedVariables('1.12.2', 'windows')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testOS() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "HAL9000" })
+    env.GO_VERSION = '1.12.2'
+    def isOK = false
+    script.call(){
+      isOK = definedVariables('1.12.2', 'HAL9000')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+@Test
+void testOSArg() throws Exception {
+  env.GO_VERSION = '1.12.2'
+  def isOK = false
+  script.call(os: 'custom-os'){
+    isOK = definedVariables('1.12.2', 'custom-os')
+  }
+  printCallStack()
+  assertTrue(isOK)
+  assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.12.2'))
+  assertJobStatusSuccess()
+}
+
+  @Test
+  void testPkgs() throws Exception {
+    def isOK = false
+    script.call(version: '1.12.2', pkgs: [ "P1", "P2" ]){
+      isOK = definedVariables('1.12.2', 'windows')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing P1'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testDefaultGoVersion() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "windows" })
+    def isOK = false
+    script.call(){
+      isOK = definedVariables('1.14.2', 'windows')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.14.2'))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -2254,7 +2254,8 @@ withGithubNotify(context: 'Release', tab: 'artifacts') {
 [Pipeline GitHub Notify Step plugin](https://plugins.jenkins.io/pipeline-githubnotify-step)
 
 ## withGoEnv
- Install Go and run some command in a pre-configured environment.
+ Install Go and run some command in a pre-configured environment multiplatform. For such
+ it's recommended to use the `cmd` step.
 
 ```
   withGoEnv(version: '1.14.2'){
@@ -2276,6 +2277,54 @@ withGithubNotify(context: 'Release', tab: 'artifacts') {
 * version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
+
+## withGoEnvUnix
+ Install Go and run some command in a pre-configured environment for Unix.
+
+```
+  withGoEnvUnix(version: '1.14.2'){
+    sh(label: 'Go version', script: 'go version')
+  }
+```
+
+```
+   withGoEnvUnix(version: '1.14.2', pkgs: [
+       "github.com/magefile/mage",
+       "github.com/elastic/go-licenser",
+       "golang.org/x/tools/cmd/goimports",
+   ]){
+       sh(label: 'Run mage',script: 'mage -version')
+   }
+  }
+```
+
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* pkgs: Go packages to install with Go get before to execute any command.
+* os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
+
+## withGoEnvWindows
+ Install Go and run some command in a pre-configured environment for Windows.
+
+```
+  withGoEnvWindows(version: '1.14.2'){
+    bat(label: 'Go version', script: 'go version')
+  }
+```
+
+```
+   withGoEnvWindows(version: '1.14.2', pkgs: [
+       "github.com/magefile/mage",
+       "github.com/elastic/go-licenser",
+       "golang.org/x/tools/cmd/goimports",
+   ]){
+       bat(label: 'Run mage',script: 'mage -version')
+   }
+  }
+```
+
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* pkgs: Go packages to install with Go get before to execute any command.
+* os: OS to use. (Example: `windows`). This is an option argument and if not set, the worker label will be used.
 
 ## withHubCredentials
 Configure the hub app to run the body closure.

--- a/vars/withGoEnv.groovy
+++ b/vars/withGoEnv.groovy
@@ -19,7 +19,7 @@
  Install Go and run some command in a pre-configured environment.
 
   withGoEnv(version: '1.14.2'){
-    sh(label: 'Go version', script: 'go version')
+    cmd(label: 'Go version', script: 'go version')
   }
 
    withGoEnv(version: '1.14.2', pkgs: [
@@ -27,34 +27,20 @@
        "github.com/elastic/go-licenser",
        "golang.org/x/tools/cmd/goimports",
    ]){
-       sh(label: 'Run mage',script: 'mage -version')
+       cmd(label: 'Run mage',script: 'mage -version')
    }
 
 }
 
 */
 def call(Map args = [:], Closure body) {
-  def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
-  def version = args.containsKey('version') ? args.version : goDefaultVersion
-  def pkgs = args.containsKey('pkgs') ? args.pkgs : []
-  def os = args.containsKey('os') ? args.os : nodeOS()
-  def lastCoordinate = version[-2..-1]
-  // gvm remove the last coordinate if it is 0
-  def goDir = ".gvm/versions/go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.amd64"
-  withEnv([
-    "HOME=${env.WORKSPACE}",
-    "PATH=${env.WORKSPACE}/bin:${env.WORKSPACE}/${goDir}/bin:${env.PATH}",
-    "GOROOT=${env.WORKSPACE}/${goDir}",
-    "GOPATH=${env.WORKSPACE}"
-  ]){
-    retryWithSleep(retries: 3, seconds: 5, backoff: true){
-      sh(label: "Installing go ${version}", script: "gvm ${version}")
+  if (isUnix()) {
+    withGoEnvUnix(args) {
+      body()
     }
-    pkgs?.each{ p ->
-      retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        sh(label: "Installing ${p}", script: "go get -u ${p}")
-      }
+  } else {
+    withGoEnvWindows(args) {
+      body()
     }
-    body()
   }
 }

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ Install Go and run some command in a pre-configured environment for Unix.
+
+  withGoEnvUnix(version: '1.14.2'){
+    sh(label: 'Go version', script: 'go version')
+  }
+
+   withGoEnvUnix(version: '1.14.2', pkgs: [
+       "github.com/magefile/mage",
+       "github.com/elastic/go-licenser",
+       "golang.org/x/tools/cmd/goimports",
+   ]){
+       sh(label: 'Run mage',script: 'mage -version')
+   }
+
+}
+
+*/
+def call(Map args = [:], Closure body) {
+  def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
+  def version = args.containsKey('version') ? args.version : goDefaultVersion
+  def pkgs = args.containsKey('pkgs') ? args.pkgs : []
+  def os = args.containsKey('os') ? args.os : nodeOS()
+  def lastCoordinate = version[-2..-1]
+  // gvm remove the last coordinate if it is 0
+  def goDir = ".gvm/versions/go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.amd64"
+  withEnv([
+    "HOME=${env.WORKSPACE}",
+    "PATH=${env.WORKSPACE}/bin:${env.WORKSPACE}/${goDir}/bin:${env.PATH}",
+    "GOROOT=${env.WORKSPACE}/${goDir}",
+    "GOPATH=${env.WORKSPACE}"
+  ]){
+    retryWithSleep(retries: 3, seconds: 5, backoff: true){
+      sh(label: "Installing go ${version}", script: "gvm ${version}")
+    }
+    pkgs?.each{ p ->
+      retryWithSleep(retries: 3, seconds: 5, backoff: true){
+        sh(label: "Installing ${p}", script: "go get -u ${p}")
+      }
+    }
+    body()
+  }
+}

--- a/vars/withGoEnvUnix.txt
+++ b/vars/withGoEnvUnix.txt
@@ -1,14 +1,13 @@
- Install Go and run some command in a pre-configured environment multiplatform. For such
- it's recommended to use the `cmd` step.
+ Install Go and run some command in a pre-configured environment for Unix.
 
 ```
-  withGoEnv(version: '1.14.2'){
+  withGoEnvUnix(version: '1.14.2'){
     sh(label: 'Go version', script: 'go version')
   }
 ```
 
 ```
-   withGoEnv(version: '1.14.2', pkgs: [
+   withGoEnvUnix(version: '1.14.2', pkgs: [
        "github.com/magefile/mage",
        "github.com/elastic/go-licenser",
        "golang.org/x/tools/cmd/goimports",

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -52,7 +52,8 @@ def call(Map args = [:], Closure body) {
     "HOME=${env.WORKSPACE}",
     "PATH=${path}",
     "GOROOT=${goRoot}",
-    "GOPATH=${env.WORKSPACE}"
+    "GOPATH=${env.WORKSPACE}",
+    "USERPROFILE=${userProfile}"
   ]){
     def content = libraryResource('scripts/install-tools.bat')
     retryWithSleep(retries: 2, seconds: 5, backoff: true){

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ Install Go and run some command in a pre-configured environment for Windows.
+
+  withGoEnvWindows(version: '1.14.2'){
+    bat(label: 'Go version', script: 'go version')
+  }
+
+   withGoEnvWindows(version: '1.14.2', pkgs: [
+       "github.com/magefile/mage",
+       "github.com/elastic/go-licenser",
+       "golang.org/x/tools/cmd/goimports",
+   ]){
+       bat(label: 'Run mage',script: 'mage -version')
+   }
+
+}
+
+*/
+def call(Map args = [:], Closure body) {
+  def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
+  def version = args.containsKey('version') ? args.version : goDefaultVersion
+  def pkgs = args.containsKey('pkgs') ? args.pkgs : []
+  def os = args.containsKey('os') ? args.os : nodeOS()
+  def mingwArch = is32() ? '32' : '64'
+  def goArch = is32() ? '386' : 'amd64'
+  def chocoPath = 'C:\\ProgramData\\chocolatey\\bin'
+  def userProfile="${env.WORKSPACE}"
+  // gvm remove the last coordinate if it is 0
+  def lastCoordinate = version[-2..-1]
+  def goDir = ".gvm\\versions\\go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.${goArch}"
+  def goRoot = "${userProfile}\\${goDir}"
+  def path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};C:\\tools\\mingw${mingwArch}\\bin;${env.PATH}"
+
+  withEnv([
+    "HOME=${env.WORKSPACE}",
+    "PATH=${path}",
+    "GOROOT=${goRoot}",
+    "GOPATH=${env.WORKSPACE}"
+  ]){
+    def content = libraryResource('scripts/install-tools.bat')
+    retryWithSleep(retries: 2, seconds: 5, backoff: true){
+      bat(label: "Installing Go ${version}", script: content)
+    }
+    pkgs?.each{ p ->
+      retryWithSleep(retries: 3, seconds: 5, backoff: true){
+        bat(label: "Installing ${p}", script: "go get -u ${p}")
+      }
+    }
+    body()
+  }
+}

--- a/vars/withGoEnvWindows.txt
+++ b/vars/withGoEnvWindows.txt
@@ -1,0 +1,22 @@
+ Install Go and run some command in a pre-configured environment for Windows.
+
+```
+  withGoEnvWindows(version: '1.14.2'){
+    bat(label: 'Go version', script: 'go version')
+  }
+```
+
+```
+   withGoEnvWindows(version: '1.14.2', pkgs: [
+       "github.com/magefile/mage",
+       "github.com/elastic/go-licenser",
+       "golang.org/x/tools/cmd/goimports",
+   ]){
+       bat(label: 'Run mage',script: 'mage -version')
+   }
+  }
+```
+
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* pkgs: Go packages to install with Go get before to execute any command.
+* os: OS to use. (Example: `windows`). This is an option argument and if not set, the worker label will be used.


### PR DESCRIPTION
## What does this PR do?

Support Windows for `withGoEnv`

## Why is it important?

Helps to refactor the support for Go projects in Windows.

## Related issues
Caused by https://github.com/elastic/go-windows/pull/14/files and https://github.com/elastic/go-concert/pull/36

## Tests

- [x] UTs
- [x] ITs - > See https://github.com/elastic/go-windows/pull/15
