### PR TITLE
[CI] support sending a PR to each ecs agent when spec change

### DIFF
--- a/.ci/jobs/ecs-logging-update-specs-mbp.yml
+++ b/.ci/jobs/ecs-logging-update-specs-mbp.yml
@@ -1,0 +1,42 @@
+---
+- job:
+    name: apm-shared/ecs-logging-update-specs-mbp
+    display-name: ecs-logging Update Specs
+    description: Send PRs to the subscribed ECS Agents if the spec files (JSON) are modified, triggered for the master branch for the elastic/ecs-logging project
+    view: APM-CI
+    project-type: multibranch
+    script-path: .ci/Jenkinsfile
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: false
+          notification-context: 'apm-ci'
+          repo: ecs-logging
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: true
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 4
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'
+    triggers:
+      - timed: 'H H(4-5) * * 1,5'


### PR DESCRIPTION
## What does this PR do?

Create MBP fro https://github.com/elastic/ecs-logging/pull/47

## Why is it important?

Automate the PR creation


## Related issues
Closes #ISSUE