### PR TITLE
Add getFlakyJobName

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -245,8 +245,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true, slackComment: true, analyzeFlakey: true,
-                        flakyReportIdx: 'reporter-apm-shared-apm-pipeline-library-master')
+      notifyBuildResult(prComment: true, slackComment: true, analyzeFlakey: true, jobName: getFlakyJobName(withBranch: 'master'))
     }
   }
 }

--- a/src/test/groovy/GetFlakyJobNameStepTests.groovy
+++ b/src/test/groovy/GetFlakyJobNameStepTests.groovy
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class GetFlakyJobNameStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/getFlakyJobName.groovy')
+  }
+
+  @Test
+  void test_missing_withBranch_param() throws Exception {
+    testMissingArgument('withBranch') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_multibranch_pipeline() throws Exception {
+    addEnvVar('JOB_NAME', 'folder/acme')
+    addEnvVar('JOB_BASE_NAME', 'acme')
+    def value = script.call(withBranch: 'foo')
+    printCallStack()
+    assertTrue(value == 'folder/foo')
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_single_pipeline() throws Exception {
+    env.remove('JOB_NAME')
+    try {
+      script.call(withBranch: 'foo')
+    } catch(err) {
+      // NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'getFlakyJobName: only works for multibranch pipelines.'))
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -537,6 +537,15 @@ Then put all togeder in a simple JSON file.
 * buildNumber: the build id. Mandatory
 * returnData: whether to return a data structure with the build details then other steps can consume them. Optional. Default false
 
+## getFlakyJobName
+Get the flaky job name in a given multibranch pipeline.
+
+```
+getFlakyJobName(withBranch: 'master')
+```
+
+* withBranch: the job base name to compare with. Mandatory
+
 ## getGitCommitSha
 Get the current commit SHA from the .git folder.
 If the checkout was made by Jenkins, you would use the environment variable GIT_COMMIT.
@@ -1563,12 +1572,14 @@ def timmerTrigger = isTimerTrigger()
 ```
 
 ## isUpstreamTrigger
-Check if the build was triggered by an upstream job, being it possible to add a filter for the upstream cause.
+Check if the build was triggered by an upstream job, being it possible to add some filters.
 
 ```
 def upstreamTrigger = isUpstreamTrigger()
 def upstreamTrigger = isUpstreamTrigger(filter: 'PR-')
 ```
+
+* filter: The string filter to be used when selecting the ustream build cause. If no filter is set, then 'all' will be used.
 
 ## isUserTrigger
 Check if the build was triggered by a user.
@@ -1912,11 +1923,10 @@ emails on Failed builds that are not pull request.
 * slackCredentials: What slack credentials to be used. Default value uses `jenkins-slack-integration-token`.
 * slackNotify: Whether to send or not the slack notifications, by default it sends notifications on Failed builds that are not pull request.
 * analyzeFlakey: Whether or not to add a comment in the PR with tests which have been detected as flakey. Default: `false`.
-* flakyReportIdx: The flaky index to compare this jobs results to. e.g. reporter-apm-agent-java-apm-agent-java-master
-* flakyThreshold: The threshold below which flaky tests will be ignored. Default: 0.0
 * flakyDisableGHIssueCreation: whether to disable the GH create issue if any flaky matches. Default false.
 * newPRComment: The map of the data to be populated as a comment. Default empty.
 * aggregateComments: Whether to create only one single GitHub PR Comment with all the details. Default true.
+* jobName: The name of the job, e.g. `Beats/beats/master`.
 
 ## opbeansPipeline
 Opbeans Pipeline
@@ -2847,3 +2857,4 @@ writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secre
 
 * secret: Name of the secret on the the vault root path. Mandatory
 * data: What's the data to be written. Mandatory
+

--- a/vars/getFlakyJobName.groovy
+++ b/vars/getFlakyJobName.groovy
@@ -19,12 +19,16 @@ import org.jenkinsci.plugins.workflow.graph.StepNode
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
 /**
-  Get the flaky job name
+  Get the flaky job name in a given multibranch pipeline.
+
+  def flakyJobName = getFlakyJobName(withBranch: 'master')
 */
 
 def call(Map args=[:]) {
-  if (env.JOB_NAME.trim() && env.JOB_BASE_NAME.trim()) {
-    def flakyJobName = (env.JOB_NAME - env.JOB_BASE_NAME) + args.withBranch
+  def withBranch = args.containsKey('withBranch') ? args.withBranch : error('getFlakyJobName: withBranch parameter is required.')
+  if (env.JOB_NAME?.trim() && env.JOB_BASE_NAME?.trim()) {
+    def flakyJobName = (env.JOB_NAME - env.JOB_BASE_NAME) + withBranch
     return flakyJobName
   }
+  error('getFlakyJobName: only works for multibranch pipelines.')
 }

--- a/vars/getFlakyJobName.groovy
+++ b/vars/getFlakyJobName.groovy
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.jenkinsci.plugins.workflow.graph.StepNode
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor
+
+/**
+  Get the flaky job name
+*/
+
+def call(Map args=[:]) {
+  if (env.JOB_NAME.trim() && env.JOB_BASE_NAME.trim()) {
+    def flakyJobName = (env.JOB_NAME - env.JOB_BASE_NAME) + args.withBranch
+    return flakyJobName
+  }
+}

--- a/vars/getFlakyJobName.txt
+++ b/vars/getFlakyJobName.txt
@@ -1,0 +1,5 @@
+Get the flaky job name in a given multibranch pipeline
+  
+```
+getFlakyJobName(withBranch: 'master')
+```

--- a/vars/getFlakyJobName.txt
+++ b/vars/getFlakyJobName.txt
@@ -1,5 +1,7 @@
-Get the flaky job name in a given multibranch pipeline
-  
+Get the flaky job name in a given multibranch pipeline.
+
 ```
 getFlakyJobName(withBranch: 'master')
 ```
+
+* withBranch: the job base name to compare with. Mandatory


### PR DESCRIPTION
## What does this PR do?

As a consequence of https://github.com/elastic/apm-pipeline-library/pull/1016 then let's enable a step to calculate the flaky Job Name

## Why is it important?

Test it out in our master branch

