### PR TITLE
Grant running access for the renovate bot

### DIFF
--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -100,7 +100,7 @@ def hasWritePermission(token, repo, user){
   Check if the PR come from a bot and if the bot is authorized.
 */
 def isAuthorizedBot(login, type){
-  def authorizedBots = ['greenkeeper[bot]', 'dependabot[bot]', 'mergify[bot]']
+  def authorizedBots = ['greenkeeper[bot]', 'dependabot[bot]', 'mergify[bot]', 'renovate[bot]']
   log(level: 'DEBUG', text: "githubPrCheckApproved: User: ${login}, Type: ${type}")
   def ret = false;
   if('bot'.equalsIgnoreCase(type)){


### PR DESCRIPTION
## What does this PR do?

Enable renovate bot

## Why is it important?

To run in the CI

## User

```
curl -s https://api.github.com/repos/elastic/kibana/pulls/60422 | jq .user.login
"renovate[bot]"
```

## Related issues

Caused by https://github.com/elastic/integrations/issues/802