### PR TITLE
ARM workers are now ephemeral

### DIFF
--- a/src/test/groovy/IsStaticWorkerStepTests.groovy
+++ b/src/test/groovy/IsStaticWorkerStepTests.groovy
@@ -38,7 +38,7 @@ class IsStaticWorkerStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_with_static_worker() throws Exception {
-    assertTrue(script.call(labels: 'arm'))
+    assertTrue(script.call(labels: 'macosx'))
   }
 
   @Test

--- a/vars/README.md
+++ b/vars/README.md
@@ -1570,7 +1570,7 @@ Whether the existing worker is a static one
   }
 ```
 
-TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
+TODO: as soon as macOS workers are ephemerals then we need to change this method
 
 ## isTag
 Whether the build is based on a Tag Request or no
@@ -1759,7 +1759,7 @@ pipeline {
   }
 ```
 
-* *es_secret:* Vault secret with the details to access to Elasticsearch, this parameter is mandatory ({user: 'foo', password: 'myFoo', url: 'http://foo.example.com'})
+* *es_secret:* Vault secrets with the details to access to Elasticsearch, this parameter is mandatory ({user: 'foo', password: 'myFoo', url: 'http://foo.example.com'})
 * *config:* metricbeat configuration file, a default configuration is created if the file does not exists (metricbeat_conf.yml).
 * *image:* metricbeat Docker image to use (docker.elastic.co/beats/metricbeat:7.10.1).
 * *timeout:* Time to wait before kill the metricbeat Docker container on the stop operation.

--- a/vars/isStaticWorker.groovy
+++ b/vars/isStaticWorker.groovy
@@ -25,5 +25,5 @@
 */
 def call(Map args=[:]){
   def labels = args.containsKey('labels') ? args.labels : error("isStaticWorker: labels parameter is required.")
-  return (labels?.contains('arm') || labels?.contains('macosx') || labels?.contains('metal'))
+  return (labels?.contains('macosx') || labels?.contains('metal'))
 }

--- a/vars/isStaticWorker.txt
+++ b/vars/isStaticWorker.txt
@@ -10,4 +10,4 @@ Whether the existing worker is a static one
   }
 ```
 
-TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
+TODO: as soon as macOS workers are ephemerals then we need to change this method


### PR DESCRIPTION
## What does this PR do?

static ARM workers are not a thing

## Why is it important?

Ensure the reused workers workaround works for the ephemeral ARM workers
