### PR TITLE
feat: add a new step to build and push a Docker image for Kibana

### DIFF
--- a/resources/buildKibana.groovy
+++ b/resources/buildKibana.groovy
@@ -1,0 +1,10 @@
+pipeline {
+  agent { label 'linux && immutable' }
+  stages {
+    stage('Docker build for Kibana') {
+      steps {
+        buildKibanaDockerImage(refspec: 'PR/94867', baseDir: 'kibana')
+      }
+    }
+  }
+}

--- a/resources/buildKibana.groovy
+++ b/resources/buildKibana.groovy
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 pipeline {
   agent { label 'linux && immutable' }
   stages {

--- a/resources/scripts/build-kibana-docker-image.sh
+++ b/resources/scripts/build-kibana-docker-image.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# It uses a version of NVM to install NodeJS, and then uses it to install
+# the proper NodeJS version for building Kibana. Finally, it will generate
+# the Docker image for Kibana for the current state of the Git repository.
+#
+
+set -x
+unset NVM_DIR
+
+export BABEL_DISABLE_CACHE=true
+export FORCE_COLOR=1
+export NODE_OPTIONS=" --max-old-space-size=4096"
+
+if [ -z "$(command -v nvm)" ]; then
+  curl -Sso- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  # shellcheck disable=SC1090,SC1091
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+fi
+
+if [ "v${NODE_VERSION}" != "$(node --version)" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "${NVM_DIR}/nvm.sh"
+  nvm install "${NODE_VERSION}"
+  nvm use "${NODE_VERSION}"
+fi
+
+npm install -g yarn
+yarn kbn clean
+yarn kbn bootstrap
+node scripts/build --no-debug --no-oss --skip-docker-ubi --docker-images

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -43,9 +43,23 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     }
 
     @Test
-    void test_with_PR_target() throws Exception {
-        def result = script.call(target: 'pr-123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: 123456'))
+    void test_with_PR_target_uppercase() throws Exception {
+        def result = script.call(target: 'PR/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_with_PR_target_lowercase() throws Exception {
+        def result = script.call(target: 'pr/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_with_PR_target_no_case() throws Exception {
+        def result = script.call(target: 'pR/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
         assertJobStatusSuccess()
     }
 }

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -37,28 +37,28 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
     @Test
     void test_with_branch_target() throws Exception {
-        def result = script.call(target: 'foo')
+        def result = script.call(branch: 'foo')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: foo'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_uppercase() throws Exception {
-        def result = script.call(target: 'PR/123456')
+        def result = script.call(branch: 'PR/123456')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_lowercase() throws Exception {
-        def result = script.call(target: 'pr/123456')
+        def result = script.call(branch: 'pr/123456')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_no_case() throws Exception {
-        def result = script.call(target: 'pR/123456')
+        def result = script.call(branch: 'pR/123456')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -34,6 +34,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_without_refspec() throws Exception {
         def result = script.call()
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: master'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
         assertJobStatusSuccess()
     }
 
@@ -41,27 +43,35 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_with_branch_refspec() throws Exception {
         def result = script.call(refspec: 'foo')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: foo'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo were pushed"))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_refspec_uppercase() throws Exception {
-        def result = script.call(refspec: 'PR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
+        def result = script.call(refspec: 'PR/111111')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/111111'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111 were pushed"))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_refspec_lowercase() throws Exception {
-        def result = script.call(refspec: 'pr/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
+        def result = script.call(refspec: 'pr/222222')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/222222'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222 were pushed"))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_refspec_no_case() throws Exception {
-        def result = script.call(refspec: 'pR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
+        def result = script.call(refspec: 'pR/333333')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/333333'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333 were pushed"))
         assertJobStatusSuccess()
     }
 }

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -26,6 +26,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void setUp() throws Exception {
         super.setUp()
         script = loadScript('vars/buildKibanaDockerImage.groovy')
+
+        env.BASE_DIR = "buildKibana"
     }
 
     @Test

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -31,35 +31,35 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     @Test
     void test_without_target() throws Exception {
         def result = script.call()
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a branch: master'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: master'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_branch_target() throws Exception {
         def result = script.call(target: 'foo')
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a branch: foo'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: foo'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_uppercase() throws Exception {
         def result = script.call(target: 'PR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_lowercase() throws Exception {
         def result = script.call(target: 'pr/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
     void test_with_PR_target_no_case() throws Exception {
         def result = script.call(target: 'pR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: PR/123456'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
         assertJobStatusSuccess()
     }
 }

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -29,37 +29,37 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     }
 
     @Test
-    void test_without_target() throws Exception {
+    void test_without_refspec() throws Exception {
         def result = script.call()
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: master'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: master'))
         assertJobStatusSuccess()
     }
 
     @Test
-    void test_with_branch_target() throws Exception {
-        def result = script.call(branch: 'foo')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: foo'))
+    void test_with_branch_refspec() throws Exception {
+        def result = script.call(refspec: 'foo')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: foo'))
         assertJobStatusSuccess()
     }
 
     @Test
-    void test_with_PR_target_uppercase() throws Exception {
-        def result = script.call(branch: 'PR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
+    void test_with_PR_refspec_uppercase() throws Exception {
+        def result = script.call(refspec: 'PR/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
-    void test_with_PR_target_lowercase() throws Exception {
-        def result = script.call(branch: 'pr/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
+    void test_with_PR_refspec_lowercase() throws Exception {
+        def result = script.call(refspec: 'pr/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
         assertJobStatusSuccess()
     }
 
     @Test
-    void test_with_PR_target_no_case() throws Exception {
-        def result = script.call(branch: 'pR/123456')
-        assertTrue(assertMethodCallContainsPattern('log', 'Kibana branch is: PR/123456'))
+    void test_with_PR_refspec_no_case() throws Exception {
+        def result = script.call(refspec: 'pR/123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/123456'))
         assertJobStatusSuccess()
     }
 }

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -26,13 +26,11 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void setUp() throws Exception {
         super.setUp()
         script = loadScript('vars/buildKibanaDockerImage.groovy')
-
-        env.BASE_DIR = "buildKibana"
     }
 
     @Test
     void test_without_refspec() throws Exception {
-        def result = script.call()
+        def result = script.call(packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: master'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
@@ -41,7 +39,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
     @Test
     void test_with_branch_refspec() throws Exception {
-        def result = script.call(refspec: 'foo')
+        def result = script.call(refspec: 'foo', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: foo'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo were pushed"))
@@ -50,7 +48,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
     @Test
     void test_with_PR_refspec_uppercase() throws Exception {
-        def result = script.call(refspec: 'PR/111111')
+        def result = script.call(refspec: 'PR/111111', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/111111'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111 were pushed"))
@@ -59,7 +57,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
     @Test
     void test_with_PR_refspec_lowercase() throws Exception {
-        def result = script.call(refspec: 'pr/222222')
+        def result = script.call(refspec: 'pr/222222', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/222222'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222 were pushed"))
@@ -68,7 +66,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
     @Test
     void test_with_PR_refspec_no_case() throws Exception {
-        def result = script.call(refspec: 'pR/333333')
+        def result = script.call(refspec: 'pR/333333', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/333333'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333 were pushed"))
@@ -78,7 +76,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     @Test
     void test_with_custom_registry() throws Exception {
         def registry = 'hub.docker.com'
-        def result = script.call(refspec: 'pr/444444', dockerRegistry: registry)
+        def result = script.call(refspec: 'pr/444444', packageJSON: 'buildKibana/package.json', dockerRegistry: registry)
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/444444'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444"))
         assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444 were pushed"))
@@ -91,7 +89,7 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         def targetTag = 'ABCDEFG'
         def src = 'the_source'
         def target = 'the_target'
-        def result = script.call(refspec: 'pr/555555', targetTag: targetTag, dockerRegistry: registry, dockerImageSource: src, dockerImageTarget: target)
+        def result = script.call(refspec: 'pr/555555', packageJSON: 'buildKibana/package.json', targetTag: targetTag, dockerRegistry: registry, dockerImageSource: src, dockerImageTarget: target)
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/555555'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:${targetTag} and ${target}:pr55555"))
         assertTrue(assertMethodCallContainsPattern('log', "${target}:${targetTag} and ${target}:pr555555 were pushed"))

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -26,12 +26,24 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void setUp() throws Exception {
         super.setUp()
         script = loadScript('vars/buildKibanaDockerImage.groovy')
+        env.BASE_DIR = 'base_dir'
+    }
+
+    @Test
+    void test_with_baseDir() throws Exception {
+        def result = script.call(baseDir: 'foo', packageJSON: 'buildKibana/package.json')
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: master'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec master, into foo'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
+        assertJobStatusSuccess()
     }
 
     @Test
     void test_without_refspec() throws Exception {
         def result = script.call(packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: master'))
+        assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec master, into base_dir/build'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
         assertJobStatusSuccess()

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        super.setUp()
+        script = loadScript('vars/buildKibanaDockerImage.groovy')
+    }
+
+    @Test
+    void test_without_target() throws Exception {
+        def result = script.call()
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a branch: master'))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_with_branch_target() throws Exception {
+        def result = script.call(target: 'foo')
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a branch: foo'))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_with_PR_target() throws Exception {
+        def result = script.call(target: 'pr-123456')
+        assertTrue(assertMethodCallContainsPattern('log', 'Target is a PR: 123456'))
+        assertJobStatusSuccess()
+    }
+}

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -74,4 +74,27 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333 were pushed"))
         assertJobStatusSuccess()
     }
+
+    @Test
+    void test_with_custom_registry() throws Exception {
+        def registry = 'hub.docker.com'
+        def result = script.call(refspec: 'pr/444444', dockerRegistry: registry)
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/444444'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444"))
+        assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444 were pushed"))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_with_custom_values() throws Exception {
+        def registry = 'hub.docker.com'
+        def targetTag = 'ABCDEFG'
+        def src = 'the_source'
+        def target = 'the_target'
+        def result = script.call(refspec: 'pr/555555', targetTag: targetTag, dockerRegistry: registry, dockerImageSource: src, dockerImageTarget: target)
+        assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/555555'))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:${targetTag} and ${target}:pr55555"))
+        assertTrue(assertMethodCallContainsPattern('log', "${target}:${targetTag} and ${target}:pr555555 were pushed"))
+        assertJobStatusSuccess()
+    }
 }

--- a/src/test/resources/buildKibana/package.json
+++ b/src/test/resources/buildKibana/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "kibana",
+    "version": "8.0.0"
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -174,14 +174,6 @@ buildKibanaDockerImage(refspec: 'master')
 buildKibanaDockerImage(refspec: 'PR/12345')
 ```
 
-See https://jenkins.io/doc/pipeline/steps/pipeline-build-step/#build-build-a-job
-
-## buildStatus
-Fetch the current build status for a given job
-```
-def status = buildStatus(host: 'localhost', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master']), return_bool: false)
-```
-
 * refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
 * packageJSON: Full name of the package.json file. Defaults to `package.json`
 * baseDir: Directory where to clone the Kibana repository. Defaults to`${env.BASE_DIR}/build`
@@ -191,6 +183,25 @@ def status = buildStatus(host: 'localhost', job: ['apm-agent-java', 'apm-agent-j
 * dockerRegistrySecret: Name of the Vault secret with the credentials for logining into the registry. Defaults to `secret/observability-team/ci/docker-registry/prod`
 * dockerImageSource: Name of the source Docker image when tagging. Defaults to `${dockerRegistry}/kibana/kibana`
 * dockerImageTarget: Name of the target Docker image to be tagged. Defaults to `${dockerRegistry}/observability-ci/kibana`
+
+## buildStatus
+Fetch the current build status for a given job
+```
+def status = buildStatus(host: 'localhost', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master']), return_bool: false)
+```
+
+* host: The Jenkins server to connect to. Defaults to `localhost`.
+* job:  The job to fetch status for. This should be a list consisting of the path to job. For example, when viewing the Jenkins
+        CI, in the upper-left of the browser, one might see a path to a job with a URL as follows:
+
+            https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/
+
+        In this case, the corresponding list would be formed as:
+
+            ['apm-agent-java', 'apm-agent-java-mbp', 'master']
+
+* as_bool: Returns `true` if the job status is `Success`. Any other job status returns `false`.
+* ssl: Set to `false` to disable SSL. Default is `true`.
 
 ## cancelPreviousRunningBuilds
 Abort any previously running builds as soon as a new build starts

--- a/vars/README.md
+++ b/vars/README.md
@@ -166,24 +166,31 @@ build(job: 'foo', parameters: [string(name: "my param", value: some_value)])
 
 See https://jenkins.io/doc/pipeline/steps/pipeline-build-step/#build-build-a-job
 
+## buildKibanaDockerImage
+Builds the Docker image for Kibana, from a branch or a pull Request.
+
+```
+buildKibanaDockerImage(refspec: 'master')
+buildKibanaDockerImage(refspec: 'PR/12345')
+```
+
+See https://jenkins.io/doc/pipeline/steps/pipeline-build-step/#build-build-a-job
+
 ## buildStatus
 Fetch the current build status for a given job
 ```
 def status = buildStatus(host: 'localhost', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master']), return_bool: false)
 ```
 
-* host: The Jenkins server to connect to. Defaults to `localhost`.
-* job:  The job to fetch status for. This should be a list consisting of the path to job. For example, when viewing the Jenkins
-        CI, in the upper-left of the browser, one might see a path to a job with a URL as follows:
-
-            https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/
-
-        In this case, the corresponding list would be formed as:
-
-            ['apm-agent-java', 'apm-agent-java-mbp', 'master']
-
-* as_bool: Returns `true` if the job status is `Success`. Any other job status returns `false`.
-* ssl: Set to `false` to disable SSL. Default is `true`.
+* refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
+* packageJSON: Full name of the package.json file. Defaults to `package.json`
+* baseDir: Directory where to clone the Kibana repository. Defaults to`${env.BASE_DIR}/build`
+* credentialsId: Credentials used access Github repositories.
+* targetTag: Docker tag to be used in the image. Defaults to `the commit SHA`.
+* dockerRegistry: Name of the Docker registry. Defaults to `docker.elastic.co`
+* dockerRegistrySecret: Name of the Vault secret with the credentials for logining into the registry. Defaults to `secret/observability-team/ci/docker-registry/prod`
+* dockerImageSource: Name of the source Docker image when tagging. Defaults to `${dockerRegistry}/kibana/kibana`
+* dockerImageTarget: Name of the target Docker image to be tagged. Defaults to `${dockerRegistry}/observability-ci/kibana`
 
 ## cancelPreviousRunningBuilds
 Abort any previously running builds as soon as a new build starts

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -74,7 +74,14 @@ def buildKibana(Map args = [:]) {
 
   dir("${baseDir}"){
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
-    setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: packageJSON).version + '-SNAPSHOT')
+
+    def pathSeparator = '/'
+    if (nodeOS() == 'windows') {
+      pathSeparator = '\\'
+    }
+
+    def kibanaVersion = readJSON(file: baseDir + pathSeparator + packageJSON).version
+    setEnvVar('KIBANA_DOCKER_TAG',  kibanaVersion + '-SNAPSHOT')
 
     retryWithSleep(retries: 3) {
       sh(label: 'Build Docker image', script: libraryResource('scripts/build-kibana-docker-image.sh'))

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -80,7 +80,7 @@ def buildKibana(Map args = [:]) {
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
     setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: 'package.json').version + '-SNAPSHOT')
 
-    retry(3){
+    retryWithSleep(retries: 3) {
       sh(label: 'Build Docker image', script: '''#!/bin/bash
         set -x
         unset NVM_DIR
@@ -106,7 +106,7 @@ def buildKibana(Map args = [:]) {
   }
 
   dockerLogin(secret: "${dockerRegistrySecret}", registry: "${dockerRegistry}")
-  retry(3){
+  retryWithSleep(retries: 3) {
     sh(label: 'Push Docker image', script: """
       docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${kibanaDockerTargetTag}
       docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${deployName}

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -38,6 +38,7 @@ def call(Map args = [:]){
 def buildKibana(Map args = [:]) {
   def refspec = args.refspec
   def deployName = normalize(refspec)
+  def packageJSON = !isEmptyString(args.packageJSON) ? args.packageJSON : 'package.json'
   def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}"
   def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
@@ -73,7 +74,7 @@ def buildKibana(Map args = [:]) {
 
   dir("${baseDir}"){
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
-    setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: 'package.json').version + '-SNAPSHOT')
+    setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: packageJSON).version + '-SNAPSHOT')
 
     retryWithSleep(retries: 3) {
       sh(label: 'Build Docker image', script: libraryResource('scripts/build-kibana-docker-image.sh'))

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -44,12 +44,10 @@ def buildKibana(Map args = [:]) {
   def branch = args.branch
   def deployName = normalize(branch)
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
-
-  // constant values
-  def dockerRegistry = 'docker.elastic.co'
-  def dockerRegistrySecret = 'secret/observability-team/ci/docker-registry/prod'
-  def dockerImageSource = "${dockerRegistry}/kibana/kibana"
-  def dockerImageTarget = "${dockerRegistry}/observability-ci/kibana"
+  def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
+  def dockerRegistrySecret = !isEmptyString(args.dockerRegistrySecret) ? args.dockerRegistrySecret : 'secret/observability-team/ci/docker-registry/prod'
+  def dockerImageSource = !isEmptyString(args.dockerImageSource) ? args.dockerImageSource : "${dockerRegistry}/kibana/kibana"
+  def dockerImageTarget = !isEmptyString(args.dockerImageTarget) ? args.dockerImageTarget : "${dockerRegistry}/observability-ci/kibana"
 
   log(level: 'INFO', text: "Cloning Kibana repository, branch ${branch}")
 

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -84,8 +84,8 @@ def buildKibana(Map args = [:]) {
   dockerLogin(secret: "${dockerRegistrySecret}", registry: "${dockerRegistry}")
   retryWithSleep(retries: 3) {
     sh(label: 'Push Docker image', script: """
-      docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${kibanaDockerTargetTag}
-      docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${deployName}
+      docker tag ${dockerImageSource}:${env.KIBANA_DOCKER_TAG} ${dockerImageTarget}:${kibanaDockerTargetTag}
+      docker tag ${dockerImageSource}:${env.KIBANA_DOCKER_TAG} ${dockerImageTarget}:${deployName}
       docker push ${dockerImageTarget}:${kibanaDockerTargetTag}
       docker push ${dockerImageTarget}:${deployName}
     """)

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -21,6 +21,7 @@
 
   buildKibanaDockerImage(refspec: 'master')
   buildKibanaDockerImage(refspec: 'PR/12345')
+  buildKibanaDockerImage(refspec: 'PR/12345', dockerRegistry: hub.docker.com)
 */
 def call(Map args = [:]){
   def kibanaRefspec = args?.refspec?.trim() ? args.refspec : 'master'

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -31,9 +31,9 @@ def call(Map args = [:]){
   def target = args?.target?.trim() ? args.target : 'master'
   def uppercaseTarget = target.toUpperCase()
 
+  def kibanaBranch = target
   if (uppercaseTarget.startsWith('PR/')) {
-    log(level: 'INFO', text: "Target is a PR: ${uppercaseTarget}")
-  } else {
-    log(level: 'INFO', text: "Target is a branch: ${target}")
+    kibanaBranch = uppercaseTarget
   }
+  log(level: 'INFO', text: "Kibana branch is: ${kibanaBranch}")
 }

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -38,6 +38,7 @@ def call(Map args = [:]){
 def buildKibana(Map args = [:]) {
   def refspec = args.refspec
   def deployName = normalize(refspec)
+  def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}"
   def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
   def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
@@ -51,7 +52,7 @@ def buildKibana(Map args = [:]) {
     branches: [[name: "*/${refspec}"]],
     doGenerateSubmoduleConfigurations: false,
     extensions: [
-      [$class: 'RelativeTargetDirectory', relativeTargetDir: "${env.BASE_DIR}"],
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: "${baseDir}"],
       [$class: 'CheckoutOption', timeout: 15],
       [$class: 'AuthorInChangelog'],
       [$class: 'IgnoreNotifyCommit'],
@@ -70,7 +71,7 @@ def buildKibana(Map args = [:]) {
         ]]
   ])
 
-  dir("${env.BASE_DIR}"){
+  dir("${baseDir}"){
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
     setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: 'package.json').version + '-SNAPSHOT')
 

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -70,12 +70,7 @@ def call(Map args = [:]){
   dir("${baseDir}"){
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
 
-    def pathSeparator = '/'
-    if (nodeOS() == 'windows') {
-      pathSeparator = '\\'
-    }
-
-    def kibanaVersion = readJSON(file: baseDir + pathSeparator + packageJSON).version
+    def kibanaVersion = readJSON(file: packageJSON).version
     setEnvVar('KIBANA_DOCKER_TAG',  kibanaVersion + '-SNAPSHOT')
 
     retryWithSleep(retries: 3) {

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -69,7 +69,7 @@ def call(Map args = [:]){
   ])
 
   dir("${baseDir}"){
-    kibanaDockerTargetTag = !isEmptyString(kibanaDockerTargetTag) ? kibanaDockerTargetTag : getGitCommitSha()
+    kibanaDockerTargetTag = isEmptyString(kibanaDockerTargetTag) ? getGitCommitSha() : kibanaDockerTargetTag
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
 
     def kibanaVersion = readJSON(file: packageJSON).version

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -24,35 +24,35 @@ import co.elastic.BuildException
 
   Builds the Docker image for Kibana, from a branch or a pull Request.
 
-  buildKibanaDockerImage(branch: 'master')
-  buildKibanaDockerImage(branch: 'PR/12345')
+  buildKibanaDockerImage(refspec: 'master')
+  buildKibanaDockerImage(refspec: 'PR/12345')
 */
 def call(Map args = [:]){
-  def branch = args?.branch?.trim() ? args.branch : 'master'
-  def uppercaseBranch = branch.toUpperCase()
+  def refspec = args?.refspec?.trim() ? args.refspec : 'master'
+  def uppercaseRefspec = refspec.toUpperCase()
 
-  def kibanaBranch = branch
-  if (uppercaseBranch.startsWith('PR/')) {
-    kibanaBranch = uppercaseBranch
+  def kibanaRefspec = refspec
+  if (uppercaseRefspec.startsWith('PR/')) {
+    kibanaRefspec = uppercaseRefspec
   }
-  log(level: 'INFO', text: "Kibana branch is: ${kibanaBranch}")
+  log(level: 'INFO', text: "Kibana refspec is: ${kibanaRefspec}")
 
-  //buildKibana(branch: "${kibanaBranch}")
+  //buildKibana(refspec: "${kibanaRefspec}")
 }
 
 def buildKibana(Map args = [:]) {
-  def branch = args.branch
-  def deployName = normalize(branch)
+  def refspec = args.refspec
+  def deployName = normalize(refspec)
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
   def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
   def dockerRegistrySecret = !isEmptyString(args.dockerRegistrySecret) ? args.dockerRegistrySecret : 'secret/observability-team/ci/docker-registry/prod'
   def dockerImageSource = !isEmptyString(args.dockerImageSource) ? args.dockerImageSource : "${dockerRegistry}/kibana/kibana"
   def dockerImageTarget = !isEmptyString(args.dockerImageTarget) ? args.dockerImageTarget : "${dockerRegistry}/observability-ci/kibana"
 
-  log(level: 'INFO', text: "Cloning Kibana repository, branch ${branch}")
+  log(level: 'INFO', text: "Cloning Kibana repository, refspec ${refspec}")
 
   checkout([$class: 'GitSCM',
-    branches: [[name: "*/${branch}"]],
+    branches: [[name: "*/${refspec}"]],
     doGenerateSubmoduleConfigurations: false,
     extensions: [
       [$class: 'RelativeTargetDirectory', relativeTargetDir: "${env.BASE_DIR}"],

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -37,7 +37,7 @@ def call(Map args = [:]){
   def packageJSON = !isEmptyString(args.packageJSON) ? args.packageJSON : 'package.json'
   def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}/build"
   def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
-  def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
+  def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : ''
   def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
   def dockerRegistrySecret = !isEmptyString(args.dockerRegistrySecret) ? args.dockerRegistrySecret : 'secret/observability-team/ci/docker-registry/prod'
   def dockerImageSource = !isEmptyString(args.dockerImageSource) ? args.dockerImageSource : "${dockerRegistry}/kibana/kibana"
@@ -69,6 +69,7 @@ def call(Map args = [:]){
   ])
 
   dir("${baseDir}"){
+    kibanaDockerTargetTag = !isEmptyString(kibanaDockerTargetTag) ? kibanaDockerTargetTag : getGitCommitSha()
     setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
 
     def kibanaVersion = readJSON(file: packageJSON).version

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -34,7 +34,7 @@ def call(Map args = [:]){
 
   def deployName = normalize(refspec)
   def packageJSON = !isEmptyString(args.packageJSON) ? args.packageJSON : 'package.json'
-  def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}"
+  def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}/build"
   def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
   def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
@@ -42,7 +42,7 @@ def call(Map args = [:]){
   def dockerImageSource = !isEmptyString(args.dockerImageSource) ? args.dockerImageSource : "${dockerRegistry}/kibana/kibana"
   def dockerImageTarget = !isEmptyString(args.dockerImageTarget) ? args.dockerImageTarget : "${dockerRegistry}/observability-ci/kibana"
 
-  log(level: 'DEBUG', text: "Cloning Kibana repository, refspec ${refspec}")
+  log(level: 'DEBUG', text: "Cloning Kibana repository, refspec ${refspec}, into ${baseDir}")
 
   checkout([$class: 'GitSCM',
     branches: [[name: "*/${refspec}"]],

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -15,11 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
-import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
-import hudson.model.Result
-import co.elastic.BuildException
-
 /**
 
   Builds the Docker image for Kibana, from a branch or a pull Request.

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -43,6 +43,7 @@ def call(Map args = [:]){
 def buildKibana(Map args = [:]) {
   def refspec = args.refspec
   def deployName = normalize(refspec)
+  def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
   def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
   def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
   def dockerRegistrySecret = !isEmptyString(args.dockerRegistrySecret) ? args.dockerRegistrySecret : 'secret/observability-team/ci/docker-registry/prod'
@@ -68,7 +69,7 @@ def buildKibana(Map args = [:]) {
       ]],
       submoduleCfg: [],
       userRemoteConfigs: [[
-        credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+        credentialsId: "${credentialsId}",
         url: "http://github.com/elastic/kibana.git",
         refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/PR/*',
         ]]

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -25,14 +25,14 @@ import co.elastic.BuildException
   Builds the Docker image for Kibana, from a branch or a pull Request.
 
   buildKibanaDockerImage(target: 'master')
-  buildKibanaDockerImage(target: 'pr-12345')
+  buildKibanaDockerImage(target: 'PR/12345')
 */
 def call(Map args = [:]){
   def target = args?.target?.trim() ? args.target : 'master'
+  def uppercaseTarget = target.toUpperCase()
 
-  if (target.startsWith('pr-')) {
-    def prID = target.substring(target.indexOf("-") + 1)
-    log(level: 'INFO', text: "Target is a PR: ${prID}")
+  if (uppercaseTarget.startsWith('PR/')) {
+    log(level: 'INFO', text: "Target is a PR: ${uppercaseTarget}")
   } else {
     log(level: 'INFO', text: "Target is a branch: ${target}")
   }

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -24,16 +24,16 @@ import co.elastic.BuildException
 
   Builds the Docker image for Kibana, from a branch or a pull Request.
 
-  buildKibanaDockerImage(target: 'master')
-  buildKibanaDockerImage(target: 'PR/12345')
+  buildKibanaDockerImage(branch: 'master')
+  buildKibanaDockerImage(branch: 'PR/12345')
 */
 def call(Map args = [:]){
-  def target = args?.target?.trim() ? args.target : 'master'
-  def uppercaseTarget = target.toUpperCase()
+  def branch = args?.branch?.trim() ? args.branch : 'master'
+  def uppercaseBranch = branch.toUpperCase()
 
-  def kibanaBranch = target
-  if (uppercaseTarget.startsWith('PR/')) {
-    kibanaBranch = uppercaseTarget
+  def kibanaBranch = branch
+  if (uppercaseBranch.startsWith('PR/')) {
+    kibanaBranch = uppercaseBranch
   }
   log(level: 'INFO', text: "Kibana branch is: ${kibanaBranch}")
 }

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -36,4 +36,90 @@ def call(Map args = [:]){
     kibanaBranch = uppercaseBranch
   }
   log(level: 'INFO', text: "Kibana branch is: ${kibanaBranch}")
+
+  //buildKibana(branch: "${kibanaBranch}")
+}
+
+def buildKibana(Map args = [:]) {
+  def branch = args.branch
+  def deployName = normalize(branch)
+  def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : getGitCommitSha()
+
+  // constant values
+  def dockerRegistry = 'docker.elastic.co'
+  def dockerRegistrySecret = 'secret/observability-team/ci/docker-registry/prod'
+  def dockerImageSource = "${dockerRegistry}/kibana/kibana"
+  def dockerImageTarget = "${dockerRegistry}/observability-ci/kibana"
+
+  log(level: 'INFO', text: "Cloning Kibana repository, branch ${branch}")
+
+  checkout([$class: 'GitSCM',
+    branches: [[name: "*/${branch}"]],
+    doGenerateSubmoduleConfigurations: false,
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: "${env.BASE_DIR}"],
+      [$class: 'CheckoutOption', timeout: 15],
+      [$class: 'AuthorInChangelog'],
+      [$class: 'IgnoreNotifyCommit'],
+      [$class: 'CloneOption',
+        depth: 0,
+        noTags: false,
+        reference: "/var/lib/jenkins/kibana.git",
+        shallow: true,
+        timeout: 15
+      ]],
+      submoduleCfg: [],
+      userRemoteConfigs: [[
+        credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+        url: "http://github.com/elastic/kibana.git",
+        refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/PR/*',
+        ]]
+  ])
+
+  dir("${env.BASE_DIR}"){
+    setEnvVar('NODE_VERSION', readFile(file: ".node-version")?.trim())
+    setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: 'package.json').version + '-SNAPSHOT')
+
+    retry(3){
+      sh(label: 'Build Docker image', script: '''#!/bin/bash
+        set -x
+        unset NVM_DIR
+        if [ -z "$(command -v nvm)" ]; then
+          curl -Sso- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        fi
+        if [ "v${NODE_VERSION}" != "$(node --version)" ]; then
+          . "${NVM_DIR}/nvm.sh"
+          nvm install "${NODE_VERSION}"
+          nvm use "${NODE_VERSION}"
+        fi
+        export NODE_OPTIONS=" --max-old-space-size=4096"
+        export FORCE_COLOR=1
+        export BABEL_DISABLE_CACHE=true
+        npm install -g yarn
+        yarn kbn clean
+        yarn kbn bootstrap
+        node scripts/build --no-debug --no-oss --skip-docker-ubi --docker-images
+      ''')
+    }
+  }
+
+  dockerLogin(secret: "${dockerRegistrySecret}", registry: "${dockerRegistry}")
+  retry(3){
+    sh(label: 'Push Docker image', script: """
+      docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${kibanaDockerTargetTag}
+      docker tag ${dockerImageSource}:${KIBANA_DOCKER_TAG} ${dockerImageTarget}:${deployName}
+      docker push ${dockerImageTarget}:${kibanaDockerTargetTag}
+      docker push ${dockerImageTarget}:${deployName}
+    """)
+  }
+}
+
+def isEmptyString(value){
+  return value == null || value?.trim() == ""
+}
+
+def normalize(value){
+  return value?.trim().toLowerCase().replaceAll("[^A-Za-z0-9 ]", "")
 }

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -34,14 +34,14 @@ def call(Map args = [:]){
   log(level: 'DEBUG', text: "Kibana refspec is: ${refspec}")
 
   def deployName = normalize(refspec)
-  def packageJSON = !isEmptyString(args.packageJSON) ? args.packageJSON : 'package.json'
-  def baseDir = !isEmptyString(args.baseDir) ? args.baseDir : "${env.BASE_DIR}/build"
-  def credentialsId = !isEmptyString(args.credentialsId) ? args.credentialsId : '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken'
-  def kibanaDockerTargetTag = !isEmptyString(args.targetTag) ? args.targetTag : ''
-  def dockerRegistry = !isEmptyString(args.dockerRegistry) ? args.dockerRegistry : 'docker.elastic.co'
-  def dockerRegistrySecret = !isEmptyString(args.dockerRegistrySecret) ? args.dockerRegistrySecret : 'secret/observability-team/ci/docker-registry/prod'
-  def dockerImageSource = !isEmptyString(args.dockerImageSource) ? args.dockerImageSource : "${dockerRegistry}/kibana/kibana"
-  def dockerImageTarget = !isEmptyString(args.dockerImageTarget) ? args.dockerImageTarget : "${dockerRegistry}/observability-ci/kibana"
+  def packageJSON = isEmptyString(args.packageJSON) ? 'package.json' : args.packageJSON
+  def baseDir = isEmptyString(args.baseDir) ? "${env.BASE_DIR}/build" : args.baseDir
+  def credentialsId = isEmptyString(args.credentialsId) ? '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken' : args.credentialsId
+  def kibanaDockerTargetTag = isEmptyString(args.targetTag) ? '' : args.targetTag
+  def dockerRegistry = isEmptyString(args.dockerRegistry) ? 'docker.elastic.co' : args.dockerRegistry
+  def dockerRegistrySecret = isEmptyString(args.dockerRegistrySecret) ? 'secret/observability-team/ci/docker-registry/prod' : args.dockerRegistrySecret
+  def dockerImageSource = isEmptyString(args.dockerImageSource) ?  "${dockerRegistry}/kibana/kibana" : args.dockerImageSource
+  def dockerImageTarget = isEmptyString(args.dockerImageTarget) ? "${dockerRegistry}/observability-ci/kibana" : args.dockerImageTarget
 
   log(level: 'DEBUG', text: "Cloning Kibana repository, refspec ${refspec}, into ${baseDir}")
 

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -81,27 +81,7 @@ def buildKibana(Map args = [:]) {
     setEnvVar('KIBANA_DOCKER_TAG', readJSON(file: 'package.json').version + '-SNAPSHOT')
 
     retryWithSleep(retries: 3) {
-      sh(label: 'Build Docker image', script: '''#!/bin/bash
-        set -x
-        unset NVM_DIR
-        if [ -z "$(command -v nvm)" ]; then
-          curl -Sso- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-        fi
-        if [ "v${NODE_VERSION}" != "$(node --version)" ]; then
-          . "${NVM_DIR}/nvm.sh"
-          nvm install "${NODE_VERSION}"
-          nvm use "${NODE_VERSION}"
-        fi
-        export NODE_OPTIONS=" --max-old-space-size=4096"
-        export FORCE_COLOR=1
-        export BABEL_DISABLE_CACHE=true
-        npm install -g yarn
-        yarn kbn clean
-        yarn kbn bootstrap
-        node scripts/build --no-debug --no-oss --skip-docker-ubi --docker-images
-      ''')
+      sh(label: 'Build Docker image', script: libraryResource('scripts/build-kibana-docker-image.sh'))
     }
   }
 

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+import hudson.model.Result
+import co.elastic.BuildException
+
+/**
+
+  Builds the Docker image for Kibana, from a branch or a pull Request.
+
+  buildKibanaDockerImage(target: 'master')
+  buildKibanaDockerImage(target: 'pr-12345')
+*/
+def call(Map args = [:]){
+  def target = args?.target?.trim() ? args.target : 'master'
+
+  if (target.startsWith('pr-')) {
+    def prID = target.substring(target.indexOf("-") + 1)
+    log(level: 'INFO', text: "Target is a PR: ${prID}")
+  } else {
+    log(level: 'INFO', text: "Target is a branch: ${target}")
+  }
+}

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -1,8 +1,8 @@
 Builds the Docker image for Kibana, from a branch or a pull Request.
 
 ```
-buildKibanaDockerImage(branch: 'master')
-buildKibanaDockerImage(branch: 'PR/12345')
+buildKibanaDockerImage(refspec: 'master')
+buildKibanaDockerImage(refspec: 'PR/12345')
 ```
 
-* branch: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
+* refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -7,7 +7,7 @@ buildKibanaDockerImage(refspec: 'PR/12345')
 
 * refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
 * packageJSON: Full name of the package.json file. Defaults to 'package.json'
-* baseDir: Directory where to clone the Kibana repository. Defaults to "${env.BASE_DIR}/build
+* baseDir: Directory where to clone the Kibana repository. Defaults to "${env.BASE_DIR}/build"
 * credentialsId: Credentials used access Github repositories.
 * targetTag: Docker tag to be used in the image. Defaults to the commit SHA.
 * dockerRegistry: Name of the Docker registry. Defaults to 'docker.elastic.co'

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -1,8 +1,8 @@
 Builds the Docker image for Kibana, from a branch or a pull Request.
 
 ```
-buildKibanaDockerImage(target: 'master')
-buildKibanaDockerImage(target: 'PR/12345')
+buildKibanaDockerImage(branch: 'master')
+buildKibanaDockerImage(branch: 'PR/12345')
 ```
 
-* target: A branch (i.e. master), or a pull request identified by the "pr-" prefix and the pull request ID.
+* branch: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -1,0 +1,8 @@
+Builds the Docker image for Kibana, from a branch or a pull Request.
+
+```
+buildKibanaDockerImage(target: 'master')
+buildKibanaDockerImage(target: 'pr-12345')
+```
+
+* target: A branch (i.e. master), or a pull request identified by the "pr-" prefix and the pull request ID.

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -6,3 +6,11 @@ buildKibanaDockerImage(refspec: 'PR/12345')
 ```
 
 * refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
+* packageJSON: Full name of the package.json file. Defaults to 'package.json'
+* baseDir: Directory where to clone the Kibana repository. Defaults to "${env.BASE_DIR}/build
+* credentialsId: Credentials used access Github repositories.
+* targetTag: Docker tag to be used in the image. Defaults to the commit SHA.
+* dockerRegistry: Name of the Docker registry. Defaults to 'docker.elastic.co'
+* dockerRegistrySecret: Name of the Vault secret with the credentials for logining into the registry. Defaults to 'secret/observability-team/ci/docker-registry/prod'
+* dockerImageSource: Name of the source Docker image when tagging. Defaults to '${dockerRegistry}/kibana/kibana'
+* dockerImageTarget: Name of the target Docker image to be tagged. Defaults to '${dockerRegistry}/observability-ci/kibana'

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -2,7 +2,7 @@ Builds the Docker image for Kibana, from a branch or a pull Request.
 
 ```
 buildKibanaDockerImage(target: 'master')
-buildKibanaDockerImage(target: 'pr-12345')
+buildKibanaDockerImage(target: 'PR/12345')
 ```
 
 * target: A branch (i.e. master), or a pull request identified by the "pr-" prefix and the pull request ID.


### PR DESCRIPTION
## What does this PR do?
It creates a new step to build and push the Docker image for Kibana branches or PRs.

<img width="1391" alt="Screenshot 2021-03-18 at 17 42 35" src="https://user-images.githubusercontent.com/951580/111665288-e6543800-8812-11eb-82d2-29c29a97156f.png">


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It will allow pipelines living in different Jenkins instances (i.e. Beats CI) to call this step, instead of copying the existing pipeline in the APM CI.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #1039

## Follow-ups
The original pipeline lives in the clusters repository. We should update it to consume this step once merged and released.

Another follow-up is to enable kibana repo as a reference repo for Beats CI