### PR TITLE
fix: set KIBANA_DOCKER_TAG env var properly

### DIFF
--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -36,6 +36,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec master, into foo'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'master')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'master')
         assertJobStatusSuccess()
     }
 
@@ -46,6 +48,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec master, into base_dir/build'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:master were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'master')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'master')
         assertJobStatusSuccess()
     }
 
@@ -55,6 +59,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: foo'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'foo')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'foo')
         assertJobStatusSuccess()
     }
 
@@ -64,6 +70,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/111111'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111 were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'pr111111')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'pr111111')
         assertJobStatusSuccess()
     }
 
@@ -73,6 +81,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/222222'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222 were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'pr222222')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'pr222222')
         assertJobStatusSuccess()
     }
 
@@ -82,6 +92,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/333333'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333"))
         assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333 were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'pr333333')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'pr333333')
         assertJobStatusSuccess()
     }
 
@@ -92,6 +104,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/444444'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444"))
         assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444 were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'pr444444')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'pr444444')
         assertJobStatusSuccess()
     }
 
@@ -105,6 +119,8 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/555555'))
         assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:${targetTag} and ${target}:pr55555"))
         assertTrue(assertMethodCallContainsPattern('log', "${target}:${targetTag} and ${target}:pr555555 were pushed"))
+        assertTrue(env.DEPLOY_NAME == 'pr555555')
+        assertTrue(env.KIBANA_DOCKER_TAG == 'pr555555')
         assertJobStatusSuccess()
     }
 }


### PR DESCRIPTION
## What does this PR do?
It exports the `KIBANA_DOCKER_TAG` env var to be used in the consumer pipelines with the value of the docker tag that was built, provided by the internal `deployName` variable.

Because there is a existing consumer reading the `DEPLOY_NAME` variable, we are exporting that variable with same value as `KIBANA_DOCKER_TAG`.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Do not break consumers.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Relates #1039
- Completes #1040