### PR TITLE
feat: Archive only on fail

### DIFF
--- a/src/test/groovy/AxisStepTests.groovy
+++ b/src/test/groovy/AxisStepTests.groovy
@@ -45,6 +45,7 @@ class AxisStepTests extends ApmBasePipelineTest {
     assertJobStatusSuccess()
   }
 
+  @Test
   void testMissingName() throws Exception {
     def script = loadScript(scriptName)
     testMissingArgument('name', 'argument missing') {
@@ -52,6 +53,7 @@ class AxisStepTests extends ApmBasePipelineTest {
     }
   }
 
+  @Test
   void testMissingValues() throws Exception {
     def script = loadScript(scriptName)
     testMissingArgument('values', 'argument missing') {

--- a/src/test/groovy/IsBuildFailureStepTests.groovy
+++ b/src/test/groovy/IsBuildFailureStepTests.groovy
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import co.elastic.mock.RunWrapperMock
+import static org.junit.Assert.assertTrue
+
+class IsBuildFailureStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isBuildFailure.groovy')
+  }
+
+  @Test
+  void test() throws Exception {
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret == false)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    binding.setVariable('currentBuild', new RunWrapperMock(result: 'FAILURE'))
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void testUnstable() throws Exception {
+    binding.setVariable('currentBuild', new RunWrapperMock(result: 'UNSTABLE'))
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusUnstable()
+  }
+}

--- a/src/test/resources/filebeatTest_2/filebeat_container_worker-0676d01d9601f8191.json
+++ b/src/test/resources/filebeatTest_2/filebeat_container_worker-0676d01d9601f8191.json
@@ -1,0 +1,9 @@
+{
+  "id": "fooID",
+  "output": "foo.log",
+  "config": "bar.xml",
+  "image": "foo: latest",
+  "workdir": "fooDir",
+  "timeout": "30",
+  "archiveOnlyOnFail": "true"
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -408,6 +408,7 @@ Print a text on color on a xterm.
 * *output:* log file to save all Docker containers logs (docker_logs.log).
 * *timeout:* Time to wait before kill the Filebeat Docker container on the stop operation.
 * *workdir:* Directory to use as root folder to read and write files (current folder).
+* *archiveOnlyOnFail:* if true only archive the files in case of failure.
 
 ```
   filebeat(config: 'filebeat.yml',
@@ -1370,6 +1371,16 @@ Check it the build was triggered by a Branch index.
 ```
 def branchIndexTrigger = isBranchIndexTrigger()
 ```
+
+## isBuildFailure
+
+  Return true if the build status is FAILURE or UNSTABLE
+
+  ```
+  if(isBuildFailure()){
+    echo("The build failed")
+  }
+  ```
 
 ## isCommentTrigger
 Check it the build was triggered by a comment in GitHub and the user is an Elastic user.

--- a/vars/filebeat.txt
+++ b/vars/filebeat.txt
@@ -21,6 +21,7 @@
 * *output:* log file to save all Docker containers logs (docker_logs.log).
 * *timeout:* Time to wait before kill the Filebeat Docker container on the stop operation.
 * *workdir:* Directory to use as root folder to read and write files (current folder).
+* *archiveOnlyOnFail:* if true only archive the files in case of failure.
 
 ```
   filebeat(config: 'filebeat.yml',

--- a/vars/isBuildFailure.groovy
+++ b/vars/isBuildFailure.groovy
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Return true if the build status is FAILURE or UNSTABLE
+*/
+def call() {
+  return currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE'
+}

--- a/vars/isBuildFailure.txt
+++ b/vars/isBuildFailure.txt
@@ -1,0 +1,8 @@
+
+  Return true if the build status is FAILURE or UNSTABLE
+
+  ```
+  if(isBuildFailure()){
+    echo("The build failed")
+  }
+  ```


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* new step isBuildFailure
* implement archiveOnlyOnFail for filebeat step
* add some missing annotations on the Axis step tests

## Why is it important?

Sometimes, we need to archive the Docker logs when there are errors, this new parameter allow that.
