### PR TITLE
Report only one DeleteDir step failure

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -81,10 +81,12 @@ ${errorStackTrace}
 
 <!-- STEPS ERRORS IF ANY -->
 <% errorGitHub = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Notifies GitHub')}%>
-<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
+<% errorDeleteDir = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
+<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit') && !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
 <% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>
 <% stepsErrors = stepsErrors?.findAll{ !it?.displayName?.contains('Error signal') } %>
 <% if (errorSignal) { stepsErrors = stepsErrors << errorSignal }%>
+<% if (errorDeleteDir) { stepsErrors = stepsErrors << errorDeleteDir }%>
 <% if (stepsErrors?.size() <= 0 && !buildStatus?.equals('SUCCESS') && errorGitHub) {%>
   <% stepsErrors = stepsErrors << errorGitHub %>
 <%}%>

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -620,6 +620,14 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     }
   }
 
+  def assertMethodCallContainsPatternOccurrences(String methodName, String pattern, int compare) {
+    return helper.callStack.findAll { call ->
+      call.methodName == methodName
+    }.any { call ->
+      ((callArgsToString(call) =~ /${pattern}/).count) == compare
+    }
+  }
+
   def assertMethodCall(String methodName) {
     return helper.callStack.find { call ->
       call.methodName == methodName

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -427,6 +427,25 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_failure_and_deleteDir_issues() throws Exception {
+    script.notifyPR(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "FAILURE",
+      changeSet: readJSON(file: "changeSet-info.json"),
+      log: f.getText(),
+      statsUrl: "https://ecs.example.com/app/kibana",
+      stepsErrors: readJSON(file: "steps-errors-with-deleteDir-issue.json"),
+      testsErrors: [],
+      testsSummary: readJSON(file: "tests-summary.json")
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Shell Script'))
+    assertTrue(assertMethodCallContainsPatternOccurrences('githubPrComment', 'Recursively delete the current directory from the workspace', 1))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_pr_with_a_generated_comment() throws Exception {
     script.notifyPR(comment: 'My Comment')
     printCallStack()

--- a/src/test/resources/steps-errors-with-deleteDir-issue.json
+++ b/src/test/resources/steps-errors-with-deleteDir-issue.json
@@ -1,0 +1,50 @@
+[
+  {
+    "displayDescription": "Unable to delete 'C:\\Users\\jenkins\\workspace\\Beats_beats_PR-22662'. Tried 3 times (of a maximum of 3",
+    "displayName": "Recursively delete the current directory from the workspace",
+    "durationInMillis": 270827,
+    "id": "12168",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-02-18T16:23:33.466+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22662/runs/3/steps/12168/log"
+  },
+  {
+    "displayDescription": "Unable to delete 'C:\\Users\\jenkins\\workspace\\Beats_beats_PR-22662'. Tried 3 times (of a maximum of 3",
+    "displayName": "Recursively delete the current directory from the workspace",
+    "durationInMillis": 282224,
+    "id": "11714",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-02-18T16:22:37.478+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22662/runs/3/steps/11714/log"
+  },
+  {
+    "displayDescription": "Unable to delete 'C:\\Users\\jenkins\\workspace\\Beats_beats_PR-22662'. Tried 3 times (of a maximum of 3",
+    "displayName": "Recursively delete the current directory from the workspace",
+    "durationInMillis": 193494,
+    "id": "12939",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-02-18T16:24:40.836+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22662/runs/3/steps/12939/log"
+  },
+  {
+    "displayDescription": null,
+    "displayName": "Shell Script",
+    "durationInMillis": 101825,
+    "id": "58",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-02-18T16:24:40.836+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://beats-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/Beats/pipelines/beats/pipelines/PR-22662/runs/3/steps/58/log"
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Report only one deleteDir step failure

## Why is it important?

`deleteDir` step might not be as important as some other steps and might cause some misleading, so if multiple deleteDir failures then let's report only one.

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1005
