### PR TITLE
feat: goDefaultVersion step

### DIFF
--- a/src/test/groovy/GoDefaultVersionStepTests.groovy
+++ b/src/test/groovy/GoDefaultVersionStepTests.groovy
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotEquals
+
+class GoDefaultVersionStepTests extends ApmBasePipelineTest {
+  String scriptName = 'vars/goDefaultVersion.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    helper.registerAllowedMethod('fileExists', [String.class], { false })
+  }
+
+  @Test
+  void test() throws Exception {
+    def script = loadScript(scriptName)
+    String version = script.call()
+    printCallStack()
+    assertNotEquals("", version)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGoVersionEnvVar() throws Exception {
+    def script = loadScript(scriptName)
+    env.GO_VERSION = "foo"
+    String version = script.call()
+    printCallStack()
+    assertEquals("foo", version)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGoVersionFromFile() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('fileExists', [String.class], { true })
+    helper.registerAllowedMethod('readFile', [Map.class], { 'fooFromFile\n' })
+    String version = script.call()
+    printCallStack()
+    assertEquals("fooFromFile", version)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testGoVersionEnvVarPrecedence() throws Exception {
+    def script = loadScript(scriptName)
+    env.GO_VERSION = "foo"
+    helper.registerAllowedMethod('fileExists', [String.class], { true })
+    helper.registerAllowedMethod('readFile', [Map.class], { 'fooFromFile\n' })
+    String version = script.call()
+    printCallStack()
+    assertEquals("foo", version)
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Return the value of the variable GO_VERSION, the value in the file `.go-version`, or a default value.
+
+  goDefaultVersion()
+**/
+def call(Map args = [:]) {
+  def goDefaultVersion = isGoVersionEnvVarSet() ? "${env.GO_VERSION}" : '1.15.6'
+  def goFileVersion = '.go-version'
+  if(!isGoVersionEnvVarSet() && fileExists(goFileVersion)){
+    goDefaultVersion = readFile(file: goFileVersion)?.trim()
+  }
+  return  goDefaultVersion
+}
+
+def isGoVersionEnvVarSet(){
+  return env.GO_VERSION != null && "" != "${env.GO_VERSION}"
+}

--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -21,12 +21,16 @@
   goDefaultVersion()
 **/
 def call(Map args = [:]) {
-  def goDefaultVersion = isGoVersionEnvVarSet() ? "${env.GO_VERSION}" : '1.15.6'
-  def goFileVersion = '.go-version'
-  if(!isGoVersionEnvVarSet() && fileExists(goFileVersion)){
-    goDefaultVersion = readFile(file: goFileVersion)?.trim()
+  def goDefaultVersion = '1.15.6'
+  if(isGoVersionEnvVarSet()) {
+    goDefaultVersion = "${env.GO_VERSION}"
+  } else {
+    def goFileVersion = '.go-version'
+    if (fileExists(goFileVersion)){
+      goDefaultVersion = readFile(file: goFileVersion)?.trim()
+    }
   }
-  return  goDefaultVersion
+  return goDefaultVersion
 }
 
 def isGoVersionEnvVarSet(){

--- a/vars/goDefaultVersion.txt
+++ b/vars/goDefaultVersion.txt
@@ -1,0 +1,6 @@
+
+  Return the value of the variable GO_VERSION, the value in the file `.go-version`, or a default value
+
+  ```
+  goDefaultVersion()
+  ```


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Add a new step to get the default Go version we use.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
We have duplicate logic across projects to do exactly the same, also we have harcoded values we have to update manually across repos, this resolves both issues.

## Related issues
caused by https://github.com/elastic/ecs-logging-go-zap/pull/28