### PR TITLE
WIP [Usability] Access dynamically to the stage BO URL linked to the GH Check

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@master') _
+@Library('apm@feature/blueocean-stage-url') _
 
 pipeline {
   agent { label 'linux && immutable' }


### PR DESCRIPTION
## What does this PR do?

Trying to support GitHub check URLs that point to the Blue Ocean Stage URL with the logs.

## Why is it important?

Avoid any further access to anything that's not BlueOcean
