### PR TITLE
fix: GO_VERSION can be undefined

### DIFF
--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -52,7 +52,8 @@ def call(Map args = [:], Closure body) {
     "PATH=${path}",
     "GOROOT=${goRoot}",
     "GOPATH=${env.WORKSPACE}",
-    "USERPROFILE=${userProfile}"
+    "USERPROFILE=${userProfile}",
+    "GO_VERSION=${version}"
   ]){
     def content = libraryResource('scripts/install-tools.bat')
     retryWithSleep(retries: 2, seconds: 5, backoff: true){


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It set the GO_VERSION environment variable in the context of install and use of Go.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
If the GO_VERSION environment variable is not defined then `scripts/install-tools.bat` script fails, so we have to use the variable `version` that is the version passed as a parameter, or the value in GO_VERISON, or the value in the file `.go-version` to set the value of GO_VERSION.

```
[2021-02-04T13:18:07.159Z] C:\Users\jenkins\workspace\Beats_gosigar_PR-153>gvm.exe version 
[2021-02-04T13:18:07.417Z] gvm: error: Malformed version: version
[2021-02-04T13:18:07.417Z] 
[2021-02-04T13:18:07.417Z] C:\Users\jenkins\workspace\Beats_gosigar_PR-153>REM Install the given go version 
[2021-02-04T13:18:07.417Z] 
[2021-02-04T13:18:07.417Z] C:\Users\jenkins\workspace\Beats_gosigar_PR-153>gvm.exe --debug install  
[2021-02-04T13:18:07.417Z] gvm: error: no version specified
```
