### PR TITLE
Add isStaticWorker step

### DIFF
--- a/src/test/groovy/IsStaticWorkerStepTests.groovy
+++ b/src/test/groovy/IsStaticWorkerStepTests.groovy
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsStaticWorkerStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isStaticWorker.groovy')
+  }
+
+  @Test
+  void testMissingLabelsArgument() throws Exception {
+    testMissingArgument('labels') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_with_static_worker() throws Exception {
+    assertTrue(script.call(labels: 'arm'))
+  }
+
+  @Test
+  void test_with_immutable_worker() throws Exception {
+    assertFalse(script.call(labels: 'immutable&&linux'))
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1527,6 +1527,21 @@ Whether the build is based on a Pull Request or no
   }
 ```
 
+## isStaticWorker
+Whether the existing worker is a static one
+
+```
+  // Assign to a variable
+  def isStatic = isStaticWorker(labels: 'linux&&immutable')
+
+  // Use whenTrue condition
+  whenTrue(isStaticWorker(labels: 'linux&&immutable')) {
+    echo "I'm a static worker"
+  }
+```
+
+TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
+
 ## isTag
 Whether the build is based on a Tag Request or no
 

--- a/vars/isStaticWorker.groovy
+++ b/vars/isStaticWorker.groovy
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Whether the existing worker is a static one
+  whenTrue(isStaticWorker(labels: 'linux&&immutable')) {
+    echo "I'm a static worker"
+  }
+
+  TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
+*/
+def call(Map args=[:]){
+  def labels = args.containsKey('labels') ? args.labels : error("isStaticWorker: labels parameter is required.")
+  return (labels?.contains('arm') || labels?.contains('macosx') || labels?.contains('metal'))
+}

--- a/vars/isStaticWorker.txt
+++ b/vars/isStaticWorker.txt
@@ -1,0 +1,13 @@
+Whether the existing worker is a static one
+
+```
+  // Assign to a variable
+  def isStatic = isStaticWorker(labels: 'linux&&immutable')
+
+  // Use whenTrue condition
+  whenTrue(isStaticWorker(labels: 'linux&&immutable')) {
+    echo "I'm a static worker"
+  }
+```
+
+TODO: as soon as ARM and MacOS are ephemerals then we need to change this method


### PR DESCRIPTION
## What does this PR do?

Create new step to centralise the knowledge when a worker is static or ephemeral

## Why is it important?

Simplifies the login in some pipelines:
- https://github.com/elastic/beats/pull/24435/files
