### PR TITLE
Add resilience when GitHub got some glitches

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -71,10 +71,14 @@ ${errorStackTrace}
 <%}%>
 
 <!-- STEPS ERRORS IF ANY -->
+<% errorGitHub = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Notifies GitHub')}%>
 <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
 <% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>
 <% stepsErrors = stepsErrors?.findAll{ !it?.displayName?.contains('Error signal') } %>
 <% if (errorSignal) { stepsErrors = stepsErrors << errorSignal }%>
+<% if (stepsErrors?.size() <= 0 && !buildStatus?.equals('SUCCESS') && errorGitHub) {%>
+  <% stepsErrors = stepsErrors << errorGitHub %>
+<%}%>
 <% if (stepsErrors?.size() != 0) {%>
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)
   <details><summary>Expand to view the steps failures</summary>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -441,6 +441,44 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_failure_and_github_environmental_issue() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifyPR(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "FAILURE",
+      changeSet: readJSON(file: "changeSet-info.json"),
+      log: f.getText(),
+      statsUrl: "https://ecs.example.com/app/kibana",
+      stepsErrors: readJSON(file: "steps-errors-with-github-environmental-issue.json"),
+      testsErrors: [],
+      testsSummary: readJSON(file: "tests-summary.json")
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Notifies GitHub of the status of a Pull Request'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_notify_pr_with_failure_and_github_environmental_issue_and_further_errors() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifyPR(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "FAILURE",
+      changeSet: readJSON(file: "changeSet-info.json"),
+      log: f.getText(),
+      statsUrl: "https://ecs.example.com/app/kibana",
+      stepsErrors: readJSON(file: "steps-errors-with-also-github-environmental-issue.json"),
+      testsErrors: [],
+      testsSummary: readJSON(file: "tests-summary.json")
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
+    assertFalse(assertMethodCallContainsPattern('githubPrComment', 'Notifies GitHub of the status of a Pull Request'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_slack_with_aborted_but_no_cancel_build() throws Exception {
     def script = loadScript(scriptName)
     script.notifySlack(

--- a/src/test/resources/steps-errors-with-also-github-environmental-issue.json
+++ b/src/test/resources/steps-errors-with-also-github-environmental-issue.json
@@ -1,0 +1,26 @@
+[
+  {
+    "displayDescription": "Server returned HTTP response code: 500, message: '500 Internal Server Error' for URL: https://api.g",
+    "displayName": "Notifies GitHub of the status of a Pull Request",
+    "durationInMillis": 447,
+    "id": "6672",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-01-19T10:47:45.782+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-23560/runs/1/steps/6672/log"
+  },
+  {
+    "displayDescription": "Error 'hudson.AbortException: script returned exit code 2'",
+    "displayName": "Error signal",
+    "durationInMillis": 14,
+    "id": "4473",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2019-05-29T12:08:57.040+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22495/runs/6/steps/4473/log"
+  }
+]

--- a/src/test/resources/steps-errors-with-github-environmental-issue.json
+++ b/src/test/resources/steps-errors-with-github-environmental-issue.json
@@ -1,0 +1,14 @@
+[
+  {
+    "displayDescription": "Server returned HTTP response code: 500, message: '500 Internal Server Error' for URL: https://api.g",
+    "displayName": "Notifies GitHub of the status of a Pull Request",
+    "durationInMillis": 447,
+    "id": "6672",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-01-19T10:47:45.782+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-23560/runs/1/steps/6672/log"
+  }
+]

--- a/vars/withGithubNotify.groovy
+++ b/vars/withGithubNotify.groovy
@@ -57,5 +57,7 @@ def call(Map params = [:], Closure body) {
 }
 
 def notify(String context, String description, String status, String redirect) {
-  githubNotify(context: "${context}", description: "${description}", status: "${status}", targetUrl: "${redirect}")
+  retryWithSleep(retries: 2, seconds: 5, backoff: true) {
+    githubNotify(context: "${context}", description: "${description}", status: "${status}", targetUrl: "${redirect}")
+  }
 }


### PR DESCRIPTION
## What does this PR do?

* Add resilience when GitHub is not accessible.
* Add failed GitHub step as a PR comment when no other failed steps, to help with the build analysis.

## Why is it important?

Avoid environmental build issues when third-party systems are not accessible.

## For instance

![image](https://user-images.githubusercontent.com/2871786/105029161-deae2800-5a49-11eb-9029-d25878d452dc.png)

[logs](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats%2FPR-23560/detail/PR-23560/1/pipeline/#step-6672-log-1)

Created a GitHub comment in the PR without anything to highlight:

https://github.com/elastic/beats/pull/23560#issuecomment-762774196


The reason there is no failed step with those details is caused by the filtering of the githubNotify https://github.com/elastic/apm-pipeline-library/issues/747

