### PR TITLE
Disable getStageId call

### DIFF
--- a/src/test/groovy/DetailsURLStepTests.groovy
+++ b/src/test/groovy/DetailsURLStepTests.groovy
@@ -16,6 +16,7 @@
 // under the License.
 
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import static org.junit.Assert.assertTrue
 
@@ -53,6 +54,7 @@ class DetailsURLStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  @Ignore("StageId call is not working with parallel. See https://github.com/elastic/apm-pipeline-library/issues/961")
   void test_with_stage() throws Exception {
     addEnvVar('BUILD_NUMBER', '1')
     helper.registerAllowedMethod('getStageId', [], { 2 })

--- a/vars/detailsURL.groovy
+++ b/vars/detailsURL.groovy
@@ -29,11 +29,12 @@ def call(Map args = [:]) {
   }
 
   // Let's point to the Blue Ocean stage logs if possible
-  def stageId = getStageId()
-  if (stageId) {
-    def restURLJob = getBlueoceanRestURLJob(jobURL: env.JOB_URL)
-    return "${restURLJob}runs/${env.BUILD_NUMBER}/nodes/${stageId}/log/?start=0"
-  }
+  // See https://github.com/elastic/apm-pipeline-library/issues/961
+  //def stageId = getStageId()
+  //if (stageId) {
+  //  def restURLJob = getBlueoceanRestURLJob(jobURL: env.JOB_URL)
+  //  return "${restURLJob}runs/${env.BUILD_NUMBER}/nodes/${stageId}/log/?start=0"
+  //}
 
   // Get the URL for the given tab if no other option
   if (isBlueOcean) {


### PR DESCRIPTION
See https://github.com/elastic/apm-pipeline-library/issues/961|

## What does this PR do?

There is a bug when using the getStageId with the beats project

## Why is it important?

Disable the getStageId call temporarily that was introduced with https://github.com/elastic/apm-pipeline-library/issues/935

## Related issues

Relates https://github.com/elastic/apm-pipeline-library/issues/961|


## Test

https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-23879/3/console is running with the changes in https://github.com/elastic/apm-pipeline-library/commit/b4fd3a5657b34210d5dc4a4ffdc83e620e9d82fc