### PR TITLE
Remove dependency with https://plugins.jenkins.io/junit-attachments/

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -175,12 +175,7 @@ pipeline {
       }
       post {
         always {
-          junit(allowEmptyResults: true,
-            testDataPublishers: [
-              [$class: 'AttachmentPublisher']
-            ],
-            testResults:"${BASE_DIR}/.ci/jobDSL/build/test-results/test/TEST-*.xml"
-          )
+          junit(allowEmptyResults: true, testResults: "${BASE_DIR}/.ci/jobDSL/build/test-results/test/TEST-*.xml")
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Remove https://plugins.jenkins.io/junit-attachments/ dependency

## Why is it important?

https://plugins.jenkins.io/junit-attachments/ is in adoption, and let's remove a plugin that probably we won't need 

