### PR TITLE
fix: use current folder instead of the workspace

### DIFF
--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -58,6 +58,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
       }
       return ret
     })
+    helper.registerAllowedMethod('pwd', [], { 'filebeatTest' })
   }
 
   @Test
@@ -67,7 +68,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     script.call()
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'filebeat_conf.yml:/usr/share/filebeat/filebeat.yml'))
-    assertTrue(assertMethodCallContainsPattern('writeFile', "file=${env.WORKSPACE}/filebeat_conf.yml"))
+    assertTrue(assertMethodCallContainsPattern('writeFile', "file=filebeatTest/filebeat_conf.yml"))
     assertTrue(assertMethodCallContainsPattern('writeFile', 'filename: docker_logs.log'))
     assertTrue(assertMethodCallContainsPattern('sh', 'docker.elastic.co/beats/filebeat'))
     assertJobStatusSuccess()

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -39,7 +39,7 @@ def start(Map args = [:]) {
   def output = args.containsKey('output') ? args.output : 'docker_logs.log'
   def config = args.containsKey('config') ? args.config : "filebeat_conf.yml"
   def image = args.containsKey('image') ? args.image : "docker.elastic.co/beats/filebeat:7.10.1"
-  def workdir = args.containsKey('workdir') ? args.workdir : "${env.WORKSPACE}"
+  def workdir = args.containsKey('workdir') ? args.workdir : pwd()
   def timeout = args.containsKey('timeout') ? args.timeout : "30"
   def configPath = "${workdir}/${config}"
 
@@ -77,7 +77,7 @@ def start(Map args = [:]) {
 }
 
 def stop(Map args = [:]){
-  def workdir = args.containsKey('workdir') ? args.workdir : "${env.WORKSPACE}"
+  def workdir = args.containsKey('workdir') ? args.workdir : pwd()
   def stepConfig = readJSON(file: "${workdir}/filebeat_container_${env.NODE_NAME}.json")
   def timeout = args.containsKey('timeout') ? args.timeout : stepConfig.timeout
 

--- a/vars/filebeat.txt
+++ b/vars/filebeat.txt
@@ -2,7 +2,7 @@
  This step run a filebeat Docker container to grab the Docker containers logs in a single file.
  `filebeat.stop()` will stop the Filebeat Docker container and grab the output files,
  the only argument need is the `workdir` if you set it on the `filebeat step` call.
- The output log files should be in a relative parth to the current path (see [archiveArtifacts](https://www.jenkins.io/doc/pipeline/steps/core/#archiveartifacts-archive-the-artifacts))
+ The output log files should be in a relative path to the current path (see [archiveArtifacts](https://www.jenkins.io/doc/pipeline/steps/core/#archiveartifacts-archive-the-artifacts))
 
 ```
   filebeat()

--- a/vars/filebeat.txt
+++ b/vars/filebeat.txt
@@ -2,6 +2,7 @@
  This step run a filebeat Docker container to grab the Docker containers logs in a single file.
  `filebeat.stop()` will stop the Filebeat Docker container and grab the output files,
  the only argument need is the `workdir` if you set it on the `filebeat step` call.
+ The output log files should be in a relative parth to the current path (see [archiveArtifacts](https://www.jenkins.io/doc/pipeline/steps/core/#archiveartifacts-archive-the-artifacts))
 
 ```
   filebeat()
@@ -19,7 +20,7 @@
 * *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
 * *output:* log file to save all Docker containers logs (docker_logs.log).
 * *timeout:* Time to wait before kill the Filebeat Docker container on the stop operation.
-* *workdir:* Directory to use as root folder to read and write files (WORKSPACE).
+* *workdir:* Directory to use as root folder to read and write files (current folder).
 
 ```
   filebeat(config: 'filebeat.yml',


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Use the current dir by default for all generated files.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
ArchiveArtifacts uses relative routes to the current folder, so grab files outside this scope make the step complex without need, because of that we change to use the current folder as workdir for the generated files.

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/897
