### PR TITLE
Support not_changeset_full_match for beats

### DIFF
--- a/src/test/groovy/BeatsWhenStepTests.groovy
+++ b/src/test/groovy/BeatsWhenStepTests.groovy
@@ -361,6 +361,90 @@ class BeatsWhenStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_whenNotChangesetFullMatch_and_no_data() throws Exception {
+    def script = loadScript(scriptName)
+    def ret = script.whenNotChangesetFullMatch()
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_and_content_without_match() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = 'Jenkinsfile'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '^.ci'])
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_and_content_with_match() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = 'Jenkinsfile'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '^Jenkinsfile'])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_and_content_with_full_match() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = '''.ci/Jenkinsfile
+.ci/jobs
+'''
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '^.ci.*'])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_and_content_without_full_match_no_matches() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = '''.ci/Jenkinsfile
+.ci/jobs
+'''
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '^.foo.*'])
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_and_content_without_full_match_with_partial_matches() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = '''.ci/Jenkinsfile
+.foo/jobs
+'''
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '^.ci.*'])
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_content_and_macro() throws Exception {
+    def script = loadScript(scriptName)
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '@oss'],
+                                               changeset: [ oss: [ '^oss'] ])
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_whenNotChangesetFullMatch_content_and_macro_with_match() throws Exception {
+    def script = loadScript(scriptName)
+    def changeset = 'oss'
+    helper.registerAllowedMethod('readFile', [String.class], { return changeset })
+    def ret = script.whenNotChangesetFullMatch(content: [ not_changeset_full_match: '@oss'],
+                                               changeset: [ oss: [ '^oss'] ])
+    printCallStack()
+    assertFalse(ret)
+  }
+
+  @Test
   void test_whenParameters_and_no_params() throws Exception {
     def script = loadScript(scriptName)
     def ret = script.whenParameters()

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -64,7 +64,7 @@ private Boolean whenChangeset(Map args = [:]) {
   if (args.content?.get('changeset')) {
     def arguments = args
     arguments.name = name
-    return changeset(args)
+    return changeset(arguments)
   } else {
     markdownReason(project: args.project, reason: "* ${name} is `disabled`.")
   }


### PR DESCRIPTION
## What does this PR do?

Support a new when condition to full match the changeset

## Why is it important?

Otherwise, there is a chance that some PRs won't trigger mandatory fields since it uses a partial match at the moment.


## For the review

- First commit (https://github.com/elastic/apm-pipeline-library/pull/890/commits/e1ba36d22b1b1dc09b5a0b795becf2f7f9b11db4) was a refactor, so almost all the logic for the `whenChangeset` was moved to a new function `changeset`.
- Second commit (https://github.com/elastic/apm-pipeline-library/pull/890/commits/578f4f80b197a9d6a9b21098ecb3c3e5f2d9d461), added the new when condition.
