### PR TITLE
fix: hardcode markdown-lint parameters

### DIFF
--- a/.ci/scripts/markdown-lint.sh
+++ b/.ci/scripts/markdown-lint.sh
@@ -5,5 +5,5 @@ docker pull "${IMAGE}" > /dev/null || true
 
 for f in **/*.md
 do
-    docker run --rm -t -v "${PWD}:/markdown:ro" -u "$(id -u):$(id -g)" "${IMAGE}" "$@" "/markdown/$f"
+    docker run --rm -t -v "${PWD}:/markdown:ro" -u "$(id -u):$(id -g)" "${IMAGE}" "--progress" "/markdown/$f"
 done

--- a/.ci/scripts/markdown-lint.sh
+++ b/.ci/scripts/markdown-lint.sh
@@ -5,5 +5,5 @@ docker pull "${IMAGE}" > /dev/null || true
 
 for f in **/*.md
 do
-    docker run --rm -t -v "${PWD}:/markdown:ro" -u "$(id -u):$(id -g)" "${IMAGE}" "--progress" "/markdown/$f"
+    docker run --rm -t -v "${PWD}:/markdown:ro" -u "$(id -u):$(id -g)" "${IMAGE}" "--progress" "/markdown/${f}"
 done


### PR DESCRIPTION
## What does this PR do?
It forces the usage of the `--progress` parameter, instead of consuming those passed by the caller of the hook.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
See #918

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #918