### PR TITLE
Use GOARCH to install the package for that particular architecture

### DIFF
--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -155,4 +155,32 @@ void testOSArg() throws Exception {
     assertJobStatusSuccess()
   }
 
+  @Test
+  void test_installPackages_with_env_variable() throws Exception {
+    addEnvVar('GOARCH', 'amd64')
+    script.installPackages(pkgs: [ "P1", "P2" ])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOARCH=amd64'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_installPackages_without_env_variable() throws Exception {
+    script.installPackages(pkgs: [ "P1", "P2" ])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOARCH=TODO'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_goArch() throws Exception {
+    def ret = script.goArch()
+    printCallStack()
+    assertTrue(ret.equals('TODO'))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -168,19 +168,30 @@ void testOSArg() throws Exception {
 
   @Test
   void test_installPackages_without_env_variable() throws Exception {
+    helper.registerAllowedMethod('isArm', { return true })
     script.installPackages(pkgs: [ "P1", "P2" ])
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOARCH=TODO'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOARCH=arm64'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
     assertJobStatusSuccess()
   }
 
   @Test
-  void test_goArch() throws Exception {
-    def ret = script.goArch()
-    printCallStack()
-    assertTrue(ret.equals('TODO'))
-    assertJobStatusSuccess()
+  void test_goArch_for_arm() throws Exception {
+    helper.registerAllowedMethod('isArm', { return true })
+    assertTrue(script.goArch().equals('arm64'))
+  }
+
+  @Test
+  void test_goArch_for_linux() throws Exception {
+    helper.registerAllowedMethod('isUnix', { return true })
+    assertTrue(script.goArch().equals('amd64'))
+  }
+
+  @Test
+  void test_goArch_for_windows() throws Exception {
+    helper.registerAllowedMethod('isUnix', { return false })
+    assertTrue(script.goArch().equals('amd64'))
   }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -2506,6 +2506,10 @@ withGithubStatus(context: 'Release', tab: 'artifacts') {
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
 
+
+NOTE: If the `GOARCH` environment variable is defined then it will be used to install the given packages for that architecture,
+      otherwise it will be evaluated on the fly.
+
 ## withGoEnvWindows
  Install Go and run some command in a pre-configured environment for Windows.
 

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -47,14 +47,22 @@ def call(Map args = [:], Closure body) {
     "GOROOT=${env.WORKSPACE}/${goDir}",
     "GOPATH=${env.WORKSPACE}"
   ]){
-    retryWithSleep(retries: 3, seconds: 5, backoff: true){
-      sh(label: "Installing go ${version}", script: "gvm ${version}")
-    }
-    pkgs?.each{ p ->
-      retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        sh(label: "Installing ${p}", script: "go get -u ${p}")
-      }
-    }
+    installGo(version)
+    installPackages(pkgs)
     body()
+  }
+}
+
+def installGo(version) {
+  retryWithSleep(retries: 3, seconds: 5, backoff: true){
+    sh(label: "Installing go ${version}", script: "gvm ${version}")
+  }
+}
+
+def installPackages(pkgs) {
+  pkgs?.each{ p ->
+    retryWithSleep(retries: 3, seconds: 5, backoff: true){
+      sh(label: "Installing ${p}", script: "go get -u ${p}")
+    }
   }
 }

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -47,20 +47,20 @@ def call(Map args = [:], Closure body) {
     "GOROOT=${env.WORKSPACE}/${goDir}",
     "GOPATH=${env.WORKSPACE}"
   ]){
-    installGo(version)
-    installPackages(pkgs)
+    installGo(version: version)
+    installPackages(pkgs: pkgs)
     body()
   }
 }
 
-def installGo(version) {
+def installGo(Map args = [:]) {
   retryWithSleep(retries: 3, seconds: 5, backoff: true){
-    sh(label: "Installing go ${version}", script: "gvm ${version}")
+    sh(label: "Installing go ${args.version}", script: "gvm ${args.version}")
   }
 }
 
-def installPackages(pkgs) {
-  pkgs?.each{ p ->
+def installPackages(Map args = [:]) {
+  args.pkgs?.each{ p ->
     retryWithSleep(retries: 3, seconds: 5, backoff: true){
       sh(label: "Installing ${p}", script: "go get -u ${p}")
     }

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -72,7 +72,11 @@ def installPackages(Map args = [:]) {
 }
 
 def goArch() {
-  // TODO
-  def arch = (isArm()) ? 'arm64' : 'amd64'
-  return 'TODO'
+  // Unsupported architectures:
+  //    darwin for arm64 in case isArm() needs a tweak
+  //    MIPS, PPC, RISC, S390X, WASM
+  if(isArm()) {
+    return 'arm64'
+  }
+  return 'amd64'
 }

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -60,9 +60,19 @@ def installGo(Map args = [:]) {
 }
 
 def installPackages(Map args = [:]) {
-  args.pkgs?.each{ p ->
-    retryWithSleep(retries: 3, seconds: 5, backoff: true){
-      sh(label: "Installing ${p}", script: "go get -u ${p}")
+  // GOARCH is required to be able to install the given packages for the specific arch
+  def arch = (env.GOARCH?.trim()) ?: goArch()
+  withEnv(["GOARCH=${arch}"]){
+    args.pkgs?.each{ p ->
+      retryWithSleep(retries: 3, seconds: 5, backoff: true){
+        sh(label: "Installing ${p}", script: "go get -u ${p}")
+      }
     }
   }
+}
+
+def goArch() {
+  // TODO
+  def arch = (isArm()) ? 'arm64' : 'amd64'
+  return 'TODO'
 }

--- a/vars/withGoEnvUnix.txt
+++ b/vars/withGoEnvUnix.txt
@@ -20,3 +20,7 @@
 * version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
 * pkgs: Go packages to install with Go get before to execute any command.
 * os: OS to use. (Example: `linux`). This is an option argument and if not set, the worker label will be used.
+
+
+NOTE: If the `GOARCH` environment variable is defined then it will be used to install the given packages for that architecture,
+      otherwise it will be evaluated on the fly.


### PR DESCRIPTION
## What does this PR do?

Use `GOARCH` environment variable when installing the go packages:
* If `GOARCH` is set then use it (that's the current behaviour anyway)
* Otherwise it will calculate the ARCH for that particular node. So far `arm64` or `amd64`, since we do not use any other architecture for `Unix`

## Why is it important?

This will help the consumers of the `withGoEnv` to be ARCH agnostic.

## Actions

- [x] Implement goArch for https://github.com/golang/go/blob/210f70e298cf7e45a2b2638545228a44c78740de/src/cmd/internal/sys/arch.go#L13-L25

## Related issues

Blockes https://github.com/elastic/beats/pull/PR-23592
