### PR TITLE
[TEST]Test multiple shared libraries

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -99,6 +99,21 @@ unclassified:
                   - wildcard: "src/test/**"
                   - wildcard: "target/**"
                   - wildcard: "test-infra/**"
+      - name: "cloud"
+        defaultVersion: "master"
+        retriever:
+          modernSCM:
+            scm:
+              github:
+                configuredByUrl: true
+                credentialsId: "2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken"
+                id: "d84cb940-87bd-460f-a28f-c5459bdaa373"
+                repoOwner: "elastic"
+                repository: "cloud-pipeline-library"
+                repositoryUrl: "https://github.com/elastic/cloud-pipeline-library.git"
+                traits:
+                - "gitBranchDiscovery":
+                  strategyId: 1
   gitscm:
     globalConfigName: username
     globalConfigEmail: username@example.com

--- a/src/test/resources/jobs/cloud.dsl
+++ b/src/test/resources/jobs/cloud.dsl
@@ -1,0 +1,23 @@
+NAME = 'it/cloud'
+DSL = '''
+@Library('cloud@master') _
+pipeline {
+  agent none
+  stages {
+    stage('linux') {
+      steps {
+        retryWithSleep(1) {
+          echo 'hi'
+        }
+      }
+    }
+  }
+}'''
+
+pipelineJob(NAME) {
+  definition {
+    cps {
+      script(DSL.stripIndent())
+    }
+  }
+}


### PR DESCRIPTION
Same step with different signatures

## What does this PR do?

Validate behaviour for two different shared libraries which got the same step with different signatures

It fails as expected


```
Started by user unknown or anonymous
Running in Durability level: MAX_SURVIVABILITY
Loading library apm@current
FSSCM.checkout /var/pipeline-library to /var/jenkins_home/workspace/cloud@libs/apm
FSSCM.check completed in 251 milliseconds
[Checks API] No suitable checks publisher found.
Loading library cloud@master
Examining elastic/cloud-pipeline-library
Attempting to resolve master as a branch
Resolved master as branch master at revision f62f23333456a170863cb0f7c3b27c9b5e257d62
The recommended git tool is: NONE
using credential 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/elastic/cloud-pipeline-library.git # timeout=10
Fetching without tags
Fetching upstream changes from https://github.com/elastic/cloud-pipeline-library.git
 > git --version # timeout=10
 > git --version # 'git version 2.20.1'
using GIT_ASKPASS to set credentials GitHub user @elasticmachine User + Personal Access Token
 > git fetch --no-tags --force --progress -- https://github.com/elastic/cloud-pipeline-library.git +refs/heads/master:refs/remotes/origin/master # timeout=10
Checking out Revision f62f23333456a170863cb0f7c3b27c9b5e257d62 (master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f f62f23333456a170863cb0f7c3b27c9b5e257d62 # timeout=10
Commit message: "Merge pull request #53 from elastic/add-withgoenv"
 > git rev-list --no-walk f62f23333456a170863cb0f7c3b27c9b5e257d62 # timeout=10
[Checks API] No suitable checks publisher found.
[Pipeline] Start of Pipeline
[Pipeline] stage
[Pipeline] { (linux)
[Pipeline] }
[Pipeline] // stage
[Pipeline] End of Pipeline
[Checks API] No suitable checks publisher found.
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: retryWithSleep.call() is applicable for argument types: (java.lang.Integer, org.jenkinsci.plugins.workflow.cps.CpsClosure2) values: [1, org.jenkinsci.plugins.workflow.cps.CpsClosure2@5bb70211]
Possible solutions: call(groovy.lang.Closure), call(java.util.Map, groovy.lang.Closure), wait(), any(), run(), run()
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:58)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:64)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:54)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:163)
	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:23)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:157)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:142)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:161)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:165)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)
	at WorkflowScript.run(WorkflowScript:7)
```