### PR TITLE
Mask the GitHub app generated token

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -570,7 +570,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return [data: [ value: 'mytoken' ]]
     }
     if(VaultSecret.SECRET_GITHUB_APP.equals(s)){
-      return [data: [ key: 'secret', installation_id: '123', app_id: '42' ]]
+      return [data: [ key: new File('src/test/resources/github-app-private-key-tests.pem').text, installation_id: '123', app_id: '42' ]]
     }
     if(VaultSecret.SECRET_NOT_VALID.equals(s)){
       return [data: [ user: null, password: null, url: null, apiKey: null, token: null ]]

--- a/src/test/groovy/GithubAppTokenStepTests.groovy
+++ b/src/test/groovy/GithubAppTokenStepTests.groovy
@@ -45,6 +45,21 @@ class GithubAppTokenStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_with_default() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], {
+      return [token: 1]
+    })
+    try {
+    script.call()
+    } catch (e) {
+      println e
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('wrap', 'MaskPasswordsBuildWrapper'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_getToken_success() throws Exception {
     helper.registerAllowedMethod('githubApiCall', [Map.class], {
       return [token: 1]

--- a/vars/githubAppToken.groovy
+++ b/vars/githubAppToken.groovy
@@ -50,10 +50,12 @@ def call(Map args = [:]) {
 
 def getJsonWebToken(Map args=[:]) {
   try {
+    // 50 seconds
+    def expirationTime = 50000l
     return Jwts.builder()
             .setSubject('RS256')
             .signWith(RS256, getRSAPrivateKey(args.privateKeyContent))
-            .setExpiration(new Date((new Date()).getTime() + 50000l))
+            .setExpiration(new Date((new Date()).getTime() + expirationTime))
             .setIssuedAt(new Date(System.currentTimeMillis() + 1000))
             .setIssuer(args.appId)
             .compact()

--- a/vars/githubAppToken.groovy
+++ b/vars/githubAppToken.groovy
@@ -82,12 +82,14 @@ def getRSAPrivateKey(privateKeyPEM) {
 
 def getToken(Map args=[:]) {
   try {
-    return githubApiCall(authorizationType: 'Bearer',
-                         token: args.jsonWebToken,
-                         url: "https://api.github.com/app/installations/${args.installationId}/access_tokens",
-                         headers: ['Accept': 'application/vnd.github.v3+json'],
-                         forceMethod: true,
-                         noCache: true)?.token
+    wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [[regex: 'token:[^,]*']]]) {
+      return githubApiCall(authorizationType: 'Bearer',
+                          token: args.jsonWebToken,
+                          url: "https://api.github.com/app/installations/${args.installationId}/access_tokens",
+                          headers: ['Accept': 'application/vnd.github.v3+json'],
+                          forceMethod: true,
+                          noCache: true)?.token
+    }
   } catch(Exception e){
     log(level: 'ERROR', text: "Exception: ${e}")
     error 'getToken: Failed to create a JWT'


### PR DESCRIPTION
## What does this PR do?

Mask the GitHub App token when using the debug traces

## Why is it important?

Avoid any leaking

## Test

![image](https://user-images.githubusercontent.com/2871786/105734367-75875280-5f2a-11eb-8f04-935db37af125.png)

