### PR TITLE
feat: use goDefaultVersion

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -435,6 +435,13 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return script.call(m)
     })
     helper.registerAllowedMethod('gitPush', [Map.class], { return "OK" })
+    helper.registerAllowedMethod('goDefaultVersion', [],  {
+      def ret = '1.15.6'
+      if(env.GO_VERSION != null){
+        ret = env.GO_VERSION
+      }
+      return ret
+    })
     helper.registerAllowedMethod('httpRequest', [Map.class], { true })
     helper.registerAllowedMethod('installTools', [List.class], { l ->
       def script = loadScript('vars/installTools.groovy')

--- a/src/test/groovy/GoTestJUnitStepTests.groovy
+++ b/src/test/groovy/GoTestJUnitStepTests.groovy
@@ -34,11 +34,13 @@ class GoTestJUnitStepTests extends ApmBasePipelineTest {
 
   @Test
   void test() throws Exception {
+    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
+    def version = scriptDV.defaultVersion()
     def script = loadScript(scriptName)
     script.call()
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'gotestsum --format testname --junitfile junit-report.xml --'))
-    assertTrue(assertMethodCallContainsPattern('withGoEnvUnix', 'version=null'))
+    assertTrue(assertMethodCallContainsPattern('withGoEnvUnix', "version=${version}"))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/GoTestJUnitStepTests.groovy
+++ b/src/test/groovy/GoTestJUnitStepTests.groovy
@@ -34,8 +34,8 @@ class GoTestJUnitStepTests extends ApmBasePipelineTest {
 
   @Test
   void test() throws Exception {
-    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
-    def version = scriptDV.defaultVersion()
+    def version = "1.15.1"
+    helper.registerAllowedMethod('goDefaultVersion', [], { version })
     def script = loadScript(scriptName)
     script.call()
     printCallStack()

--- a/src/test/groovy/SendBenchmarksStepTests.groovy
+++ b/src/test/groovy/SendBenchmarksStepTests.groovy
@@ -34,6 +34,8 @@ class SendBenchmarksStepTests extends ApmBasePipelineTest {
     env.GITHUB_TOKEN = "TOKEN"
     env.PIPELINE_LOG_LEVEL = 'DEBUG'
 
+    helper.registerAllowedMethod('withGoEnv', [Map.class, Closure.class], { m, b -> b()  })
+    helper.registerAllowedMethod('withGoEnv', [Closure.class], { b -> b()  })
     helper.registerAllowedMethod('httpRequest', [Map.class], {
       return "{'errors': false}"
     })

--- a/src/test/groovy/SendBenchmarksStepTests.groovy
+++ b/src/test/groovy/SendBenchmarksStepTests.groovy
@@ -217,7 +217,9 @@ class SendBenchmarksStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('withEnv', "URL_=${EXAMPLE_URL}, USER_=username, PASS_=user_password"))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', "var=URL_, password=${EXAMPLE_URL}"))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', "var=USER_, password=username"))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', "var=PASS_, password=user_password"))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -122,8 +122,8 @@ void testOSArg() throws Exception {
   @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "linux" })
