### PR TITLE
[CI][mvn4] Use lastSuccessfulBuild

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/70/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin.zip
+distributionUrl=https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/lastSuccessfulBuild/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar


### PR DESCRIPTION
## What does this PR do?

Use link to the latest successfull build instead a specific build

## Why is it important?

Avoid using old deleted builds.

It's not ideal but as long as mvn 4 is not released in a different manner, we cannot do much unless we archive those artifacts somewhere.

## Important

This will not add reproducibility to our builds since it'll use the latest stable artifacts, but I think once we are on mvn4 any incremental changes should be backward compatibly, if not, at least we can provide value feedback to the maven project.


I'll ask the maven project if they have another suggestion to use their latest mvn 4 artifacts
