### PR TITLE
Use maven 4 alpha

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/70/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar
-


### PR DESCRIPTION
## What does this PR do?

Use maven 4 alpha from [here](https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/70/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/) that was found with the brew tap [module](https://github.com/mthmulders/homebrew-maven-snapshot/blob/master/Formula/maven-snapshot.rb#L4)

## Why is it important?

Test if it works as expected :)


## Related issues
Closes #ISSUE