### PR TITLE
Return the build digested output

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -224,7 +224,7 @@ def notifyPR(Map args = [:]) {
     def body = args.get('comment', '')
 
     // In case body is empty let's fallback to the previous behaviour for compatibility reasons.
-    if (!body.trim()) {
+    if (!body?.trim()) {
       def arguments = args
       arguments['archiveFile'] = false
       body = generateBuildReport(arguments)

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -470,6 +470,23 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_a_null_comment() throws Exception {
+    def script = loadScript(scriptName)
+    script.notifyPR(comment: null,
+                    build: readJSON(file: "build-info.json"),
+                    buildStatus: "FAILURE",
+                    changeSet: readJSON(file: "changeSet-info.json"),
+                    log: f.getText(),
+                    statsUrl: "https://ecs.example.com/app/kibana",
+                    stepsErrors: readJSON(file: "steps-errors-with-github-environmental-issue.json"),
+                    testsErrors: [],
+                    testsSummary: readJSON(file: "tests-summary.json"))
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('libraryResource', 'github-comment-markdown.template'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_pr_with_failure_and_github_environmental_issue_and_further_errors() throws Exception {
     def script = loadScript(scriptName)
     script.notifyPR(

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -238,7 +238,7 @@ def customisedEmail(String email) {
 def generateBuildReport(def args=[:]) {
   log(level: 'DEBUG', text: 'notifyBuildResult: Generate build report.')
   catchError(message: "There were some failures when generating the build report", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-    (new NotificationManager()).generateBuildReport(args.data)
+    return (new NotificationManager()).generateBuildReport(args.data)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Validate not null objects and generateBuildReport  returns now the message

## Why is it important?

Regression when merging #926

## Related issues
Closes #https://github.com/elastic/apm-pipeline-library/issues/930
