### PR TITLE
Fix the getCause and getCauses for the AbortException

### DIFF
--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -44,7 +44,11 @@ def call(Map args = [:]){
   } catch (Exception e) {
     def buildLogOutput = currentBuild.rawBuild.getLog(2).find { it.contains('Starting building') }
     url = getRedirectLink(buildLogOutput, job)
-    throw new BuildException(getBuildId(buildLogOutput), Result.FAILURE, e.getCauses())
+    if (e instanceof FlowInterruptedException) {
+      throw new BuildException(getBuildId(buildLogOutput), Result.FAILURE, e.getCauses())
+    } else {
+      throw new BuildException(getBuildId(buildLogOutput), Result.FAILURE)
+    }
   } finally {
     log(level: 'INFO', text: "${url}")
   }


### PR DESCRIPTION
## What does this PR do?

Distinguish the error since FlowInterruptions provides `getCauses()`. (See https://javadoc.jenkins.io/plugin/workflow-step-api/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.html#getCauses--)


## Why is it important?

Fixes some errors

```
groovy.lang.MissingMethodException: No signature of method: hudson.AbortException.getCauses() is applicable for argument types: () values: []
Possible solutions: getCause(), getClass(), initCause(java.lang.Throwable), metaClass(groovy.lang.Closure)

```
