### PR TITLE
feat: improvements in filebeat step

### DIFF
--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -108,7 +108,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -143,7 +143,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${fallbackOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${fallbackOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -179,7 +179,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${expectedOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${expectedOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -214,7 +214,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
       assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${output}*"))
     }
   }
 
@@ -282,7 +282,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -298,7 +298,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -314,7 +314,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=./${output}*"))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -256,6 +256,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
 
   @Test
   void testSanitizeOutputFileName() throws Exception {
+    assertEquals(null, null)
     assertEquals("", script.sanitizeOutputFileName(" "))
     assertEquals("foo_bar.log", script.sanitizeOutputFileName("foo && bar.log"))
     assertEquals("foo_bar.log", script.sanitizeOutputFileName("foo         && bar.log"))

--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -108,7 +108,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -143,7 +143,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${fallbackOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${fallbackOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -179,7 +179,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${expectedOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${expectedOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -214,7 +214,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
       assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
+      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     }
   }
 
@@ -282,7 +282,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -298,7 +298,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
+    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -314,7 +314,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/FilebeatStepTests.groovy
+++ b/src/test/groovy/FilebeatStepTests.groovy
@@ -108,7 +108,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -143,7 +143,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${fallbackOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${fallbackOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -179,7 +179,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${expectedOutput}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${expectedOutput}*"))
     assertJobStatusSuccess()
   }
 
@@ -214,7 +214,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
       assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
       assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+      assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
     }
   }
 
@@ -281,7 +281,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('readJSON', "file=${workdir}/${jsonConfig}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker exec -t ${id}"))
     assertTrue(assertMethodCallContainsPattern('sh', "docker stop --time 30 ${id}"))
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -297,7 +297,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
     assertJobStatusSuccess()
   }
 
@@ -313,7 +313,7 @@ class FilebeatStepTests extends ApmBasePipelineTest {
         workdir: workdir,
       )
     }
-    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=${workdir}/${output}*"))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/resources/filebeatTest/filebeat_container_worker-0676d01d9601f8191.json
+++ b/src/test/resources/filebeatTest/filebeat_container_worker-0676d01d9601f8191.json
@@ -3,6 +3,5 @@
   "output": "foo.log",
   "config": "bar.xml",
   "image": "foo: latest",
-  "workdir": "fooDir",
   "timeout": "30"
 }

--- a/src/test/resources/filebeatTest_2/filebeat_container_worker-0676d01d9601f8191.json
+++ b/src/test/resources/filebeatTest_2/filebeat_container_worker-0676d01d9601f8191.json
@@ -3,7 +3,6 @@
   "output": "foo.log",
   "config": "bar.xml",
   "image": "foo: latest",
