### PR TITLE
Unzip does not strip components

### DIFF
--- a/vars/gsutil.groovy
+++ b/vars/gsutil.groovy
@@ -19,8 +19,10 @@ def call(Map args = [:]) {
   def command = args.containsKey('command') ? args.command : error('gsutil: command argument is required.')
   def credentialsId = args.containsKey('credentialsId') ? args.credentialsId : error('gsutil: credentialsId argument is required.')
   def gsUtilLocation = pwd(tmp: true)
+  def gsUtilLocationWin = "${gsUtilLocation}/google-cloud-sdk"
 
-  withEnv(["PATH+GSUTIL=${gsUtilLocation}", "PATH+GSUTIL_BIN=${gsUtilLocation}/bin"]) {
+  withEnv(["PATH+GSUTIL=${gsUtilLocation}", "PATH+GSUTIL_BIN=${gsUtilLocation}/bin",
+           "PATH+GSUTILWIN=${gsUtilLocationWin}", "PATH+GSUTILWIN_BIN=${gsUtilLocationWin}/bin"]) {
     if(!isInstalled(tool: 'gsutil', flag: '--version')) {
       downloadInstaller(gsUtilLocation)
     }


### PR DESCRIPTION
## What does this PR do?

Add top level folder to the PATH

## Why is it important?

Unzip does not strip components, therefore the gcloud is not available in the PATH

```
unzip google-cloud-sdk-319.0.0-windows-x86_64.zip 
Archive:  google-cloud-sdk-319.0.0-windows-x86_64.zip
   creating: google-cloud-sdk/.install/.download/
  inflating: google-cloud-sdk/.install/anthoscli-windows-x86_64.manifest  
  inflating: google-cloud-sdk/.install/anthoscli-windows-x86_64.snapshot.json  
  inflating: google-cloud-sdk/.install/anthoscli.manifest  
  inflating: google-cloud-sdk/.install/anthoscli.snapshot.json  
  inflating: google-cloud-sdk/.install/bq-win.manifest  
```

![image](https://user-images.githubusercontent.com/2871786/108750678-36ecb400-7539-11eb-8243-1c6ef974eac3.png)
