### PR TITLE
gsutil for windows with python

### DIFF
--- a/src/test/groovy/GsutilStepTests.groovy
+++ b/src/test/groovy/GsutilStepTests.groovy
@@ -134,7 +134,7 @@ class GsutilStepTests extends ApmBasePipelineTest {
     script.call(command: 'cp', credentialsId: 'foo')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withEnv', 'PATH+GSUTIL'))
-    assertTrue(assertMethodCallContainsPattern('bat', 'wget -q -O gsutil.zip https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-319.0.0-windows-x86_64.zip'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'wget -q -O gsutil.zip https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-319.0.0-windows-x86_64-bundled-python.zip'))
     assertJobStatusSuccess()
   }
 }

--- a/vars/gsutil.groovy
+++ b/vars/gsutil.groovy
@@ -73,6 +73,7 @@ def googleCloudSdkURL() {
   if (isUnix()) {
     return "${url}-linux-${arch}.tar.gz"
   } else {
+    // use the bundled python artifact to avoid issues with the existing python2 installation when running gsutil in some Windows versions
     return "${url}-windows-${arch}-bundled-python.zip"
   }
 }

--- a/vars/gsutil.groovy
+++ b/vars/gsutil.groovy
@@ -69,9 +69,12 @@ def downloadWithCurl(tarball, url) {
 
 def googleCloudSdkURL() {
   def url = 'https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-319.0.0'
-  def os = isUnix() ? 'linux' : 'windows'
-  def ext = isUnix() ? 'tar.gz' : 'zip'
-  return "${url}-${os}-${is64() ? 'x86_64' : 'x86'}.${ext}"
+  def arch = is64() ? 'x86_64' : 'x86'
+  if (isUnix()) {
+    return "${url}-linux-${arch}.tar.gz"
+  } else {
+    return "${url}-windows-${arch}-bundled-python.zip"
+  }
 }
 
 def uncompress(tarball) {


### PR DESCRIPTION
## What does this PR do?

Install the google cloud sdk with Python bundled for Windows

## Why is it important?

Some Windows versions got issues with the python2.exe

![image](https://user-images.githubusercontent.com/2871786/109002946-c2cc2080-769e-11eb-8630-765f0830a72a.png)

Though we are not the only ones suffering this issue -> https://stackoverflow.com/questions/64289902/gsutil-says-it-cannot-find-python

Python 2 is correctly configured:

![image](https://user-images.githubusercontent.com/2871786/109003016-d37c9680-769e-11eb-9714-62a5c72dd4c3.png)


## Test

And the bundled python has been validated in a W8 VM:

![image](https://user-images.githubusercontent.com/2871786/109003095-ed1dde00-769e-11eb-9180-20073961de5c.png)

