### PR TITLE
fix: wait for docker exec to finish

### DIFF
--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -69,7 +69,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('sh', "${image}"))
 
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${stepConfig}"))
-    assertTrue(assertMethodCallContainsPattern('sh', "docker exec ${id}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker kill ${id}"))
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()
@@ -106,7 +106,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
       assertTrue(assertMethodCallContainsPattern('sh', "${image}"))
 
       assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${stepConfig}"))
-      assertTrue(assertMethodCallContainsPattern('sh', "docker exec ${id}"))
+      assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker kill ${id}"))
       assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     }
@@ -161,7 +161,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${config}"))
-    assertTrue(assertMethodCallContainsPattern('sh', "docker exec ${id}"))
+    assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker kill ${id}"))
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -80,8 +80,8 @@ def stop(Map args = [:]){
   // we need to change the permission because the group others never will have permissions
   // due to the harcoded creation mask, see https://github.com/elastic/beats/issues/20584
   sh(label: 'Stop filebeat', script: """
-    docker exec ${config.id} chmod -R ugo+rw /output
-    docker kill ${config.id}
+    docker exec -t ${config.id} chmod -R ugo+rw /output || echo "Exit code \$?"
+    docker kill ${config.id} || echo "Exit code \$?"
   """)
   archiveArtifacts(artifacts: "**/${config.output}*", allowEmptyArchive: true)
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* add a docker option to wait for `docker exec`
* ignore command failures and print the exit code

