### PR TITLE
feat: filebeat pipeline step

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -27,6 +27,7 @@ alpine:3.10.1
 node:12-slim
 node:12.7.0-stretch-slim
 python:3.7.4-alpine3.10
+docker.elastic.co/beats/filebeat:7.10.1
 docker.elastic.co/infra/jjbb
 docker.elastic.co/observability-ci/codecov
 docker.elastic.co/observability-ci/golang-mage

--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class FilebeatStepTests extends ApmBasePipelineTest {
+  String scriptName = 'vars/filebeat.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+  }
+
+  @Test
+  void test() throws Exception {
+    helper.registerAllowedMethod('fileExists', [String.class], { false })
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'filebeat_conf.yml:/usr/share/filebeat/filebeat.yml'))
+    assertTrue(assertMethodCallContainsPattern('writeFile', 'file=filebeat_conf.yml'))
+    assertTrue(assertMethodCallContainsPattern('writeFile', 'filename: docker_logs.log'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker.elastic.co/beats/filebeat'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testConfigurationExists() throws Exception {
+    def script = loadScript(scriptName)
+    script.call()
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'filebeat_conf.yml:/usr/share/filebeat/filebeat.yml'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker.elastic.co/beats/filebeat'))
+    assertFalse(assertMethodCallContainsPattern('writeFile', 'file=filebeat_conf.yml'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testArguments() throws Exception {
+    helper.registerAllowedMethod('fileExists', [String.class], { false })
+    def output = "foo.log"
+    def config = "bar.xml"
+    def image = "foo:latest"
+    def workdir = "fooDir"
+
+    def script = loadScript(scriptName)
+    script.call(
+      output: output,
+      config: config,
+      image: image,
+      workdir: workdir,
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "${config}:/usr/share/filebeat/filebeat.yml"))
+    assertTrue(assertMethodCallContainsPattern('writeFile', "file=${config}"))
+    assertTrue(assertMethodCallContainsPattern('writeFile', "filename: ${output}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "${image}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "${workdir}:/output"))
+    assertJobStatusSuccess()
+  }
+}

--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -76,4 +76,24 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('sh', "${workdir}:/output"))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testStop() throws Exception {
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], { m -> return m.artifacts})
+    def config = "filebeat_container_config.json"
+    def id = "fooID"
+    def output = "foo.log"
+    def workdir = "filebeatTest"
+
+    def script = loadScript(scriptName)
+    script.stop(
+      workdir: workdir,
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${config}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "docker exec ${id}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "docker kill ${id}"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/resources/filebeatTest/filebeat_container_config.json
+++ b/src/test/resources/filebeatTest/filebeat_container_config.json
@@ -1,0 +1,7 @@
+{
+  "id": "fooID",
+  "output": "foo.log",
+  "config": "bar.xml",
+  "image": "foo: latest",
+  "workdir": "fooDir"
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -377,6 +377,12 @@ Print a text on color on a xterm.
   filebeat.stop()
 ```
 
+```
+  filebeat(){
+    ....
+  }
+```
+
 * *config:* Filebeat configuration file, a default configuration is created if the file does not exists (filebeat_conf.yml).
 * *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
 * *output:* log file to save all Docker containers logs (docker_logs.log).
@@ -405,6 +411,21 @@ pipeline {
           script {
             filebeat.stop(workdir: "${env.WORKSPACE}")
           }
+        }
+      }
+    }
+  }
+}
+```
+
+```
+pipeline {
+  agent { label "ubuntu" }
+  stages {
+    stage('My Docker tests') {
+      steps {
+        filebeat(workdir: "${env.WORKSPACE}"){
+          sh('docker run busybox  ls')
         }
       }
     }

--- a/vars/README.md
+++ b/vars/README.md
@@ -365,6 +365,53 @@ Print a text on color on a xterm.
 * *colorfg*: Foreground color.(default, red, green, yellow,...)
 * *colorbg*: Background color.(default, red, green, yellow,...)
 
+## filebeat
+
+ This step run a filebeat Docker container to grab the Docker containers logs in a single file.
+ `filebeat.stop()` will stop the Filebeat Docker container and grab the output files,
+ the only argument need is the `workdir` if you set it on the `filebeat step` call.
+
+```
+  filebeat()
+  ...
+  filebeat.stop()
+```
+
+* *config:* Filebeat configuration file, a default configuration is created if the file does not exists (filebeat_conf.yml).
+* *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
+* *output:* log file to save all Docker containers logs (docker_logs.log).
+* *workdir:* Directory to use as root folder to read and write files (WORKSPACE).
+
+```
+  filebeat(config: 'filebeat.yml',
+    image: 'docker.elastic.co/beats/filebeat:7.10.1',
+    output: 'docker_logs.log',
+    workdir: "${env.WORKSPACE}")
+  ...
+  filebeat.stop(workdir: "${env.WORKSPACE}")
+```
+
+```
+pipeline {
+  agent { label "ubuntu" }
+  stages {
+    stage('My Docker tests') {
+      steps {
+        filebeat(workdir: "${env.WORKSPACE}")
+        sh('docker run busybox  ls')
+      }
+      post {
+        cleanup{
+          script {
+            filebeat.stop(workdir: "${env.WORKSPACE}")
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## generateChangelog
 Programatically generate a CHANGELOG
 

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ This step run a filebeat Docker container to grab the Docker containers logs ina single file.
+
+ filebeat(output: 'docker_logs.log')
+ ...
+ filebeat.stop()
+*/
+def call(Map args = [:]) {
+  start(args)
+}
+
+def start(Map args = [:]) {
+  def output = args.containsKey('output') ? args.output : 'docker_logs.log'
+  def config = args.containsKey('config') ? args.config : "filebeat_conf.yml"
+  def image = args.containsKey('image') ? args.image : "docker.elastic.co/beats/filebeat:7.10.1"
+  def workdir = args.containsKey('workdir') ? args.workdir : "${env.WORKSPACE}"
+  log(level: 'INFO', text: 'Running Filebeat Docker container')
+
+  configureFilebeat(config, output)
+  dockerID = sh(label: 'Run filebeat to grab container logs', script: """
+    docker run \
+      --detach \
+      -v ${workdir}:/output \
+      -v ${workdir}/${config}:/usr/share/filebeat/filebeat.yml \
+      -u 0:0 \
+      -v /var/lib/docker/containers:/var/lib/docker/containers \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      ${image} \
+        --strict.perms=false \
+        -environment container \
+        -E http.enabled=true
+  """, returnStdout: true)?.trim()
+  sh(label: 'Wait for Filebeat', script: """
+    docker exec ${dockerID} \
+      curl -sSfI --retry 10 --retry-delay 5 --max-time 5 'http://localhost:5066/stats?pretty'
+  """)
+
+  def json = [
+    id: dockerID,
+    output: output,
+    config: config,
+    image: image,
+    workdir: workdir
+  ]
+
+  writeJSON(file: "${workdir}/filebeat_container_config.json", json: json)
+}
+
+def stop(Map args = [:]){
+  def workdir = args.containsKey('workdir') ? args.workdir : "${env.WORKSPACE}"
+  def config = readJSON(file: "${workdir}/filebeat_container_config.json")
+  log(level: 'INFO', text: 'Stopping Filebeat Docker container')
+
+  sh(label: 'Stop filebeat', script: """
+    docker exec ${dockerID} chmod -R ugo+rw /output
+    docker kill ${config.id}
+  """)
+  archiveArtifacts(artifacts: "**/${config.output}*", allowEmptyArchive: true)
+}
+
+def configureFilebeat(config, output){
+  if(fileExists(config)){
+    return
+  }
+  def configuration = """
+---
+filebeat.autodiscover:
+  providers:
+    - type: docker
+      templates:
+        - config:
+          - type: container
+            paths:
+              - /var/lib/docker/containers/\${data.docker.container.id}/*.log
+processors:
+  - add_host_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
+  - add_kubernetes_metadata: ~
+output.file:
+  path: "/output"
+  filename: ${output}
+  permissions: 0644
+  codec.format:
+    string: '[%{[container.name]}][%{[container.image.name]}][%{[container.id]}][%{[@timestamp]}] %{[message]}'
+"""
+  writeFile(file: config, text: configuration)
+}

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -26,6 +26,15 @@ def call(Map args = [:]) {
   start(args)
 }
 
+def call(Map args = [:], Closure body) {
+  try{
+    start(args)
+    body()
+  } finally {
+    stop(args)
+  }
+}
+
 def start(Map args = [:]) {
   def output = args.containsKey('output') ? args.output : 'docker_logs.log'
   def config = args.containsKey('config') ? args.config : "filebeat_conf.yml"

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -69,7 +69,7 @@ def stop(Map args = [:]){
   log(level: 'INFO', text: 'Stopping Filebeat Docker container')
 
   sh(label: 'Stop filebeat', script: """
-    docker exec ${dockerID} chmod -R ugo+rw /output
+    docker exec ${config.id} chmod -R ugo+rw /output
     docker kill ${config.id}
   """)
   archiveArtifacts(artifacts: "**/${config.output}*", allowEmptyArchive: true)

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -68,6 +68,8 @@ def stop(Map args = [:]){
   def config = readJSON(file: "${workdir}/filebeat_container_config.json")
   log(level: 'INFO', text: 'Stopping Filebeat Docker container')
 
+  // we need to change the permission because the group others never will have permissions
+  // due to the harcoded creation mask, see https://github.com/elastic/beats/issues/20584
   sh(label: 'Stop filebeat', script: """
     docker exec ${config.id} chmod -R ugo+rw /output
     docker kill ${config.id}

--- a/vars/filebeat.txt
+++ b/vars/filebeat.txt
@@ -1,0 +1,45 @@
+
+ This step run a filebeat Docker container to grab the Docker containers logs in a single file.
+ `filebeat.stop()` will stop the Filebeat Docker container and grab the output files,
+ the only argument need is the `workdir` if you set it on the `filebeat step` call.
+
+```
+  filebeat()
+  ...
+  filebeat.stop()
+```
+
+* *config:* Filebeat configuration file, a default configuration is created if the file does not exists (filebeat_conf.yml).
+* *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
+* *output:* log file to save all Docker containers logs (docker_logs.log).
+* *workdir:* Directory to use as root folder to read and write files (WORKSPACE).
+
+```
+  filebeat(config: 'filebeat.yml',
+    image: 'docker.elastic.co/beats/filebeat:7.10.1',
+    output: 'docker_logs.log',
+    workdir: "${env.WORKSPACE}")
+  ...
+  filebeat.stop(workdir: "${env.WORKSPACE}")
+```
+
+```
+pipeline {
+  agent { label "ubuntu" }
+  stages {
+    stage('My Docker tests') {
+      steps {
+        filebeat(workdir: "${env.WORKSPACE}")
+        sh('docker run busybox  ls')
+      }
+      post {
+        cleanup{
+          script {
+            filebeat.stop(workdir: "${env.WORKSPACE}")
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/vars/filebeat.txt
+++ b/vars/filebeat.txt
@@ -9,6 +9,12 @@
   filebeat.stop()
 ```
 
+```
+  filebeat(){
+    ....
+  }
+```
+
 * *config:* Filebeat configuration file, a default configuration is created if the file does not exists (filebeat_conf.yml).
 * *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
 * *output:* log file to save all Docker containers logs (docker_logs.log).
@@ -37,6 +43,21 @@ pipeline {
           script {
             filebeat.stop(workdir: "${env.WORKSPACE}")
           }
+        }
+      }
+    }
+  }
+}
+```
+
+```
+pipeline {
+  agent { label "ubuntu" }
+  stages {
+    stage('My Docker tests') {
+      steps {
+        filebeat(workdir: "${env.WORKSPACE}"){
+          sh('docker run busybox  ls')
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Adds Filebeat to the packer cache
* Adds the `filebeat` pipeline step to run Filebeat easily.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This new `filebeat` pipeline step allows grabbing the Docker container logs with a couple of steps.

```
pipeline {
  agent { label "ubuntu" }
  stages {
    stage('My Docker tests') {
      steps {
        filebeat(workdir: "${env.WORKSPACE}")
        sh('docker run busybox  ls')
      }
      post {
        cleanup{
          script {
            filebeat.stop(workdir: "${env.WORKSPACE}")
          }
        }
      }
    }
  }
}
```

```
pipeline {
  agent { label "ubuntu" }
  stages {
    stage('My Docker tests') {
      steps {
        filebeat(workdir: "${env.WORKSPACE}"){
        sh('docker run busybox  ls')

        }
      }
    }
  }
}
```
