### PR TITLE
fix: retry wait for filebeat

### DIFF
--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -60,8 +60,16 @@ def start(Map args = [:]) {
         -E http.enabled=true
   """, returnStdout: true)?.trim()
   sh(label: 'Wait for Filebeat', script: """
-    docker exec ${dockerID} \
+    N=0
+    until docker exec ${dockerID} \
       curl -sSfI --retry 10 --retry-delay 5 --max-time 5 'http://localhost:5066/stats?pretty'
+    do
+      sleep 5
+      if [ \${N} -gt 6 ]; then
+        break;
+      fi
+      N=$((\${N} + 1))
+    done
   """)
 
   def json = [

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -68,7 +68,7 @@ def start(Map args = [:]) {
       if [ \${N} -gt 6 ]; then
         break;
       fi
-      N=$((\${N} + 1))
+      N=\$((\${N} + 1))
     done
   """)
 


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It retries the wait command 5 times.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Launch the Docker container in detached mode can cause the container is not available to run `curl` when the wait step is executed this causes an error.

```
[2021-01-25T12:05:00.215Z] + docker exec 90dd33fd22cc9e6c6709dfd18afd82a3b851f87952bcc057b47c136c05062ce3 curl -sSfI --retry 10 --retry-delay 5 --max-time 5 http://localhost:5066/stats?pretty

[2021-01-25T12:05:00.480Z] curl: (7) Failed to connect to ::1: Cannot assign requested address
```