### PR TITLE
add noTags - fixes #1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🚀 Enhancements
 
 -  Support arm64 MacOS M1 workers [#1023](https://github.com/elastic/apm-pipeline-library/pull/1023)
+-  Add the noTags option to gitCheckout 
 
 #### 🙈 No user affected
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 #### 🚀 Enhancements
 
 -  Support arm64 MacOS M1 workers [#1023](https://github.com/elastic/apm-pipeline-library/pull/1023)
--  Add the noTags option to gitCheckout 
 
 #### 🙈 No user affected
 

--- a/src/test/groovy/GitCheckoutStepTests.groovy
+++ b/src/test/groovy/GitCheckoutStepTests.groovy
@@ -482,4 +482,19 @@ class GitCheckoutStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallOccurrences('githubPrCheckApproved', 0))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_NoTags() throws Exception {
+    script.scm = 'SCM'
+    script.call(basedir: 'sub-folder', branch: 'master',
+      repo: 'git@github.com:elastic/apm-pipeline-library.git',
+      credentialsId: 'credentials-id',
+      reference: 'repo',
+      noTags: true)
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('log', 'Checkout master'))
+    assertTrue(assertMethodCallContainsPattern('log', 'Reference repo enabled'))
+    assertTrue(assertMethodCallContainsPattern('checkout', 'CloneOption, depth=5, noTags=true, reference=repo'))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/groovy/GitCheckoutStepTests.groovy
+++ b/src/test/groovy/GitCheckoutStepTests.groovy
@@ -494,7 +494,7 @@ class GitCheckoutStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', 'Checkout master'))
     assertTrue(assertMethodCallContainsPattern('log', 'Reference repo enabled'))
-    assertTrue(assertMethodCallContainsPattern('checkout', 'CloneOption, depth=5, noTags=true, reference=repo'))
+    assertTrue(assertMethodCallContainsPattern('checkout', 'CloneOption, depth=0, noTags=true, reference=repo, shallow=false'))
     assertJobStatusSuccess()
   }
 }

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -42,6 +42,7 @@ def call(Map args = [:]){
   def depthValue = args.containsKey('depth') ? args.get('depth') : 5
   def retryValue = args.containsKey('retry') ? args.get('retry') : 3
   def refspec = '+refs/pull/*/head:refs/remotes/origin/pr/*'
+  def noTags = args.containsKey('noTags') ? args.get('noTags') : false
 
   if(!env?.GIT_URL && args.repo) {
     log(level: 'DEBUG', text: 'Override GIT_URL with the args.repo to support simple pipeline rather than multibranch pipelines only.')
@@ -71,7 +72,7 @@ def call(Map args = [:]){
     shallowValue = false
   }
 
-  extensions.add([$class: 'CloneOption', depth: shallowValue ? depthValue : 0, noTags: false, reference: "${reference != null ? reference : '' }", shallow: shallowValue])
+  extensions.add([$class: 'CloneOption', depth: shallowValue ? depthValue : 0, noTags: noTags, reference: "${reference != null ? reference : '' }", shallow: shallowValue])
   log(level: 'DEBUG', text: "gitCheckout: Reference repo ${reference != null ? 'enabled' : 'disabled' } ${extensions.toString()}")
 
   if(mergeTarget != null){


### PR DESCRIPTION
## What does this PR do?

Adds the `noTags`  option in `gitCheclout`

## Why is it important?

We are using the apm lib in all our jobs, and we have a custom checkout function that could go away if `gitCheckout` let us chec out wih no tags

## Related issues
Closes #1024