-  "workdir": "fooDir",
   "timeout": "30",
   "archiveOnlyOnFail": "true"
 }

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -122,7 +122,8 @@ def stop(Map args = [:]){
     docker exec -t ${stepConfig.id} chmod -R ugo+rw /output || echo "Exit code \$?"
     docker stop --time ${timeout} ${stepConfig.id} || echo "Exit code \$?"
   """)
-  if(archiveOnlyOnFail == false || (archiveOnlyOnFail && isBuildFailure())){
+
+  if(!archiveOnlyOnFail || isBuildFailure()){
     archiveArtifacts(artifacts: "**/${stepConfig.output}*", allowEmptyArchive: true)
   }
 }

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -40,9 +40,7 @@ def start(Map args = [:]) {
   if (args.containsKey('output')) {
     sanitizedOutput = sanitizeOutputFileName(args.output)
   }
-  sanitizedOutput = sanitizedOutput?.trim() ? sanitizedOutput : 'docker_logs.log'
-
-  def output = sanitizedOutput
+  def output = sanitizedOutput?.trim() ? sanitizedOutput : 'docker_logs.log'
   def config = args.containsKey('config') ? args.config : "filebeat_conf.yml"
   def image = args.containsKey('image') ? args.image : "docker.elastic.co/beats/filebeat:7.10.1"
   def workdir = args.containsKey('workdir') ? args.workdir : pwd()

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -84,7 +84,6 @@ def start(Map args = [:]) {
     output: output,
     config: config,
     image: image,
-    workdir: workdir,
     timeout: timeout,
     archiveOnlyOnFail: archiveOnlyOnFail
   ]

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -36,13 +36,13 @@ def call(Map args = [:], Closure body) {
 }
 
 def start(Map args = [:]) {
-  def sanitizedOuput = ''
+  def sanitizedOutput = ''
   if (args.containsKey('output')) {
-    sanitizedOuput = sanitizeOutputFileName(args.output)
+    sanitizedOutput = sanitizeOutputFileName(args.output)
   }
-  sanitizedOuput = sanitizedOuput?.trim() ? sanitizedOuput : 'docker_logs.log'
+  sanitizedOutput = sanitizedOutput?.trim() ? sanitizedOutput : 'docker_logs.log'
 
-  def output = sanitizedOuput
+  def output = sanitizedOutput
   def config = args.containsKey('config') ? args.config : "filebeat_conf.yml"
   def image = args.containsKey('image') ? args.image : "docker.elastic.co/beats/filebeat:7.10.1"
   def workdir = args.containsKey('workdir') ? args.workdir : pwd()

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -123,7 +123,7 @@ def stop(Map args = [:]){
   """)
 
   if(!archiveOnlyOnFail || isBuildFailure()){
-    archiveArtifacts(artifacts: "**/${stepConfig.output}*", allowEmptyArchive: true)
+    archiveArtifacts(artifacts: "${workdir}/${stepConfig.output}*", allowEmptyArchive: true)
   }
 }
 

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -123,7 +123,7 @@ def stop(Map args = [:]){
   """)
 
   if(!archiveOnlyOnFail || isBuildFailure()){
-    archiveArtifacts(artifacts: "${workdir}/${stepConfig.output}*", allowEmptyArchive: true)
+    archiveArtifacts(artifacts: "**/${stepConfig.output}*", allowEmptyArchive: true)
   }
 }
 

--- a/vars/filebeat.groovy
+++ b/vars/filebeat.groovy
@@ -123,7 +123,7 @@ def stop(Map args = [:]){
   """)
 
   if(!archiveOnlyOnFail || isBuildFailure()){
-    archiveArtifacts(artifacts: "**/${stepConfig.output}*", allowEmptyArchive: true)
+    archiveArtifacts(artifacts: "./${stepConfig.output}*", allowEmptyArchive: true)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?
This PR adds to major changes in the `filebeat` step:

1. it sanitises the output parameter passed as container logs file name, which will:
   - remove leading and trailing whitespaces, using trim()
   - replace inner whitespaces with '_', using a regex
   - replace any occurrences of non-characters or numbers or dots, with a '_', using a regex
2. it uses `.` to look up for the log files to archive

A small refactor in a boolean condition was made to simplify reading it.

    |  a(archiveOnlyOnFail)  |  b(isBuildFailure) |  f  |
    |------------------------|--------------------|-----|
    |  0                     |   0                |  1  |
    |  0                     |   1                |  1  |
    |  1                     |   0                |  0  |
    |  1                     |   1                |  1  |
    
    which leads to (!a || b) or !(a && !b)

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
As shown in https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-mbp/detail/PR-707/22/pipeline, we saw errors when trying to find files in large filesystems, or in ARM workers. For that reason we are reducing the location of the files to the base directory used by `archiveArtifacts` (which is usually the workspace).

>[2021-03-08T20:52:22.755Z] Archiving artifacts
[2021-03-08T20:52:23.235Z] java.lang.InterruptedException: no matches found within 10000
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath$ValidateAntFileMask.hasMatch(FilePath.java:3067)
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath$ValidateAntFileMask.invoke(FilePath.java:2946)
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath$ValidateAntFileMask.invoke(FilePath.java:2927)
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3314)
[2021-03-08T20:52:23.235Z] Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from ec2-3-237-66-208.compute-1.amazonaws.com/3.237.66.208:38106
[2021-03-08T20:52:23.235Z] 		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1800)
[2021-03-08T20:52:23.235Z] 		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:356)
[2021-03-08T20:52:23.235Z] 		at hudson.remoting.Channel.call(Channel.java:1001)
[2021-03-08T20:52:23.235Z] 		at hudson.FilePath.act(FilePath.java:1158)
[2021-03-08T20:52:23.235Z] 		at hudson.FilePath.act(FilePath.java:1147)
[2021-03-08T20:52:23.235Z] 		at hudson.FilePath.validateAntFileMask(FilePath.java:2925)
[2021-03-08T20:52:23.235Z] 		at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:270)
[2021-03-08T20:52:23.235Z] 		at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:116)
[2021-03-08T20:52:23.235Z] 		at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
[2021-03-08T20:52:23.235Z] 		at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[2021-03-08T20:52:23.235Z] 		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2021-03-08T20:52:23.235Z] 		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-03-08T20:52:23.235Z] 		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-03-08T20:52:23.235Z] 		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-03-08T20:52:23.235Z] Caused: hudson.FilePath$TunneledInterruptedException
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3316)
[2021-03-08T20:52:23.235Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
[2021-03-08T20:52:23.235Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
[2021-03-08T20:52:23.235Z] 	at hudson.remoting.Request$2.run(Request.java:369)
[2021-03-08T20:52:23.235Z] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-03-08T20:52:23.235Z] 	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:93)
[2021-03-08T20:52:23.235Z] Caused: java.lang.InterruptedException: java.lang.InterruptedException: no matches found within 10000
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath.act(FilePath.java:1160)
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath.act(FilePath.java:1147)
[2021-03-08T20:52:23.235Z] 	at hudson.FilePath.validateAntFileMask(FilePath.java:2925)
[2021-03-08T20:52:23.235Z] 	at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:270)
[2021-03-08T20:52:23.235Z] 	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:116)
[2021-03-08T20:52:23.235Z] 	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
[2021-03-08T20:52:23.235Z] 	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-03-08T20:52:23.235Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-03-08T20:52:23.235Z] 	at java.lang.Thread.run(Thread.java:748)
[2021-03-08T20:52:23.235Z] No artifacts found that match the file pattern "**/docker_logs_fleet_Endpoint Integration.log*". Configuration error?
script returned exit code 

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Discovered while testing elastic/e2e-testing#707