### PR TITLE
Support disable GitHub issue creation for flaky tests

### DIFF
--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -862,6 +862,27 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_analyzeFlakey_in_prs_with_flaky_tests_and_disabled_issue_creation() throws Exception {
+    def script = loadScript(scriptName)
+    helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: "flake-results.json")})
+    helper.registerAllowedMethod('lookForGitHubIssues', [Map.class], { return [ bar: '' ] })
+    helper.registerAllowedMethod('isPR', { return true })
+    script.analyzeFlakey(
+      flakyReportIdx: 'reporter-apm-agent-python-apm-agent-python-master',
+      es: "https://fake_url",
+      testsErrors: readJSON(file: 'flake-tests-errors.json'),
+      testsSummary: readJSON(file: 'flake-tests-summary.json'),
+      disableGHIssueCreation: true
+    )
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('githubCreateIssue', "**Test Name:** `bar`"))
+    assertTrue(assertMethodCallContainsPattern('log', "issue has not been created since GitHub issues creation has been disabled."))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "The following tests failed"))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', "`bar` has not been reported yet"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_analyzeFlakey_in_prs_without_failed_tests() throws Exception {
     def script = loadScript(scriptName)
     helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: "flake-results.json")})

--- a/vars/README.md
+++ b/vars/README.md
@@ -1777,6 +1777,7 @@ emails on Failed builds that are not pull request.
 * analyzeFlakey: Whether or not to add a comment in the PR with tests which have been detected as flakey. Default: `false`.
 * flakyReportIdx: The flaky index to compare this jobs results to. e.g. reporter-apm-agent-java-apm-agent-java-master
 * flakyThreshold: The threshold below which flaky tests will be ignored. Default: 0.0
+* flakyDisableGHIssueCreation: whether to disable the GH create issue if any flaky matches. Default false.
 * newPRComment: The map of the data to be populated as a comment. Default empty.
 * aggregateComments: Whether to create only one single GitHub PR Comment with all the details. Default true.
 

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -67,6 +67,7 @@ def call(Map args = [:]) {
       def slackNotify = args.containsKey('slackNotify') ? args.slackNotify : !isPR() && currentBuild.currentResult != "SUCCESS"
       def slackCredentials = args.containsKey('slackCredentials') ? args.slackCredentials : 'jenkins-slack-integration-token'
       def aggregateComments = args.get('aggregateComments', true)
+      def flakyDisableGHIssueCreation = args.get('flakyDisableGHIssueCreation', false)
       catchError(message: 'There were some failures with the notifications', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
         def data = getBuildInfoJsonFiles(jobURL: env.JOB_URL, buildNumber: env.BUILD_NUMBER, returnData: true)
         data['docsUrl'] = "http://${env?.REPO_NAME}_${env?.CHANGE_ID}.docs-preview.app.elstc.co/diff"
@@ -81,6 +82,7 @@ def call(Map args = [:]) {
         data['credentialId'] = slackCredentials
         data['enabled'] = slackNotify
 
+        data['disableGHIssueCreation'] = flakyDisableGHIssueCreation
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments
         // Generate digested data to be consumed later on by the createGitHubComment.

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -37,5 +37,6 @@ emails on Failed builds that are not pull request.
 * analyzeFlakey: Whether or not to add a comment in the PR with tests which have been detected as flakey. Default: `false`.
 * flakyReportIdx: The flaky index to compare this jobs results to. e.g. reporter-apm-agent-java-apm-agent-java-master
 * flakyThreshold: The threshold below which flaky tests will be ignored. Default: 0.0
+* flakyDisableGHIssueCreation: whether to disable the GH create issue if any flaky matches. Default false.
 * newPRComment: The map of the data to be populated as a comment. Default empty.
 * aggregateComments: Whether to create only one single GitHub PR Comment with all the details. Default true.


### PR DESCRIPTION
## What does this PR do?

Allow to disable the GitHub issue creation when there is a flaky match.
- `notifyBuildResult` now got a new parameter called `flakyDisableGHIssueCreation` (Default: false) <-- this is consumed by the Jenkinsfiles.
- `analyzeFlakey` now got a new parameter called `disableGHIssueCreation` (Default: false) <-- this not consumed outside of the library, so `notifyBuildResult` calls this step.

## Why is it important?

Allow the teams to manage their flakiness analysis process.

## Further details

If you review this PR, there are two commits:
- https://github.com/elastic/apm-pipeline-library/commit/586bdb3217cbbd4b6531ac1f6bd5cd097a20c314 is the refactor
- https://github.com/elastic/apm-pipeline-library/commit/6c20a472ec8f126ed10d21272961a3e33223f677 is the actual change for the new argument.

