### PR TITLE
document Gren and GH labels for the automated release process

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,6 +7,7 @@ has a name like v[:number:].[:number:].[:number:] see [Semantic Versioning](http
 
 Follow the below steps:
 
+* Make sure your PRs contain the proper Github labels to group them under the proper changelog section, as defined in [Gren's configuration file, `groupBy` section](../.grenrc.js).
 * Navigate to the [APM Pipeline Library job](https://apm-ci.elastic.co/job/apm-shared/job/apm-pipeline-library-mbp/job/master/build?delay=0sec) 
 * Choose `Build with Parameters`
 * Select the `make_release` checkbox.


### PR DESCRIPTION
## What does this PR do?
It includes a link to Gren's configuration file in the automated release doc.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It will document the labels needed to create a release, for the PRs to be present in the changelog.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->