### PR TITLE
corner cases if wget is not available and null values

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -177,14 +177,20 @@ function fetchAndPrepareTestSummaryReport() {
     ## BlueOcean might return 500 in some scenarios. If so, let's parse the tests entrypoint
     if [ ! -e "${file}" ] ; then
         if [ -e "${testsFile}" ] ; then
-            {
-                echo "{"
-                echo "\"total\": $(jq '. | length' "${testsFile}"),"
-                echo "\"passed\": $(jq 'map(select(.status |contains("PASSED"))) | length' "${testsFile}"),"
-                echo "\"failed\": $(jq 'map(select(.status |contains("FAILED"))) | length' "${testsFile}"),"
-                echo "\"skipped\": $(jq 'map(select(.status |contains("SKIPPED"))) | length' "${testsFile}")"
-                echo "}"
-            } > "${file}"
+            ## In case the testfile contains empty values
+            total=$(jq '. | length' "${testsFile}")
+            if [[ $total =~ ^[0-9]+$ ]] ; then
+                {
+                    echo "{"
+                    echo "\"total\": ${total},"
+                    echo "\"passed\": $(jq 'map(select(.status |contains("PASSED"))) | length' "${testsFile}"),"
+                    echo "\"failed\": $(jq 'map(select(.status |contains("FAILED"))) | length' "${testsFile}"),"
+                    echo "\"skipped\": $(jq 'map(select(.status |contains("SKIPPED"))) | length' "${testsFile}")"
+                    echo "}"
+                } > "${file}"
+            else
+                echo "${default}" > "${file}"
+            fi
         else
             echo "${default}" > "${file}"
         fi

--- a/src/test/groovy/PreCommitToJunitStepTests.groovy
+++ b/src/test/groovy/PreCommitToJunitStepTests.groovy
@@ -92,4 +92,10 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
                                       new File("target/${file}"), 'UTF-8'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_null() throws Exception {
+    script.toJunit('1', null, '2')
+    printCallStack()
+  }
 }

--- a/src/test/groovy/PreCommitToJunitStepTests.groovy
+++ b/src/test/groovy/PreCommitToJunitStepTests.groovy
@@ -95,7 +95,8 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_null() throws Exception {
-    script.toJunit('1', null, '2')
+    def ret = script.toJunit('foo', null, 'bar')
     printCallStack()
+    assertTrue(ret.contains('name="foo" />'))
   }
 }

--- a/vars/preCommitToJunit.groovy
+++ b/vars/preCommitToJunit.groovy
@@ -51,9 +51,9 @@ def call(Map params = [:]) {
 
 def toJunit(String name, String status, String message) {
   String output = "<testcase classname=\"pre_commit.lint\" name=\"${name}\""
-  if (status?.toLowerCase().contains('skipped')) {
+  if (status?.toLowerCase()?.contains('skipped')) {
     output += "><skipped message=\"skipped\"/><system-out><![CDATA[${normalise(message)}]]></system-out></testcase>"
-  } else if (status?.toLowerCase().contains('failed')) {
+  } else if (status?.toLowerCase()?.contains('failed')) {
     output += "><error message=\"error\"/><system-out><![CDATA[${normalise(message)}]]></system-out></testcase>"
   } else {
     output += " />"


### PR DESCRIPTION
## What does this PR do?

I've seen some corner cases when testing this pipeline locally since my docker jenkins instance didn't have any `wget` so `jq` could not be installed and therefore no way to populate the test-summary with empty value since the `test-info` file was created with empty values.

## Why is it important?

when `wget` and `jq` are not installed then something bad might happen, so let's ensure we handle those use cases too.
