### PR TITLE
Disable/Enable pre-commit skipped tests in the report

### DIFF
--- a/src/test/groovy/PreCommitToJunitStepTests.groovy
+++ b/src/test/groovy/PreCommitToJunitStepTests.groovy
@@ -51,7 +51,7 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
   @Test
   void testSuccessWithSimpleCommitStages() throws Exception {
     def file = 'simple.xml'
-    script.call(input: 'simple.txt', output: file)
+    script.call(input: 'simple.txt', output: file, reportSkipped: true)
     printCallStack()
     assertTrue("The files differ!", FileUtils.contentEqualsIgnoreEOL(
                                       new File("${compareWith}/${file}"),
@@ -62,7 +62,7 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
   @Test
   void testSuccessWithAllPreCommitStages() throws Exception {
     def file = 'pre-commit.xml'
-    script.call(input: 'pre-commit.txt', output: file)
+    script.call(input: 'pre-commit.txt', output: file, reportSkipped: true)
     printCallStack()
     assertJobStatusSuccess()
     assertTrue("The files differ!", FileUtils.contentEqualsIgnoreEOL(
@@ -74,7 +74,7 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
   @Test
   void testSuccessWithSkippedPreCommitStages() throws Exception {
     def file = 'skipped.xml'
-    script.call(input: 'skipped.txt', output: file)
+    script.call(input: 'skipped.txt', output: file, reportSkipped: true)
     printCallStack()
     assertTrue("The files differ!", FileUtils.contentEqualsIgnoreEOL(
                                       new File("${compareWith}/${file}"),
@@ -85,7 +85,7 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
   @Test
   void testSuccessWithGherkinDefects() throws Exception {
     def file = 'gherkin.xml'
-    script.call(input: 'gherkin.txt', output: file)
+    script.call(input: 'gherkin.txt', output: file, reportSkipped: true)
     printCallStack()
     assertTrue("The files differ!", FileUtils.contentEqualsIgnoreEOL(
                                       new File("${compareWith}/${file}"),
@@ -98,5 +98,20 @@ class PreCommitToJunitStepTests extends ApmBasePipelineTest {
     def ret = script.toJunit('foo', null, 'bar')
     printCallStack()
     assertTrue(ret.contains('name="foo" />'))
+  }
+
+  @Test
+  void test_reportSkipped_enabled() throws Exception {
+    def ret = script.toJunit('foo', 'skipped', 'isortno files to check', true)
+    printCallStack()
+    assertTrue(ret.contains('<testcase classname="pre_commit.lint" name="foo"><skipped message="skipped"/><system-out>'))
+  }
+
+  @Test
+  void test_reportSkipped_disabled() throws Exception {
+    def ret = script.toJunit('foo', 'skipped', 'isortno files to check', false)
+    printCallStack()
+    println ret
+    assertTrue(ret.equals('<testcase classname="pre_commit.lint" name="foo" />'))
   }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1926,6 +1926,10 @@ Parse the pre-commit log file and generates a junit report
 preCommitToJunit(input: 'pre-commit.log', output: 'pre-commit-junit.xml')
 ```
 
+* input: the pre-commit output. Mandatory
+* output: the junit output. Mandatory
+* enableSkipped: whether to report skipped linting stages. Optional. Default false
+
 ## publishToCDN
 Publish to the [CDN](https://cloud.google.com/cdn) the given set of source files to the target bucket
 with the given headers.
@@ -2759,3 +2763,4 @@ writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secre
 
 * secret: Name of the secret on the the vault root path. Mandatory
 * data: What's the data to be written. Mandatory
+

--- a/vars/preCommitToJunit.txt
+++ b/vars/preCommitToJunit.txt
@@ -3,3 +3,7 @@ Parse the pre-commit log file and generates a junit report
 ```
 preCommitToJunit(input: 'pre-commit.log', output: 'pre-commit-junit.xml')
 ```
+
+* input: the pre-commit output. Mandatory
+* output: the junit output. Mandatory
+* enableSkipped: whether to report skipped linting stages. Optional. Default false


### PR DESCRIPTION
## What does this PR do?

Configure whether to enable/disable the pre-commited skipped checks as reported in the JUnit.


## Why is it important?

@SergeyKleyman found that the sanity-checks with skipped linted checks were a bit misleading since they are aggregated in the same test report with some other UTs/ITs....

Then we found out that it's worthy to use a red/green signal for this particular pre-commit checks.
