### PR TITLE
Support arm64 MacOS M1 workers

### DIFF
--- a/src/test/groovy/NodeArchStepTests.groovy
+++ b/src/test/groovy/NodeArchStepTests.groovy
@@ -96,4 +96,13 @@ class NodeArchStepTests extends ApmBasePipelineTest {
     assertTrue(value == "x86_64")
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_arm64_darwin() throws Exception {
+    env.NODE_LABELS = "apple arm64 darwin macosx macosx-11.2 swarm worker-h2wdt2qxq6ny"
+    def value = script.call()
+    printCallStack()
+    assertTrue(value == "aarch64")
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/nodeArch.groovy
+++ b/vars/nodeArch.groovy
@@ -67,5 +67,5 @@ def isArm(labels){
 }
 
 def isArm64(labels){
-  return labels.contains('aarch64')
+  return labels.contains('aarch64') || labels.contains('arm64')
 }


### PR DESCRIPTION
## What does this PR do?

Support `arm64` arch

## Why is it important?

Otherwise

![image](https://user-images.githubusercontent.com/2871786/110315647-73bcae80-8001-11eb-9384-599295ab6e16.png)
