### PR TITLE
Consumers of githubApiCall should not transform JSON

### DIFF
--- a/vars/githubTraditionalPrComment.groovy
+++ b/vars/githubTraditionalPrComment.groovy
@@ -45,9 +45,7 @@ def call(Map args = [:]){
        url = "${url}/${id}"
        method = 'PATCH'
     }
-    // Ensure the data is transformed to Json and then toString.
-    def transformedData = JsonOutput.toJson([ "body": "${message}" ])
-    def comment = githubApiCall(token: token, url: url, data: transformedData, method: method, noCache: true)
+    def comment = githubApiCall(token: token, url: url, data: [ "body": "${message}" ], method: method, noCache: true)
     return comment.id
   } else {
     log(level: 'WARN', text: 'githubTraditionalPrComment: is only available for PRs.')

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -86,7 +86,7 @@ def call(Map args = [:]) {
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments
         // Generate digested data to be consumed later on by the createGitHubComment.
-        data['comment'] = generateBuildReport(data: data)
+        data['comment_disabled'] = generateBuildReport(data: data)
         def notifications = []
 
         notifyEmail(data: data, when: (shouldNotify && !to?.empty))

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -86,7 +86,7 @@ def call(Map args = [:]) {
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments
         // Generate digested data to be consumed later on by the createGitHubComment.
-        data['comment_disabled'] = generateBuildReport(data: data)
+        data['comment'] = generateBuildReport(data: data)
         def notifications = []
 
         notifyEmail(data: data, when: (shouldNotify && !to?.empty))


### PR DESCRIPTION
## What does this PR do?

JSON transformation is now delegated to the githubApiCall.

## Why is it important?

Simplify consumers usage with string only format.

## Related issues

Regression from https://github.com/elastic/apm-pipeline-library/commit/41ff35c343c20069e44d68b6ee790d1697ae2f4b#diff-51b46d8d285372d54df7b418dd6a4ad57a3533e2c0eededca50fa48fbe8c6a84R56-R57 

## Fixes

![image](https://user-images.githubusercontent.com/2871786/106257218-25530d80-6214-11eb-9a74-309d82050ded.png)


## Test

See https://github.com/elastic/beats/pull/23715#issuecomment-769687240