### PR TITLE
Create GitHub Check with the digested Build data

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@master') _
+@Library('apm@test/github-check') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@test/github-check') _
+@Library('apm@master') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -395,4 +395,51 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     // Then github pr comment should not happen
     assertFalse(assertMethodCallContainsPattern('githubPrComment', 'commentFile=comment.id'))
   }
+
+  @Test
+  void test_notifyIfNewBuildNotRunning_with_previous_build_and_new_build_running() throws Exception {
+    def script = loadScript(scriptName)
+    // When there is already a new build still running
+    binding.setVariable('nextBuild', new RunWrapperMock(rawBuild: null, number: 1, result: 'RUNNING'))
+    def ret = false
+    script.notifyIfNewBuildNotRunning() {
+      println 'It should run the closure'
+      ret = true
+    }
+    printCallStack()
+    // Then it should run the closure correctly
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_notifyIfNewBuildNotRunning_with_previous_build_and_new_build_already_finished() throws Exception {
+    def script = loadScript(scriptName)
+    // When there is already a new build that finished.
+    binding.setVariable('nextBuild', new RunWrapperMock(rawBuild: null, number: 1, result: 'SUCCESS'))
+    def ret = false
+    script.notifyIfNewBuildNotRunning() {
+      println 'It should not run the closure'
+      ret = true
+    }
+    printCallStack()
+
+    // Then it should not run the closure
+    assertFalse(ret)
+  }
+
+  @Test
+  void test_notifyIfNewBuildNotRunning_with_the_very_first_build() throws Exception {
+    def script = loadScript(scriptName)
+    // When there is already a new build that finished.
+    binding.setVariable('nextBuild', null)
+    def ret = false
+    script.notifyIfNewBuildNotRunning() {
+      println 'It should run the closure'
+      ret = true
+    }
+    printCallStack()
+
+    // Then it should not run the closure
+    assertTrue(ret)
+  }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -164,7 +164,11 @@ def aggregateGitHubCheck(def args=[:]) {
           status = 'failure'
           break
       }
-      githubCheck(name: 'status', body: args.notifications?.join(''), status: status, detailsUrl: env.BUILD_URL)
+      githubCheck(name: 'Status',
+                  description: 'For further details please the `DETAILS` section',
+                  body: args.notifications?.join(''),
+                  status: status,
+                  detailsUrl: env.BUILD_URL)
     }
   } else {
     log(level: 'DEBUG', text: 'aggregateGitHubCheck: is disabled.')

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -101,6 +101,8 @@ def call(Map args = [:]) {
 
         // Notify only if there are notifications and they should be aggregated
         aggregateGitHubComments(when: (aggregateComments && notifications?.size() > 0), notifications: notifications)
+
+        aggregateGitHubCheck(when: (aggregateComments && notifications?.size() > 0), notifications: notifications)
       }
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -140,6 +142,17 @@ def notifyIfNewBuildNotRunning(Closure body) {
     log(level: 'WARN', text: 'notifyIfPossible: could not fetch the nextBuild.')
   }
   body()
+}
+
+def aggregateGitHubCheck(def args=[:]) {
+  if (args.when) {
+    notifyIfNewBuildNotRunning() {
+      log(level: 'DEBUG', text: 'aggregateGitHubCheck: aggregate all the messages in one single GitHub check.')
+      githubCheck(name: 'status', body: args.notifications?.join(''), status: success, detailsUrl: 'https://')
+    }
+  } else {
+    log(level: 'DEBUG', text: 'aggregateGitHubCheck: is disabled.')
+  }
 }
 
 def aggregateGitHubComments(def args=[:]) {

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -165,8 +165,7 @@ def aggregateGitHubCheck(def args=[:]) {
           break
       }
       githubCheck(name: 'Status',
-                  description: 'For further details please the `DETAILS` section',
-                  body: args.notifications?.join(''),
+                  description: args.notifications?.join(''),
                   status: status,
                   detailsUrl: env.BUILD_URL)
     }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -164,7 +164,7 @@ def aggregateGitHubCheck(def args=[:]) {
           status = 'failure'
           break
       }
-      githubCheck(name: 'Status',
+      githubCheck(name: '.Status',
                   description: args.notifications?.join(''),
                   status: status,
                   detailsUrl: env.BUILD_URL)


### PR DESCRIPTION
## What does this PR do?

Enable GitHub check with the build digested status. 

## Why is it important?

Transition to GitHub checks.

## Test

- See https://github.com/elastic/apm-pipeline-library/pull/921/checks?check_run_id=1764002793

![image](https://user-images.githubusercontent.com/2871786/105748077-855a6300-5f39-11eb-9e8f-0773247d1200.png)

## For the reviewer

I refactored a bit with https://github.com/elastic/apm-pipeline-library/pull/921/commits/16617f4e9eb6d6ec3e173da3feb8f0a5f952ebed to reuse the login behind whether to notify when the new build did already finished.

Then, the important changes are:
- https://github.com/elastic/apm-pipeline-library/pull/921/commits/147f527f106c0ec401040a21cc1097f5c36c7f43
- https://github.com/elastic/apm-pipeline-library/pull/921/commits/7a7cd6f30a91fee490cbf75410cc63ef26a0ac1e
- https://github.com/elastic/apm-pipeline-library/pull/921/commits/3309d460c5f9c42333e8341c0506ae445c23f8db

