### PR TITLE
Refactor notifyPR and generateBuildReport

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -214,7 +214,7 @@ def notifyEmail(Map params = [:]) {
 }
 
 /**
- * This method sends a GitHub comment with data from Jenkins
+ * This method sends a GitHub comment with data from Jenkins. It uses generateBuildReport()
  * @param comment the content of the message, see generateBuildReport()
  * @param disableGHComment whether to disable the GH comment notification.
  * @param see generateBuildReport(), if required to use the previous behaviour
@@ -299,6 +299,7 @@ def notifySlack(Map args = [:]) {
 
 /**
  * This method generates the build report, archive it and returns the build report
+ * @param archiveFile whether to create and archive the file.
  * @param build
  * @param buildStatus String with job result
  * @param changeSet list of change set, see src/test/resources/changeSet-info.json
@@ -317,8 +318,8 @@ def generateBuildReport(Map args = [:]) {
     def log = args.get('log', null)
     def statsUrl = args.get('statsUrl', '')
     def stepsErrors = args.get('stepsErrors', [])
-    def testsErrors = args.get('testsErrors'), [])
-    def testsSummary = args.contgetainsKey('testsSummary', null)
+    def testsErrors = args.get('testsErrors', [])
+    def testsSummary = args.get('testsSummary', null)
     def archiveFile = args.get('archiveFile', true)
     def output = ''
     catchError(buildResult: 'SUCCESS', message: 'generateBuildReport: Error generating build report') {

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -199,7 +199,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       //NOOP
     }
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'notifyPR: buildStatus parameter is not valid'))
+    assertTrue(assertMethodCallContainsPattern('error', 'buildStatus parameter is not valid'))
     assertJobStatusFailure()
   }
 
@@ -220,7 +220,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       //NOOP
     }
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'notifyPR: build parameter it is not valid'))
+    assertTrue(assertMethodCallContainsPattern('error', 'build parameter it is not valid'))
     assertJobStatusFailure()
   }
 
@@ -456,6 +456,16 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Notifies GitHub of the status of a Pull Request'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_notify_pr_with_a_generated_comment() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifyPR(comment: 'My Comment')
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('libraryResource', 'github-comment-markdown.template'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'My Comment'))
     assertJobStatusSuccess()
   }
 
@@ -960,6 +970,27 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('writeFile', 'Build Succeeded'))
     assertTrue(assertMethodCallContainsPattern('writeFile', 'file=build.md'))
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'build.md'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_generateBuildReport_without_archive() throws Exception {
+    def script = loadScript(scriptName)
+    script.generateBuildReport(
+      build: readJSON(file: 'build-info.json'),
+      buildStatus: 'SUCCESS',
+      changeSet: readJSON(file: 'changeSet-info.json'),
+      docsUrl: 'foo',
+      log: f.getText(),
+      statsUrl: 'https://ecs.example.com/app/kibana',
+      stepsErrors: readJSON(file: 'steps-errors.json'),
+      testsErrors: readJSON(file: 'tests-errors.json'),
+      testsSummary: readJSON(file: 'tests-summary.json'),
+      archiveFile: false
+    )
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('writeFile', 'file=build.md'))
+    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', 'build.md'))
     assertJobStatusSuccess()
   }
 

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -83,6 +83,8 @@ def call(Map args = [:]) {
 
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments
+        // Generate digested data to be consumed later on by the createGitHubComment.
+        data['comment'] = generateBuildReport(data: data)
         def notifications = []
 
         notifyEmail(data: data, when: (shouldNotify && !to?.empty))
@@ -95,8 +97,6 @@ def call(Map args = [:]) {
         analyzeFlaky(data: data, notifications: notifications, when: (analyzeFlakey && currentBuild.currentResult != 'ABORTED'))
 
         notifySlack(data: data, when: notifySlackComment)
-
-        generateBuildReport(data: data)
 
         // Notify only if there are notifications and they should be aggregated
         aggregateGitHubComments(when: (aggregateComments && notifications?.size() > 0), notifications: notifications)


### PR DESCRIPTION
## What does this PR do?

Call the `generateBuildReport` once, for such the `notifyPR` step support:
* a new argument called `comment` then it does not need to generate the build report again.
* if the comment is empty then it will generate the data, for such it calls the `generateBuildReport` step, to avoid duplicated code.

The `notifyBuildResult` now calls the `notifyPR` step with the `comment` argument.

## Why is it important?

Remove duplicated code.