### PR TITLE
Slack notification with the total build time

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -5,9 +5,10 @@
 <% pipelineUrl = String.format("<%spipeline|#%s>", jobUrl, build?.id ?: 'build')%>
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>
+<% tookMessage = (duration?.trim()) ? "(Took `${duration}`)" : '' %>
 <% stepsMessage = (steps?.size()!= 0) ? "*Steps failures*: `${steps?.size()}` (click ${artifactsUrl} and open `build.md` for further details)" : ""%>
 <% if (header?.trim()) {%>${header}<%}%>
-*Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`
+*Build*: `${jenkinsText}` ${pipelineUrl} for branch `${build?.pipeline}` got the status `${buildStatus}`. ${tookMessage}
 *Changes*: ${changesMessage}
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)
 ${stepsMessage}

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -284,6 +284,7 @@ def notifySlack(Map args = [:]) {
 
     if (enabled) {
       catchError(buildResult: 'SUCCESS', message: 'notifySlack: Error with the slack comment') {
+        def duration = (build.durationInMillis?.toString()?.trim()) ? hudson.Util.getTimeSpanString(build.durationInMillis) : ''
         def statusSuccess = (buildStatus == "SUCCESS")
         def boURL = getBlueoceanDisplayURL()
         def body = buildTemplate([
@@ -293,6 +294,7 @@ def notifySlack(Map args = [:]) {
           "buildStatus": buildStatus,
           "changeSet": changeSet,
           "docsUrl": docsUrl,
+          "duration": duration,
           "jenkinsText": env.JOB_NAME,
           "jenkinsUrl": env.JENKINS_URL,
           "jobUrl": boURL,

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -506,6 +506,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('slackSend', 'Steps failures'))
     assertTrue(assertMethodCallContainsPattern('slackSend', 'https://github.com/org/acme/issues/1234|indicator type url is in upper case (#1234)'))
     assertTrue(assertMethodCallContainsPattern('slackSend', 'by `Lola.Flores`'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'Took'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Add build time

## Why is it important?

It might help to easily identify what builds are flaky because the CI enviornmental issues with the provisioner.



## Test


From the UTs

```
*Build*: `folder/mbp/master` <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/pipeline|#49> for branch `develop` got the status `ABORTED`. (Took `3 min 22 sec`)
*Changes*: No push event to branch develop
*Tests*: `0` test/s failed out of 121 (click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/tests|here> for further details)
*Steps failures*: `3` (click <http://jenkins.example.com:8080/blue/organizations/jenkins/folder%2Fmbp/detail/master/1/artifacts|here> and open `build.md` for further details)
, tokenCredentialId=test})
```