### PR TITLE
mask credentials when using gitCmd

### DIFF
--- a/src/test/groovy/GitCmdStepTests.groovy
+++ b/src/test/groovy/GitCmdStepTests.groovy
@@ -27,8 +27,11 @@ class GitCmdStepTests extends ApmBasePipelineTest {
   @Before
   void setUp() throws Exception {
     super.setUp()
-    binding.setVariable("ORG_NAME", "my_org")
-    binding.setVariable("REPO_NAME", "my_repo")
+    addEnvVar("ORG_NAME", "my_org")
+    addEnvVar("REPO_NAME", "my_repo")
+    addEnvVar('GIT_PASSWORD', 'password')
+    addEnvVar('GIT_USERNAME', 'username')
+    helper.registerAllowedMethod('readFile', [String.class], { return 'git clone https://username:password@repo.git' })
   }
 
   @Test
@@ -108,6 +111,7 @@ class GitCmdStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'push.log'))
+    assertTrue(assertMethodCallContainsPattern('readFile', 'push.log'))
   }
 
   @Test
@@ -117,6 +121,7 @@ class GitCmdStepTests extends ApmBasePipelineTest {
     script.call(cmd: 'push', credentialsId: 'foo', store: true)
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('archiveArtifacts', 'push.log'))
+    assertTrue(assertMethodCallContainsPattern('readFile', 'push.log'))
   }
 
   @Test

--- a/vars/gitCmd.groovy
+++ b/vars/gitCmd.groovy
@@ -40,22 +40,37 @@ def call(Map params = [:]) {
     def logFilename = fileExists(folder) ? "${folder}/${filename}" : "${filename}"
     def storeFlag = store ? "> ${logFilename} 2>&1" : ''
     try {
-      sh(label: "Git ${cmd}", script: "git ${cmd} https://\${GIT_USERNAME}:\${GIT_PASSWORD}@github.com/${ORG_NAME}/${REPO_NAME}.git ${args} ${storeFlag}")
+      sh(label: "Git ${cmd}", script: "git ${cmd} https://\${GIT_USERNAME}:\${GIT_PASSWORD}@github.com/${env.ORG_NAME}/${env.REPO_NAME}.git ${args} ${storeFlag}")
     } catch(err) {
       if (store) {
         log(level: 'WARN', text: "gitCmd failed, further details in the archived file '${logFilename}'")
       }
       throw err
     } finally {
-      if (store) {
-        if (fileExists(folder)) {
-          dir(folder) {
-            archiveArtifacts(artifacts: "${filename}")
-          }
-        } else {
-          archiveArtifacts(artifacts: "${filename}")
-        }
-      }
+      storeWithMaskedCredentials(filename: filename, store: store, folder: folder)
     }
   }
+}
+
+def storeWithMaskedCredentials(Map args=[:]) {
+  def store = args.get('store', false)
+  def folder = args.get('folder')
+  def filename = args.get('filename')
+
+  if (store) {
+    if (fileExists(folder)) {
+      dir(folder) {
+        maskCredentials(filename)
+      }
+    } else {
+      maskCredentials(filename)
+    }
+  }
+}
+
+def maskCredentials(filename) {
+  def fileContent = readFile(filename)
+  def maskedContent = fileContent.replaceAll(env.GIT_PASSWORD, 'hidden').replaceAll(env.GIT_USERNAME, 'hidden')
+  writeFile(file: filename, text: maskedContent)
+  archiveArtifacts(artifacts: "${filename}")
 }


### PR DESCRIPTION
## What does this PR do?

`gitCmd` uses some credentials and if `store` then let's mask any sensitive credentials

## Why is it important?

Security