### PR TITLE
feat: add stackVersions step

### DIFF
--- a/src/test/groovy/StackVersionsStepTests.groovy
+++ b/src/test/groovy/StackVersionsStepTests.groovy
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class StackVersionsStepTests extends ApmBasePipelineTest {
+  String scriptName = 'vars/stackVersions.groovy'
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+  }
+
+  @Test
+  void test() throws Exception {
+    def script = loadScript(scriptName)
+    def versions = script.call()
+    printCallStack()
+    assertTrue(versions instanceof ArrayList)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testEdge() throws Exception {
+    def script = loadScript(scriptName)
+    def versions = script.edge()
+    printCallStack()
+    assertTrue(versions != "")
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testDev() throws Exception {
+    def script = loadScript(scriptName)
+    def versions = script.dev()
+    printCallStack()
+    assertTrue(versions != "")
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testRelease() throws Exception {
+    def script = loadScript(scriptName)
+    def versions = script.release()
+    printCallStack()
+    assertTrue(versions != "")
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testSnapshot() throws Exception {
+    def script = loadScript(scriptName)
+    def versions = script.edge(snapshot: true)
+    printCallStack()
+    assertTrue(versions != "")
+    assertTrue(versions.contains("-SNAPSHOT"))
+    assertTrue(versions.contains(script.edge()))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -27,11 +27,11 @@
   stackVersions.edge(snapshot: true)
 
 **/
-def call(Map params = [:]) {
+def call(Map args = [:]) {
   return [
-    edge(params),
-    dev(params),
-    release(params)
+    edge(args),
+    dev(args),
+    release(args)
   ]
 }
 
@@ -39,22 +39,22 @@ def snapshot(version){
   return "${version}-SNAPSHOT"
 }
 
-def version(value, params = [:]){
-  return "${value}${isSnapshot(params)}"
+def version(value, args = [:]){
+  return "${value}${isSnapshot(args)}"
 }
 
-def edge(Map params = [:]){
-  return version("8.0.0", params)
+def edge(Map args = [:]){
+  return version("8.0.0", args)
 }
 
-def dev(Map params = [:]){
-  return version("7.11.0", params)
+def dev(Map args = [:]){
+  return version("7.11.0", args)
 }
 
-def release(Map params = [:]){
-  return version("7.10.2", params)
+def release(Map args = [:]){
+  return version("7.10.2", args)
 }
 
-def isSnapshot(params){
-  return params.containsKey('snapshot') && params.snapshot ? "-SNAPSHOT" : ''
+def isSnapshot(args){
+  return args.containsKey('snapshot') && args.snapshot ? "-SNAPSHOT" : ''
 }

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Return the version currently used for testing.
+
+  stackVersions() // [ '8.0.0', '7.11.0', '7.10.2' ]
+
+  stackVersions.edge()
+  stackVersions.dev()
+  stackVersions.release()
+  stackVersions.snapshot(stackVersions.edge())
+  stackVersions.edge(snapshot: true)
+
+**/
+def call(Map params = [:]) {
+  return [
+    edge(params),
+    dev(params),
+    release(params)
+  ]
+}
+
+def snapshot(version){
+  return "${version}-SNAPSHOT"
+}
+
+def version(value, params = [:]){
+  return "${value}${isSnapshot(params)}"
+}
+
+def edge(Map params = [:]){
+  return version("8.0.0", params)
+}
+
+def dev(Map params = [:]){
+  return version("7.11.0", params)
+}
+
+def release(Map params = [:]){
+  return version("7.10.2", params)
+}
+
+def isSnapshot(params){
+  return params.containsKey('snapshot') && params.snapshot ? "-SNAPSHOT" : ''
+}

--- a/vars/stackVersions.txt
+++ b/vars/stackVersions.txt
@@ -1,0 +1,11 @@
+
+  Return the version currently used for testing.
+
+  stackVersions() // [ '8.0.0', '7.11.0', '7.10.2' ]
+  stackVersions(snapshot: true) // [ '8.0.0-SNAPSHOT', '7.11.0-SNAPSHOT', '7.10.2-SNAPSHOT' ]
+
+  stackVersions.edge() // '8.0.0'
+  stackVersions.dev() // '7.11.0'
+  stackVersions.release() // '7.10.2'
+  stackVersions.snapshot('7.11.1') // '7.11.1-SNAPSHOT'
+  stackVersions.edge(snapshot: true) // '8.0.0-SNAPSHOT'


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It adds a new step stackVersions.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This new step returns an array of the version numbers we use for testing, also can give the version using tag names (edge, dev, release, or snapshot)

## Related issues
related to https://github.com/elastic/observability-robots/issues/309
