### PR TITLE
Delegate githubPrComment if PR to the step

### DIFF
--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -53,7 +53,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
     assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results by email'))
-    assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertTrue(assertMethodCallContainsPattern('log', 'createGitHubComment: Create GitHub comment.'))
     assertTrue(assertMethodCallOccurrences('deleteDir', 1))
   }
 
@@ -224,7 +224,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(prComment: true)
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertTrue(assertMethodCallContainsPattern('log', 'createGitHubComment: Create GitHub comment.'))
   }
 
   @Test
@@ -233,7 +233,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     def script = loadScript(scriptName)
     script.call(prComment: true)
     printCallStack()
-    assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertTrue(assertMethodCallContainsPattern('log', 'createGitHubComment: Create GitHub comment.'))
   }
 
   @Test
@@ -313,7 +313,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     // Then flakey test analysis
     assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Generating flakey test analysis'))
     // with pr comment
-    assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertTrue(assertMethodCallContainsPattern('log', 'createGitHubComment: Create GitHub comment.'))
     // with github pr comment
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'commentFile=comment.id'))
   }
@@ -330,7 +330,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     // Then flakey test analysis
     assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Generating flakey test analysis'))
     // with pr comment
-    assertTrue(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results in the PR.'))
+    assertTrue(assertMethodCallContainsPattern('log', 'createGitHubComment: Create GitHub comment.'))
     // with github pr comment
     assertFalse(assertMethodCallContainsPattern('githubPrComment', 'commentFile=comment.id'))
   }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -89,8 +89,7 @@ def call(Map args = [:]) {
 
         addGitHubCustomComment(newPRComment: newPRComment)
 
-        // Should notify if it is a PR and it's enabled
-        createGitHubComment(data: data, notifications: notifications, when: (notifyPRComment && isPR()))
+        createGitHubComment(data: data, notifications: notifications, when: notifyPRComment)
 
         // Should analyze flakey but exclude it when aborted
         analyzeFlaky(data: data, notifications: notifications, when: (analyzeFlakey && currentBuild.currentResult != 'ABORTED'))
@@ -207,7 +206,7 @@ def analyzeFlaky(def args=[:]) {
 
 def createGitHubComment(def args=[:]) {
   if(args.when) {
-    log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in the PR.")
+    log(level: 'DEBUG', text: "createGitHubComment: Create GitHub comment.")
     catchError(message: "There were some failures when notifying results in the PR", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
       def prComment = (new NotificationManager()).notifyPR(args.data)
       args.notifications << prComment


### PR DESCRIPTION
## What does this PR do?

Delegate the validation if it should notify a PR to the `githubPrComment`. `notifyPR` creates the digested data and calls `githubPrComment`.

## Why is it important?

Otherwise `githubCheck` won't be able to aggregate the build digested data when running build for branches/tags.

For instance -> https://github.com/elastic/apm-pipeline-library/runs/1768580758
