### PR TITLE
Skip GitHub comment for old build when the next adjacent build has already finished

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@master') _
+@Library('apm@test/gh-comment-1') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@test/gh-comment-1') _
+@Library('apm@master') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/src/test/groovy/co/elastic/mock/RunWrapperMock.groovy
+++ b/src/test/groovy/co/elastic/mock/RunWrapperMock.groovy
@@ -38,4 +38,8 @@ public class RunWrapperMock implements Serializable {
     return previousBuild
   }
 
+  public boolean isBuilding() {
+    return this.result.equals('RUNNING')
+  }
+
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -72,14 +72,14 @@ def call(Map args = [:]) {
         data['docsUrl'] = "http://${env?.REPO_NAME}_${env?.CHANGE_ID}.docs-preview.app.elstc.co/diff"
         data['emailRecipients'] = to
         data['statsUrl'] = statsURL
-        data['es'] = args.es
-        data['es_secret'] = args.secret
-        data['flakyReportIdx'] = args.flakyReportIdx
-        data['flakyThreshold'] = args.flakyThreshold
-        data['header'] = args.slackHeader
-        data['channel'] = args.slackChannel
-        data['credentialId'] = args.slackCredentials
-        data['enabled'] = args.slackNotify
+        data['es'] = es
+        data['es_secret'] = secret
+        data['flakyReportIdx'] = flakyReportIdx
+        data['flakyThreshold'] = flakyThreshold
+        data['header'] = slackHeader
+        data['channel'] = slackChannel
+        data['credentialId'] = slackCredentials
+        data['enabled'] = slackNotify
 
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -114,10 +114,7 @@ def call(Map args = [:]) {
 
         notifySlack(when: notifySlackComment, data: data, slackHeader: slackHeader, slackChannel: slackChannel, slackCredentials: slackCredentials, slackNotify: slackNotify)
 
-        log(level: 'DEBUG', text: 'notifyBuildResult: Generate build report.')
-        catchError(message: "There were some failures when generating the build report", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-          notificationManager.generateBuildReport(data)
-        }
+        generateBuildReport(data: data)
 
         // Notify only if there are notifications and they should be aggregated
         if (aggregateComments && notifications?.size() > 0) {
@@ -172,6 +169,13 @@ def customisedEmail(String email) {
     }
   }
   return []
+}
+
+def generateBuildReport(def args=[:]) {
+  log(level: 'DEBUG', text: 'notifyBuildResult: Generate build report.')
+  catchError(message: "There were some failures when generating the build report", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+    (new NotificationManager()).generateBuildReport(data)
+  }
 }
 
 def notifySlack(def args=[:]) {

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -99,11 +99,7 @@ def call(Map args = [:]) {
         generateBuildReport(data: data)
 
         // Notify only if there are notifications and they should be aggregated
-        if (aggregateComments && notifications?.size() > 0) {
-          log(level: 'DEBUG', text: 'notifyBuildResult: aggregate all the messages in one single GH Comment.')
-          // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.
-          githubPrComment(commentFile: 'comment.id', message: notifications?.join(''))
-        }
+        aggregateGitHubComments(when: (aggregateComments && notifications?.size() > 0), notifications: notifications)
       }
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -129,6 +125,14 @@ def call(Map args = [:]) {
         deleteDir()
       }
     }
+  }
+}
+
+def aggregateGitHubComments(def args=[:]) {
+  if (args.when) {
+    log(level: 'DEBUG', text: 'notifyBuildResult: aggregate all the messages in one single GH Comment.')
+    // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.
+    githubPrComment(commentFile: 'comment.id', message: args.notifications?.join(''))
   }
 }
 

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -144,7 +144,6 @@ def aggregateGitHubComments(def args=[:]) {
     // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.
     githubPrComment(commentFile: 'comment.id', message: args.notifications?.join(''))
   } else {
-    log(level: 'DEBUG', text: "aggregateGitHubComments: is disabled. ${args.notifications?.join('')}")
     log(level: 'DEBUG', text: 'aggregateGitHubComments: is disabled.')
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -84,12 +84,9 @@ def call(Map args = [:]) {
         addGitHubCustomComment(newPRComment: newPRComment)
 
         // Should notify if it is a PR and it's enabled
-        if(notifyPRComment && isPR()) {
-          log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in the PR.")
-          catchError(message: "There were some failures when notifying results in the PR", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-            def prComment = notificationManager.notifyPR(data)
-            notifications << prComment
-          }
+        def prComment = createGitHubComment(when: (notifyPRComment && isPR()), data: data)
+        if (prComment) {
+          notifications << prComment
         }
 
         // Should analyze flakey but exclude it when aborted
@@ -157,6 +154,16 @@ def analyzeFlaky(def args=[:]) {
     catchError(message: "There were some failures when generating flakey test results", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
       def flakyComment = (new NotificationManager()).analyzeFlakey(content)
       return flakyComment
+    }
+  }
+}
+
+def createGitHubComment(def args=[:]) {
+  if(args.when) {
+    log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in the PR.")
+    catchError(message: "There were some failures when notifying results in the PR", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+      def prComment = (new NotificationManager()).notifyPR(args.data)
+      return prComment
     }
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -77,8 +77,6 @@ def call(Map args = [:]) {
         data['disableGHComment'] = aggregateComments
         def notifications = []
 
-        def notificationManager = new NotificationManager()
-
         notifyEmail(data: data, when: (shouldNotify && !to?.empty))
 
         addGitHubCustomComment(newPRComment: newPRComment)

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -130,6 +130,10 @@ def call(Map args = [:]) {
 
 def aggregateGitHubComments(def args=[:]) {
   if (args.when) {
+    if (nextBuild) {
+      log(level: 'INFO', text: 'notifyBuildResult: Notifications was already done in a younger build.')
+      return
+    }
     log(level: 'DEBUG', text: 'notifyBuildResult: aggregate all the messages in one single GH Comment.')
     // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.
     githubPrComment(commentFile: 'comment.id', message: args.notifications?.join(''))

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -112,17 +112,8 @@ def call(Map args = [:]) {
           }
         }
 
-        // Should notify in slack if it's enabled
-        if(notifySlackComment) {
-          data['header'] = slackHeader
-          data['channel'] = slackChannel
-          data['credentialId'] = slackCredentials
-          data['enabled'] = slackNotify
-          log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in slack.")
-          catchError(message: "There were some failures when notifying results in slack", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-            notificationManager.notifySlack(data)
-          }
-        }
+        notifySlack(when: notifySlackComment, data: data, slackHeader: slackHeader, slackChannel: slackChannel, slackCredentials: slackCredentials, slackNotify: slackNotify)
+
         log(level: 'DEBUG', text: 'notifyBuildResult: Generate build report.')
         catchError(message: "There were some failures when generating the build report", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
           notificationManager.generateBuildReport(data)
@@ -181,4 +172,18 @@ def customisedEmail(String email) {
     }
   }
   return []
+}
+
+def notifySlack(def args=[:]) {
+  if(args.when) {
+    def data = args.data
+    data['header'] = args.slackHeader
+    data['channel'] = args.slackChannel
+    data['credentialId'] = args.slackCredentials
+    data['enabled'] = args.slackNotify
+    log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in slack.")
+    catchError(message: "There were some failures when notifying results in slack", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+      (new NotificationManager()).notifySlack(data)
+    }
+  }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -132,7 +132,7 @@ def aggregateGitHubComments(def args=[:]) {
   if (args.when) {
     try {
       // As long as there is no a new build running.
-      if (!nextBuild?.isBuilding()) {
+      if (nextBuild && !nextBuild?.isBuilding()) {
         log(level: 'INFO', text: 'aggregateGitHubComments: Notification was already done in a younger build.')
         return
       }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -78,10 +78,8 @@ def call(Map args = [:]) {
         def notifications = []
 
         def notificationManager = new NotificationManager()
-        if(shouldNotify && !to?.empty){
-          log(level: 'DEBUG', text: 'notifyBuildResult: Notifying results by email.')
-          notificationManager.notifyEmail(data)
-        }
+
+        notifyEmail(data: data, when: (shouldNotify && !to?.empty))
 
         newPRComment.findAll { k, v ->
           catchError(message: "There were some failures when generating the customise comment for $k", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -178,6 +176,12 @@ def generateBuildReport(def args=[:]) {
   }
 }
 
+def notifyEmail(def args=[:]) {
+  if(args.when) {
+    log(level: 'DEBUG', text: 'notifyBuildResult: Notifying results by email.')
+    (new NotificationManager()).notifyEmail(args.data)
+  }
+}
 def notifySlack(def args=[:]) {
   if(args.when) {
     def data = args.data

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -81,12 +81,7 @@ def call(Map args = [:]) {
 
         notifyEmail(data: data, when: (shouldNotify && !to?.empty))
 
-        newPRComment.findAll { k, v ->
-          catchError(message: "There were some failures when generating the customise comment for $k", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-            unstash v
-            notificationManager.customPRComment(commentFile: k, file: v)
-          }
-        }
+        addGitHubCustomComment(newPRComment: newPRComment)
 
         // Should notify if it is a PR and it's enabled
         if(notifyPRComment && isPR()) {
@@ -144,6 +139,15 @@ def call(Map args = [:]) {
       catchError(message: 'There were some failures when cleaning up the workspace ', buildResult: 'SUCCESS') {
         deleteDir()
       }
+    }
+  }
+}
+
+def addGitHubCustomComment(def args=[:]) {
+  args.newPRComment.findAll { k, v ->
+    catchError(message: "There were some failures when generating the customise comment for $k", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+      unstash v
+      (new NotificationManager()).customPRComment(commentFile: k, file: v)
     }
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -130,9 +130,14 @@ def call(Map args = [:]) {
 
 def aggregateGitHubComments(def args=[:]) {
   if (args.when) {
-    if (nextBuild) {
-      log(level: 'INFO', text: 'notifyBuildResult: Notifications was already done in a younger build.')
-      return
+    try {
+      // As long as there is no a new build running.
+      if (!nextBuild?.isBuilding()) {
+        log(level: 'INFO', text: 'aggregateGitHubComments: Notification was already done in a younger build.')
+        return
+      }
+    } catch(err) {
+      log(level: 'WARN', text: 'aggregateGitHubComments: could not fetch the nextBuild.')
     }
     log(level: 'DEBUG', text: 'notifyBuildResult: aggregate all the messages in one single GH Comment.')
     // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -133,9 +133,12 @@ def aggregateGitHubComments(def args=[:]) {
     } catch(err) {
       log(level: 'WARN', text: 'aggregateGitHubComments: could not fetch the nextBuild.')
     }
-    log(level: 'DEBUG', text: 'notifyBuildResult: aggregate all the messages in one single GH Comment.')
+    log(level: 'DEBUG', text: 'aggregateGitHubComments: aggregate all the messages in one single GH Comment.')
     // Reuse the same commentFile from the notifyPR method to keep backward compatibility with the existing PRs.
     githubPrComment(commentFile: 'comment.id', message: args.notifications?.join(''))
+  } else {
+    log(level: 'DEBUG', text: "aggregateGitHubComments: is disabled. ${args.notifications?.join('')}")
+    log(level: 'DEBUG', text: 'aggregateGitHubComments: is disabled.')
   }
 }
 

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -176,7 +176,7 @@ def customisedEmail(String email) {
 def generateBuildReport(def args=[:]) {
   log(level: 'DEBUG', text: 'notifyBuildResult: Generate build report.')
   catchError(message: "There were some failures when generating the build report", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-    (new NotificationManager()).generateBuildReport(data)
+    (new NotificationManager()).generateBuildReport(args.data)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Skip any GitHub Pull Request comment if an old build is still running when its next adjacent build has already finished, if any

## Why is it important?

Avoid overriding the comment with obsoleted build data when two adjacent builds were triggered, and the old one is still running.

## Related issues

Depends on https://github.com/elastic/apm-pipeline-library/pull/916
Closes https://github.com/elastic/apm-pipeline-library/issues/906

## Actions

- [x] UTs
- [x] ITs