### PR TITLE
Update beats-ci workers for the test-infra validation

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -62,22 +62,7 @@ pipeline {
           axis {
             name 'PLATFORM'
             values (
-              'ubuntu && immutable',
-              'ubuntu-1404-i386',
-              'ubuntu-16',
-              'ubuntu-18',
-              'ubuntu-20',
-              'worker-c07jc1nzdwym',
-              'worker-c07l34n6dwym',
-              'worker-c07y20b6jyvy',
-              'worker-c07ll940dwyl',
-              'worker-c07y20b9jyvy',
-              'worker-c07y20b4jyvy',
-              'worker-c07y20bcjyvy',
-              'worker-c07mq25jdy3h',
-              'worker-c07mq1u7dy3h',
-              'worker-395930',
-              'worker-0a434dec4bdcd060f',
+              'arm',  // ephemeral workers
               'immutable && windows-2019',
               'immutable && windows-2016',
               'immutable && windows-2012-r2',
@@ -85,7 +70,22 @@ pipeline {
               'immutable && windows-8',
               'immutable && windows-2008-r2',
               'immutable && windows-7-32-bit',
-              'immutable && windows-7'
+              'immutable && windows-7',
+              'ubuntu && immutable',
+              'ubuntu-18',
+              'ubuntu-20',
+              'worker-c07c6107jyw0',  // macOS workers https://beats-ci.elastic.co/label/macosx/
+              'worker-c07jc1nzdwym',
+              'worker-c07l34n6dwym',
+              'worker-c07y20b6jyvy',
+              'worker-c07y20b9jyvy',
+              'worker-c07y20b4jyvy',
+              'worker-c07y20bcjyvy',
+              'worker-c07mq25jdy3h',
+              'worker-c07mq1u7dy3h',
+              'worker-h2wdt2qxq6ny',
+              'worker-395930',  // metal workers https://beats-ci.elastic.co/label/metal/
+              'worker-1244230'
             )
           }
         }


### PR DESCRIPTION
## What does this PR do?

Update worker references in https://beats-ci.elastic.co/job/Beats/job/beats-test-infra/

## Why is it important?

`arm` workers are now ephemeral and some static workers have been deprecated.

