### PR TITLE
Fix and simplify buildStatus step

### DIFF
--- a/src/test/groovy/BuildStatusTests.groovy
+++ b/src/test/groovy/BuildStatusTests.groovy
@@ -19,18 +19,8 @@ import org.junit.Before
 import org.junit.After
 import org.junit.Test
 import static org.junit.Assert.assertTrue
-import com.sun.net.httpserver.HttpServer
-import com.sun.net.httpserver.HttpContext
-import com.sun.net.httpserver.HttpExchange
-import com.sun.net.httpserver.HttpHandler
 
 class BuildStatusTests extends ApmBasePipelineTest {
-
-
-    // Build a small test server
-    def i = new InetSocketAddress('localhost', 9999)
-    def HttpServer ws =  HttpServer.create(i, 100)
-    HttpContext job_status_context = ws.createContext("/buildStatus/text")
 
 
     @Override
@@ -38,25 +28,11 @@ class BuildStatusTests extends ApmBasePipelineTest {
     void setUp() throws Exception {
         super.setUp()
         script = loadScript('vars/buildStatus.groovy')
-        job_status_context.setHandler({ exchange ->
-        String response = "Success"
-        exchange.responseHeaders.set("Content-Type", "text/plain;charset=utf-8")
-        exchange.sendResponseHeaders(200, response.getBytes().length);
-        OutputStream os = exchange.getResponseBody();
-        os.write(response.getBytes());
-        os.close();
-        exchange.Send
-        });
-        ws.start()
-    }
-
-    @After
-    void tearDown() throws Exception {
-        ws.stop(0)
     }
 
     @Test
     void test() throws Exception {
+        helper.registerAllowedMethod("httpRequest", [Map.class], { "Success" })
         def result = script.call(host: 'localhost:9999', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master'], ssl: false)
         assertTrue("Success" == result)
         assertJobStatusSuccess()
@@ -64,6 +40,7 @@ class BuildStatusTests extends ApmBasePipelineTest {
 
     @Test
     void testBoolSuccess() throws Exception {
+        helper.registerAllowedMethod("httpRequest", [Map.class], { "Success" })
         def result = script.call(host: 'localhost:9999', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master'], return_boolean: true, ssl: false)
         assertTrue(result)
     }

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -41,12 +41,16 @@ private static String makeRequest(URL url) throws IOException {
     InputStreamReader isr = new InputStreamReader(con.getInputStream())
     BufferedReader brd = new BufferedReader(isr)
     if (responseCode == HttpURLConnection.HTTP_OK) {
+        log(level: 'INFO', text: "Received HTTP OK")
         String inputLine
         StringBuffer response = new StringBuffer()
         while ((inputLine = brd.readLine()) != null) {
+            log(level: 'INFO', text: "Adding text")
             response.append(inputLine)
         }
         brd.close()
+        def decoded_response = response.toString()
+        log(level: 'INFO', text: "Text of response: ${decoded_response}")
         return response.toString()
     } else {
         raise IOException("Failure to connect to Jenkins instance")

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -59,7 +59,6 @@ private static URL constructURL(String host, ArrayList job, boolean ssl) throws 
     String uri
     if (ssl){
       uri = "https://${host}/buildStatus/text?job=${job_path}"
-      log(level: 'INFO', text: "Querying job status at: ${uri}")
     } else {
       uri = "http://${host}/buildStatus/text?job=${job_path}"
     }

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -45,8 +45,8 @@ def call(Map args = [:]) {
     def job = args.get('job', [])
     def return_boolean = args.get('return_boolean', false)
     def ssl = args.get('ssl', true)
-    def result = httpRequest(url: constructURL(host, job, ssl))
-    log(level: 'INFO', text: "Request result: ${result}")
+    def to_url = constructURL(host, job, ssl).toString()
+    def result = httpRequest(url: to_url)
     if (return_boolean){
         if (result == "Success") {
             return true

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -59,6 +59,7 @@ private static URL constructURL(String host, ArrayList job, boolean ssl) throws 
     String uri
     if (ssl){
       uri = "https://${host}/buildStatus/text?job=${job_path}"
+      log(level: 'INFO', text: "Querying job status at: ${uri}")
     } else {
       uri = "http://${host}/buildStatus/text?job=${job_path}"
     }
@@ -72,6 +73,7 @@ def call(Map args = [:]) {
     def return_boolean = args.get('return_boolean', false)
     def ssl = args.get('ssl', true)
     def result = makeRequest(constructURL(host, job, ssl))
+    log(level: 'INFO', text: "Request result: ${result}")
     if (return_boolean){
         if (result == "Success") {
             return true

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -41,11 +41,9 @@ private static String makeRequest(URL url) throws IOException {
     InputStreamReader isr = new InputStreamReader(con.getInputStream())
     BufferedReader brd = new BufferedReader(isr)
     if (responseCode == HttpURLConnection.HTTP_OK) {
-        log(level: 'INFO', text: "Received HTTP OK")
         String inputLine
         StringBuffer response = new StringBuffer()
         while ((inputLine = brd.readLine()) != null) {
-            log(level: 'INFO', text: "Adding text")
             response.append(inputLine)
         }
         brd.close()

--- a/vars/buildStatus.groovy
+++ b/vars/buildStatus.groovy
@@ -25,35 +25,7 @@ buildStatus(
 **/
 
 import java.net.URL
-import java.net.HttpURLConnection
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
-
-
-private static String makeRequest(URL url) throws IOException {
-    // URL url = new URL("${baseUrl}/${path}")
-    HttpURLConnection con = (HttpURLConnection)url.openConnection()
-    con.setRequestMethod("GET")
-    con.setRequestProperty("User-Agent", "Jenkins Build Status/1.0")
-    int responseCode = con.getResponseCode()
-
-    InputStreamReader isr = new InputStreamReader(con.getInputStream())
-    BufferedReader brd = new BufferedReader(isr)
-    if (responseCode == HttpURLConnection.HTTP_OK) {
-        String inputLine
-        StringBuffer response = new StringBuffer()
-        while ((inputLine = brd.readLine()) != null) {
-            response.append(inputLine)
-        }
-        brd.close()
-        def decoded_response = response.toString()
-        log(level: 'INFO', text: "Text of response: ${decoded_response}")
-        return response.toString()
-    } else {
-        raise IOException("Failure to connect to Jenkins instance")
-    }
-}
 
 private static URL constructURL(String host, ArrayList job, boolean ssl) throws Exception {
     String delim = "%2F"
@@ -73,7 +45,7 @@ def call(Map args = [:]) {
     def job = args.get('job', [])
     def return_boolean = args.get('return_boolean', false)
     def ssl = args.get('ssl', true)
-    def result = makeRequest(constructURL(host, job, ssl))
+    def result = httpRequest(url: constructURL(host, job, ssl))
     log(level: 'INFO', text: "Request result: ${result}")
     if (return_boolean){
         if (result == "Success") {


### PR DESCRIPTION
## What does this PR do?
This fixes a broken step. It was not correctly parsing HTTP results from remote Jenkins servers, causing the step to always fail.

Also adjusts the test for the step to just use a simple mock instead of a tiny server.

## Why is it important?
Fixing a bug in the apm-java release pipeline. 

## Related issues
cc: @eyalkoren 