-    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
-    def version = scriptDV.defaultVersion()
+    def version = "1.15.1"
+    helper.registerAllowedMethod('goDefaultVersion', [], { version })
     def isOK = false
     script.call(){
       if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go${version}.linux.amd64/bin:/foo/bin"

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -122,17 +122,19 @@ void testOSArg() throws Exception {
   @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
+    def version = scriptDV.defaultVersion()
     def isOK = false
     script.call(){
-      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.14.2.linux.amd64/bin:/foo/bin"
-        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.14.2.linux.amd64"
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go${version}.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go${version}.linux.amd64"
         && binding.getVariable("GOPATH") == "WS" ){
         isOK = true
       }
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.14.2'))
+    assertTrue(assertMethodCallContainsPattern('sh', "Installing go ${version}"))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -109,13 +109,15 @@ void testOSArg() throws Exception {
   @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "windows" })
+    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
+    def version = scriptDV.defaultVersion()
     def isOK = false
     script.call(){
-      isOK = definedVariables('1.14.2', 'windows')
+      isOK = definedVariables("${version}", 'windows')
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.14.2'))
+    assertTrue(assertMethodCallContainsPattern('bat', "Installing Go ${version}"))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -109,8 +109,8 @@ void testOSArg() throws Exception {
   @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "windows" })
-    def scriptDV = loadScript('vars/goDefaultVersion.groovy')
-    def version = scriptDV.defaultVersion()
+    def version = "1.15.1"
+    helper.registerAllowedMethod('goDefaultVersion', [], { version })
     def isOK = false
     script.call(){
       isOK = definedVariables("${version}", 'windows')

--- a/vars/README.md
+++ b/vars/README.md
@@ -370,6 +370,7 @@ Print a text on color on a xterm.
  This step run a filebeat Docker container to grab the Docker containers logs in a single file.
  `filebeat.stop()` will stop the Filebeat Docker container and grab the output files,
  the only argument need is the `workdir` if you set it on the `filebeat step` call.
+ The output log files should be in a relative path to the current path (see [archiveArtifacts](https://www.jenkins.io/doc/pipeline/steps/core/#archiveartifacts-archive-the-artifacts))
 
 ```
   filebeat()
@@ -387,7 +388,7 @@ Print a text on color on a xterm.
 * *image:* Filebeat Docker image to use (docker.elastic.co/beats/filebeat:7.10.1).
 * *output:* log file to save all Docker containers logs (docker_logs.log).
 * *timeout:* Time to wait before kill the Filebeat Docker container on the stop operation.
-* *workdir:* Directory to use as root folder to read and write files (WORKSPACE).
+* *workdir:* Directory to use as root folder to read and write files (current folder).
 
 ```
   filebeat(config: 'filebeat.yml',
@@ -1129,6 +1130,14 @@ _NOTE_: To edit the existing comment is required these environment variables:
         - `CHANGE_ID`
         - `ORG_NAME`
         - `REPO_NAME`
+
+## goDefaultVersion
+
+  Return the value of the variable GO_VERSION, the value in the file `.go-version`, or a default value
+
+  ```
+  goDefaultVersion()
+  ```
 
 ## goTestJUnit
  Run Go unit tests and generate a JUnit report.
@@ -2032,6 +2041,19 @@ setupAPMGitEmail(global: true)
 
 * *global*: to configure the user and email account globally. Optional.
 
+## stackVersions
+
+  Return the version currently used for testing.
+
+  stackVersions() // [ '8.0.0', '7.11.0', '7.10.2' ]
+  stackVersions(snapshot: true) // [ '8.0.0-SNAPSHOT', '7.11.0-SNAPSHOT', '7.10.2-SNAPSHOT' ]
+
+  stackVersions.edge() // '8.0.0'
+  stackVersions.dev() // '7.11.0'
+  stackVersions.release() // '7.10.2'
+  stackVersions.snapshot('7.11.1') // '7.11.1-SNAPSHOT'
+  stackVersions.edge(snapshot: true) // '8.0.0-SNAPSHOT'
+
 ## stashV2
 Stash the current location, for such it compresses the current path and
 upload it to Google Storage.
@@ -2376,7 +2398,7 @@ withGithubNotify(context: 'Release', tab: 'artifacts') {
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
 
@@ -2400,7 +2422,7 @@ withGithubNotify(context: 'Release', tab: 'artifacts') {
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
 
@@ -2424,7 +2446,7 @@ withGithubNotify(context: 'Release', tab: 'artifacts') {
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `windows`). This is an option argument and if not set, the worker label will be used.
 

--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -21,7 +21,7 @@
   goDefaultVersion()
 **/
 def call(Map args = [:]) {
-  def goDefaultVersion = '1.15.6'
+  def goDefaultVersion = defaultVersion()
   if(isGoVersionEnvVarSet()) {
     goDefaultVersion = "${env.GO_VERSION}"
   } else {
@@ -35,4 +35,8 @@ def call(Map args = [:]) {
 
 def isGoVersionEnvVarSet(){
   return env.GO_VERSION != null && "" != "${env.GO_VERSION}"
+}
+
+def defaultVersion(){
+  return '1.15.6'
 }

--- a/vars/goTestJUnit.groovy
+++ b/vars/goTestJUnit.groovy
@@ -23,7 +23,7 @@
 def call(Map args = [:]) {
   def options = args.containsKey('options') ? args.options : ''
   def output = args.containsKey('output') ? args.output : 'junit-report.xml'
-  def version = args.containsKey('version') ? args.version : null
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
 
   log(level: 'INFO', text: 'Running Go test an generating JUnit output')
 

--- a/vars/sendBenchmarks.groovy
+++ b/vars/sendBenchmarks.groovy
@@ -72,16 +72,13 @@ def call(Map params = [:]) {
         "BENCH_FILE=${benchFile}",
         "INDEX=${index}"]){
           if(index.equals('benchmark-go') || index.equals('benchmark-server')){
-            sh label: 'Sending benchmarks', script: '''#!/bin/bash
-            set +x -euo pipefail
-            GO_VERSION=${GO_VERSION:-"1.10.3"}
-            export GOPATH=${WORKSPACE}
-            export PATH=${GOPATH}/bin:${PATH}
-            eval "$(gvm ${GO_VERSION})"
-
-            go get -v -u github.com/elastic/gobench
-            gobench -index ${INDEX} -es "${CLOUD_URL}" < ${BENCH_FILE}
-            '''
+            withGoEnv(){
+              sh label: 'Sending benchmarks', script: '''#!/bin/bash
+              set +x -euo pipefail
+              go get -v -u github.com/elastic/gobench
+              gobench -index ${INDEX} -es "${CLOUD_URL}" < ${BENCH_FILE}
+              '''
+            }
           } else {
             def datafile = readFile(file: "${BENCH_FILE}")
             def messageBase64UrlPad = base64encode(text: "${CLOUD_USERNAME}:${CLOUD_PASSWORD}", encoding: "UTF-8")

--- a/vars/sendBenchmarks.groovy
+++ b/vars/sendBenchmarks.groovy
@@ -58,14 +58,13 @@ def call(Map params = [:]) {
   if(index.equals('benchmark-go') || index.equals('benchmark-server')){
     def protocol = getProtocol(url)
     url = url - protocol
-    url = "${protocol}${user}:${password}@${url}"
-    gobench(url, benchFile, index)
+    gobench("${protocol}${user}:${password}@${url}", benchFile, index)
   } else {
-    cloudBecnhmarks(url, user, password, benchFile)
+    cloudBenchmarks(url, user, password, benchFile)
   }
 }
 
-def cloudBecnhmarks(realURL, user, password, benchFile) {
+def cloudBenchmarks(realURL, user, password, benchFile) {
   withEnvMask(vars: [
     [var: "CLOUD_ADDR", password: "${realURL}"],
     [var: "CLOUD_USERNAME", password: "${user}"],

--- a/vars/withGoEnv.txt
+++ b/vars/withGoEnv.txt
@@ -18,6 +18,6 @@
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -34,8 +34,7 @@
 
 */
 def call(Map args = [:], Closure body) {
-  def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
-  def version = args.containsKey('version') ? args.version : goDefaultVersion
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
   def pkgs = args.containsKey('pkgs') ? args.pkgs : []
   def os = args.containsKey('os') ? args.os : nodeOS()
   def lastCoordinate = version[-2..-1]

--- a/vars/withGoEnvUnix.txt
+++ b/vars/withGoEnvUnix.txt
@@ -17,6 +17,6 @@
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -34,8 +34,7 @@
 
 */
 def call(Map args = [:], Closure body) {
-  def goDefaultVersion = "" != "${env.GO_VERSION}" && env.GO_VERSION != null ? "${env.GO_VERSION}" : '1.14.2'
-  def version = args.containsKey('version') ? args.version : goDefaultVersion
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
   def pkgs = args.containsKey('pkgs') ? args.pkgs : []
   def os = args.containsKey('os') ? args.os : nodeOS()
   def mingwArch = is32() ? '32' : '64'

--- a/vars/withGoEnvWindows.txt
+++ b/vars/withGoEnvWindows.txt
@@ -17,6 +17,6 @@
   }
 ```
 
-* version: Go version to install, if it is not set, it'll use GO_VERSION env var or '1.14.2'
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `windows`). This is an option argument and if not set, the worker label will be used.


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes some steps to use the new goDefaultVersion step.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
This unifies the Go version used across steps and avoid duplications.

## Related issues
related to https://github.com/elastic/apm-pipeline-library/pull/901
