### PR TITLE
Omit failed steps if build was success

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -88,12 +88,14 @@ ${errorStackTrace}
 <% if (stepsErrors?.size() <= 0 && !buildStatus?.equals('SUCCESS') && errorGitHub) {%>
   <% stepsErrors = stepsErrors << errorGitHub %>
 <%}%>
-<% if (stepsErrors?.size() != 0) {%>
+<% if (stepsErrors?.size() != 0 && !statusSuccess) {%>
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)
   <details><summary>Expand to view the steps failures</summary>
   <p>
 
-  ${(stepsErrors?.size() > 10) ? '> Show only the first 10 steps failures' : ''}
+<% if (stepsErrors?.size() > 10) {%>
+> Show only the first 10 steps failures
+<% }%>
   <% stepsErrors?.takeRight(10)?.each{ c -> %>
   <% description = (c?.displayDescription && c?.displayDescription != 'null') ? "<li>Description: <code>${c?.displayDescription}</code></l1>" : ''%>
   <% duration = (c?.durationInMillis >= 0 ) ? "Took ${Math.round(c.durationInMillis/1000/60)} min ${Math.round(c.durationInMillis/1000)%60} sec" : ''%>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -150,6 +150,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('libraryResource', 'github-comment-markdown.template'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'badge/docs-preview'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Succeeded'))
+    assertFalse(assertMethodCallContainsPattern('githubPrComment', 'Steps errors'))
     assertJobStatusSuccess()
   }
 
@@ -235,6 +236,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Steps errors'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Omit notifications with failed steps if build was success

## Why is it important?

Avoid any kind of misleading when a build was built correctly, since sometime the CI retries a few number of times certain commands which are flaky (normally when interacting with third party systems) and those details should not be shown in the digested status message.

## Issues 

Closes https://github.com/elastic/apm-pipeline-library/issues/991