### PR TITLE
Support curl in addition to wget for gsutil

### DIFF
--- a/src/test/groovy/GsutilStepTests.groovy
+++ b/src/test/groovy/GsutilStepTests.groovy
@@ -95,11 +95,22 @@ class GsutilStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_without_gh_installed_by_default_no_wget() throws Exception {
+  void test_without_gh_installed_by_default_no_wget_no_curl() throws Exception {
     helper.registerAllowedMethod('isInstalled', [Map.class], { return false })
     script.call(command: 'cp', credentialsId: 'foo')
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('sh', 'wget -q -O'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'curl'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_without_gh_installed_by_default_no_wget() throws Exception {
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m -> return !(m.tool.equals('wget') || m.tool.equals('gsutil'))})
+    script.call(command: 'cp', credentialsId: 'foo')
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', 'wget -q -O gsutil.tar.gz'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'curl -sSLo gsutil.tar.gz --retry 3 --retry-delay 2 --max-time 10'))
     assertJobStatusSuccess()
   }
 

--- a/vars/gsutil.groovy
+++ b/vars/gsutil.groovy
@@ -46,15 +46,32 @@ def call(Map args = [:]) {
 def downloadInstaller(where) {
   def url = googleCloudSdkURL()
   def tarball = "gsutil.${isUnix() ? 'tar.gz' : 'zip'}"
-  if(isInstalled(tool: 'wget', flag: '--version')) {
-    dir(where) {
-      retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-        cmd(label: 'download gsutil', script: "wget -q -O ${tarball} ${url}")
-        uncompress(tarball)
-      }
+
+  dir(where) {
+    if (!downloadWithWget(tarball, url)) {
+      downloadWithCurl(tarball, url)
     }
+    uncompress(tarball)
+  }
+}
+
+def downloadWithWget(tarball, url) {
+  if(isInstalled(tool: 'wget', flag: '--version')) {
+    retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+      cmd(label: 'download gsutil', script: "wget -q -O ${tarball} ${url}")
+    }
+    return true
   } else {
     log(level: 'WARN', text: 'gsutil: wget is not available. gsutil will not be installed then.')
+  }
+  return false
+}
+
+def downloadWithCurl(tarball, url) {
+  if(isInstalled(tool: 'curl', flag: '--version')) {
+    cmd(label: 'download gsutil', script: "curl -sSLo ${tarball} --retry 3 --retry-delay 2 --max-time 10 ${url}")
+  } else {
+    log(level: 'WARN', text: 'gsutil: curl is not available. gsutil will not be installed then.')
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fallback to curl in case wget is not installed

## Why is it important?

As long as gsutil is not widely available in each CI Worker we need to configure the installation, so no all the workers got wget so let's try with curl also 

## Related issues
Closes #ISSUE\

## Tests

```bash
$ curl -sSLo gsutil.tar.gz --retry 3 --retry-delay 2 --max-time 10 https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-319.0.0-linux-x86_64.tar.gz 
$ ls -l gsutil.tar.gz 
-rw-r--r--  1 vmartinez  staff  86364996 17 Feb 09:18 gsutil.tar.gz       
x google-cloud-sdk/.install/.download/
x google-cloud-sdk/.install/anthoscli-linux-x86_64.manifest
```
