### PR TITLE
chore: use opentelemetry release

### DIFF
--- a/local/configs/plugins.txt
+++ b/local/configs/plugins.txt
@@ -4,6 +4,6 @@ google-compute-engine
 job-dsl
 metrics
 monitoring
-opentelemetry::https://storage.googleapis.com/apm-ci-temp/plugins/opentelemetry.hpi
+opentelemetry
 plot
 ssh-agent


### PR DESCRIPTION
## What does this PR do?

Use the default way of installing plugins

## Why is it important?

@cyrille-leclerc just cut a release https://github.com/jenkinsci/opentelemetry-plugin/releases
