### PR TITLE
Add releaseNotification step to simplify agent release pipelines

### DIFF
--- a/src/test/groovy/ReleaseNotificationStepTests.groovy
+++ b/src/test/groovy/ReleaseNotificationStepTests.groovy
@@ -17,8 +17,6 @@
 
 import org.junit.Before
 import org.junit.Test
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 

--- a/src/test/groovy/ReleaseNotificationStepTests.groovy
+++ b/src/test/groovy/ReleaseNotificationStepTests.groovy
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+
+class ReleaseNotificationStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/releaseNotification.groovy')
+  }
+
+  @Test
+  void test_without_arguments() throws Exception {
+    script.call()
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('emailext', 1))
+    assertTrue(assertMethodCallOccurrences('slackSend', 0))
+  }
+
+  @Test
+  void test_without_arguments_and_env_variables() throws Exception {
+    addEnvVar('SLACK_CHANNEL', '#foo')
+    addEnvVar('NOTIFY_TO', 'to@acme.com')
+    script.call()
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('emailext', 'to@acme.com'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', '#foo'))
+  }
+
+  @Test
+  void test_without_arguments_and_env_variables_all_parameters() throws Exception {
+    addEnvVar('SLACK_CHANNEL', '#foo')
+    addEnvVar('NOTIFY_TO', 'to@acme.com')
+    script.call(slackColor: 'good',
+                slackCredentialsId: 'credentials',
+                slackChannel: '#channel',
+                to: "to@foo.com",
+                subject: "[example] Release tag *0.1.1* has been created", 
+                body: "Build: (<http://foo.bar|here>) for further details.")
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('emailext', 'to@foo.com'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', '#channel'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'good'))
+  }
+
+  @Test
+  void test_transformSlackURLFormatToEmailFormat_null() throws Exception {
+    def ret = script.transformSlackURLFormatToEmailFormat(null)
+    printCallStack()
+    assertNull(ret)
+  }
+
+  @Test
+  void test_transformSlackURLFormatToEmailFormat_empty() throws Exception {
+    def ret = script.transformSlackURLFormatToEmailFormat('')
+    printCallStack()
+    assertTrue(ret.equals(''))
+  }
+
+  @Test
+  void test_transformSlackURLFormatToEmailFormat_foo() throws Exception {
+    def ret = script.transformSlackURLFormatToEmailFormat('foo')
+    printCallStack()
+    assertTrue(ret.equals('foo'))
+  }
+
+  @Test
+  void test_transformSlackURLFormatToEmailFormat_url() throws Exception {
+    def ret = script.transformSlackURLFormatToEmailFormat('(<URL|description>)')
+    printCallStack()
+    assertTrue(ret.equals('URL'))
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1960,6 +1960,24 @@ def i = randomNumber()
 def i = randomNumber(min: 1, max: 99)
 ```
 
+## releaseNotification
+Send notifications with the release status by email and slack.
+
+If body is slack format based then it will be transformed to the email format
+  
+```
+releaseNotification(slackColor: 'good',
+                    subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", 
+                    body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+```
+
+* body: this is the body email that will be also added to the subject when using slack notifications. Optional
+* slackChannel: the slack channel, multiple channels may be provided as a comma, semicolon, or space delimited string. Default `env.SLACK_CHANNEL`
+* slackColor: an optional value that can either be one of good, warning, danger, or any hex color code (eg. #439FE0)
+* slackCredentialsId: the slack credentialsId. Default 'jenkins-slack-integration-token'
+* subject: this is subject email that will be also aggregated to the body when using slack notifications. Optional
+* to: who should receive an email. Default `env.NOTIFY_TO`
+
 ## retryWithSleep
 Retry a command for a specified number of times until the command exits successfully.
 
@@ -2759,3 +2777,4 @@ writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secre
 
 * secret: Name of the secret on the the vault root path. Mandatory
 * data: What's the data to be written. Mandatory
+

--- a/vars/releaseNotification.groovy
+++ b/vars/releaseNotification.groovy
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Send notifications with the release status by email and slack
+  
+  releaseNotification(slackColor: 'good',
+                      subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", 
+                      body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+
+*/
+def call(Map args = [:]) {
+  def slackChannel = args.get('slackChannel', env.SLACK_CHANNEL)
+  def slackColor = args.get('slackColor')
+  def credentialsId = args.get('slackCredentialsId', 'jenkins-slack-integration-token')
+  def to = args.get('to', env.NOTIFY_TO)
+  def subject = args.get('subject', '')
+  def body = args.get('body', '')
+
+  if (slackChannel?.trim()) {
+    slackSend(channel: slackChannel,
+              color: slackColor,
+              message: "${subject}. ${body}",
+              tokenCredentialId: credentialsId)
+  } else {
+    log(level: 'INFO', text: 'releaseNotification: missing slackChannel therefore skipped the slack notification.')
+  }
+  
+  emailext(subject: subject,
+           to: to,
+           body: transformSlackURLFormatToEmailFormat(body))
+}
+
+def transformSlackURLFormatToEmailFormat(String message) {
+  // transform slack URL format '(<URL|description>)' to 'URL'.
+  return message?.replaceAll('\\(<', '')?.replaceAll('\\|.*>\\)', '')
+}

--- a/vars/releaseNotification.txt
+++ b/vars/releaseNotification.txt
@@ -1,0 +1,16 @@
+Send notifications with the release status by email and slack.
+
+If body is slack format based then it will be transformed to the email format
+  
+```
+releaseNotification(slackColor: 'good',
+                    subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", 
+                    body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+```
+
+* body: this is the body email that will be also added to the subject when using slack notifications. Optional
+* slackChannel: the slack channel, multiple channels may be provided as a comma, semicolon, or space delimited string. Default `env.SLACK_CHANNEL`
+* slackColor: an optional value that can either be one of good, warning, danger, or any hex color code (eg. #439FE0)
+* slackCredentialsId: the slack credentialsId. Default 'jenkins-slack-integration-token'
+* subject: this is subject email that will be also aggregated to the body when using slack notifications. Optional
+* to: who should receive an email. Default `env.NOTIFY_TO`


### PR DESCRIPTION
## What does this PR do?

Create wrapper to notify by email and slack 

## Why is it important?

DRY approach, as we sue the same function in different release pipelines.

