### PR TITLE
fix: use valid version of yq

### DIFF
--- a/resources/JenkinsfileTemplate.groovy
+++ b/resources/JenkinsfileTemplate.groovy
@@ -262,7 +262,7 @@ pipeline {
               warnError('installTools failed')
             }
             steps {
-              installTools([ [tool: 'yq', version: '3.3' ] ])
+              installTools([ [tool: 'yq', version: '3.3.4' ] ])
             }
           }
         }

--- a/src/test/groovy/InstallToolsStepTests.groovy
+++ b/src/test/groovy/InstallToolsStepTests.groovy
@@ -93,7 +93,7 @@ class InstallToolsStepTests extends ApmBasePipelineTest {
     script.installTool([ tool: 'foo', version: 'x.y.z', provider: 'choco', extraArgs: "--foo 'bar' 'foo'" ])
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('powershell', 'Install foo:x.y.z'))
-    assertTrue(assertMethodCallContainsPattern('powershell', """script=choco install foo --no-progress -y --version 'x.y.z' "--foo 'bar' 'foo'" """))
+    assertTrue(assertMethodCallContainsPattern('powershell', """script=choco install foo --no-progress -y --version='x.y.z' "--foo 'bar' 'foo'" """))
     assertFalse(assertMethodCallContainsPattern('powershell', 'script=.\\install-with-choco.ps1'))
     assertJobStatusSuccess()
   }

--- a/test-infra/README.md
+++ b/test-infra/README.md
@@ -1,1 +1,2 @@
+# Test Infra
 https://philpep.org/blog/infrastructure-testing-with-testinfra

--- a/vars/installTools.groovy
+++ b/vars/installTools.groovy
@@ -47,7 +47,7 @@ private installTool(Map args) {
   }
   switch (provider) {
     case 'choco':
-      powershell label: "Install ${tool}:${version}", script: """choco install ${tool} --no-progress -y --version '${version}' "${extraArgs}" """
+      powershell label: "Install ${tool}:${version}", script: """choco install ${tool} --no-progress -y --version='${version}' "${extraArgs}" """
       break
     case '':
       def scriptFile = 'install-with-choco.ps1'


### PR DESCRIPTION
## What does this PR do?
It modifies the `yq` version, from `3.3` to `3.3.4`. As you can see in https://chocolatey.org/packages/yq#versionhistory, there is no "3.3" version, but "3.3.2" and "3.3.4".

What I'm not sure about, is why the tests pass in certain versions of Windows, and in a consistent manner. Could it be possible that the repositories for those Windows versions do have the `3.3` version? Weird.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
The pipeline that validates the workers is currently broken, as described in #1054

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #1054