### PR TITLE
chore: rename argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .idea
 *.iml
 release.properties

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 .idea
 *.iml
 release.properties

--- a/vars/dummy.groovy
+++ b/vars/dummy.groovy
@@ -25,7 +25,7 @@ def method(){
  dummy(text: 'hello world')
 
 */
-def call(Map params = [:]) {
-  def text = params.containsKey('text') ? params.text : 'sample text'
+def call(Map args = [:]) {
+  def text = args.containsKey('text') ? args.text : 'sample text'
   log(level: 'INFO', text: 'I am a dummy step - ' + text)
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Rename the argument `params` to `args`in the dummy step.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This step is the template for new steps, the use of `args` as name for the arguments is better and avoid conflicts/confusion with the global `params` variable.

## Related issues
Closes #ISSUE
