### PR TITLE
fix: use proper flag or recreate

### DIFF
--- a/local/Makefile
+++ b/local/Makefile
@@ -89,7 +89,7 @@ recreate-all: # Recreate all the services
 		docker-compose \
 			--log-level ${LOG_LEVEL} \
 			--file docker-compose.yml \
-			up --detach --recreate
+			up --detach --force-recreate
 
 .PHONY: start-linux-worker
 start-linux-worker:  ## Start the local linux worker


### PR DESCRIPTION
## What does this PR do?
It uses `--force-recreate` instead of `--recreate` in the `make recreate-all` goal.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
The flag is not supported, so that goal is not working anymore.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->