### PR TITLE
Support reusing an existing PR

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -115,7 +115,7 @@ def bumpStackVersion(Map args = [:]){
     prepareContext(repo: repo, branchName: branchName)
     if (reusePullRequest && reusePullRequestIfPossible(title: title, labels: labels)) {
       try {
-        sh(script: "${scriptFile} '${versionEntry.build_id}' 'noBranchCreation'", label: "Prepare changes for ${repo}")
+        sh(script: "${scriptFile} '${versionEntry.build_id}' 'false'", label: "Prepare changes for ${repo}")
         gitPush()
         return
       } catch(err) {
@@ -123,6 +123,7 @@ def bumpStackVersion(Map args = [:]){
         prepareContext(repo: repo, branchName: branchName)
       }
     }
+    sh(script: "${scriptFile} '${versionEntry.build_id}'", label: "Prepare changes for ${repo}")
     githubCreatePullRequest(title: "${title} '${stackVersion}'", labels: "${labels}", description: "${message}")
   }
 }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -144,9 +144,11 @@ def pullRequest(Map args = [:]){
 
 def ammendPullRequestIfPossible(Map args = [:]){
   def title = args.title
-  def issues = lookForGitHubPullRequests(titleContains: title, labelsFilter: labels.split(','))
-  if (issues && issues.size() == 1) {
-    def issue = issues?.collect { k, v -> k }.first()
+  def pullRequests = githubPullRequests(labels: labels.split(','), titleContains: title)
+  if (pullRequests && pullRequests.size() == 1) {
+    def pr = pullRequests?.collect { k, v -> k }.first()
+    log(level: 'INFO', text: 'Checkout branch and update accordingly')
+
   } else {
     log(level: 'INFO', text: 'Could not find a GitHub Pull Request. So fallback to create a new one instead.')
   }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -126,7 +126,7 @@ def prepareArguments(Map args = [:]){
 
 def reusePullRequest(Map args = [:]) {
   prepareContext(repo: args.repo, branchName: args.branchName)
-  if (args.reusePullRequest && reusePullRequestIfPossible(title: args.title, labels: args.labels, message: args.message)) {
+  if (args.reusePullRequest && reusePullRequestIfPossible(args)) {
     try {
       sh(script: "${args.scriptFile} '${args.stackVersion}' 'false'", label: "Prepare changes for ${args.repo}")
       if (params.DRY_RUN_MODE) {
@@ -169,7 +169,7 @@ def reusePullRequestIfPossible(Map args = [:]){
     pullRequests?.each { k, v ->
       log(level: 'INFO', text: "Reuse #${k} GitHub Pull Request.")
       gh(command: "pr checkout ${k}")
-      gh(command: "pr edit ${k}", flags: [body: "${args.title}" , title: "${args.message}"])
+      gh(command: "pr edit ${k}", flags: [title: "${args.title} ${args.stackVersion}", body: "${args.message}"])
     }
     return true
   }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -26,9 +26,10 @@ pipeline {
   agent { label 'linux && immutable' }
   environment {
     REPO = 'observability-dev'
+    ORG_NAME = 'elastic'
     HOME = "${env.WORKSPACE}"
     NOTIFY_TO = credentials('notify-to')
-    PIPELINE_LOG_LEVEL='INFO'
+    PIPELINE_LOG_LEVEL = 'INFO'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -46,7 +47,7 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/elastic/${REPO}.git")
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
       }
     }
     stage('Fetch latest versions') {
@@ -117,22 +118,24 @@ def prepareArguments(Map args = [:]){
   def message = createPRDescription(versionEntry)
   def stackVersion = versionEntry.build_id
   def title = "bump-stack-version"
-  if (labels.trim()) {
-    labels = "automation,dependency,${labels}"
+  if (labels.trim() && !labels.contains('automation')) {
+    labels = "automation,${labels}"
   }
   return [reusePullRequest: reusePullRequest, repo: repo, branchName: branchName, title: title, labels: labels, scriptFile: scriptFile, stackVersion: stackVersion, message: message]
 }
 
 def reusePullRequest(Map args = [:]) {
   prepareContext(repo: args.repo, branchName: args.branchName)
-  if (args.reusePullRequest && reusePullRequestIfPossible(title: args.title, labels: args.labels)) {
+  if (args.reusePullRequest && reusePullRequestIfPossible(title: args.title, labels: args.labels, message: args.message)) {
     try {
       sh(script: "${args.scriptFile} '${args.stackVersion}' 'false'", label: "Prepare changes for ${args.repo}")
       if (params.DRY_RUN_MODE) {
         log(level: 'INFO', text: "DRY-RUN: reusePullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}')")
         return true
       }
-      gitPush()
+      withEnv(["REPO_NAME=${args.repo}"]){
+        gitPush()
+      }
       return true
     } catch(err) {
       log(level: 'INFO', text: "Could not reuse an existing GitHub Pull Request. So fallback to create a new one instead. ${err.toString()}")
@@ -154,7 +157,7 @@ def createPullRequest(Map args = [:]) {
 def prepareContext(Map args = [:]) {
   deleteDir()
   setupAPMGitEmail(global: true)
-  git(url: "https://github.com/elastic/${args.repo}.git",
+  git(url: "https://github.com/${ORG_NAME}/${args.repo}.git",
       branch: args.branchName,
       credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken')
 }
@@ -163,8 +166,11 @@ def reusePullRequestIfPossible(Map args = [:]){
   def title = args.title
   def pullRequests = githubPullRequests(labels: args.labels.split(','), titleContains: args.title)
   if (pullRequests && pullRequests.size() == 1) {
-    log(level: 'INFO', text: "Reuse #${k} GitHub Pull Request.")
-    pullRequests?.each { k, v -> gh(command: "pr checkout ${k}") }
+    pullRequests?.each { k, v ->
+      log(level: 'INFO', text: "Reuse #${k} GitHub Pull Request.")
+      gh(command: "pr checkout ${k}")
+      gh(command: "pr edit ${k}", flags: [body: "${args.title}" , title: "${args.message}"])
+    }
     return true
   }
   log(level: 'INFO', text: 'Could not find a GitHub Pull Request. So fallback to create a new one instead.')
@@ -183,12 +189,5 @@ def findBranchName(Map args = [:]){
 }
 
 def createPRDescription(versionEntry) {
-  return """
-  ### What
-  Bump stack version with the latest one.
-  ### Further details
-  ```
-  ${versionEntry.toMapString()}
-  ```
-  """
+  return """### What \n Bump stack version with the latest one. \n ### Further details \n ${versionEntry.toMapString()}"""
 }

--- a/src/test/groovy/GithubPullRequestsStepTests.groovy
+++ b/src/test/groovy/GithubPullRequestsStepTests.groovy
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class GithubPullRequestsStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/githubPullRequests.groovy')
+  }
+
+  @Test
+  void test_windows() throws Exception {
+    testWindows() {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_with_no_data() throws Exception {
+    helper.registerAllowedMethod('gh', [Map.class], { return '' })
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret.isEmpty())
+  }
+
+  @Test
+  void test_with_gh_error() throws Exception {
+    helper.registerAllowedMethod('gh', [Map.class], { throw new Exception('unknown command "foo" for "gh issue"') })
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret.isEmpty())
+  }
+
+  @Test
+  void test_with_single_row() throws Exception {
+    helper.registerAllowedMethod('gh', [Map.class], {
+      return '#684	super-linter: enable it	v1v:fix/super-lint-defects' })
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret.size()==1)
+    ret.each { k, v ->
+      assertTrue(k == "684")
+    }
+  }
+
+  @Test
+  void test_with_multiple_data() throws Exception {
+    helper.registerAllowedMethod('gh', [Map.class], {
+      return '''#1078	Enable to customise GitHub PR comments	feature/override-notify-message-template
+#684	super-linter: enable it	v1v:fix/super-lint-defects'''})
+    def ret = script.call()
+    printCallStack()
+    println ret
+    assertTrue(ret.size()==2)
+    ret.each { k, v ->
+      assertTrue(k == '684' || k == '1078')
+    }
+  }
+}

--- a/src/test/groovy/GithubPullRequestsStepTests.groovy
+++ b/src/test/groovy/GithubPullRequestsStepTests.groovy
@@ -77,4 +77,12 @@ class GithubPullRequestsStepTests extends ApmBasePipelineTest {
       assertTrue(k == '684' || k == '1078')
     }
   }
+  @Test
+  void test_with_labels() throws Exception {
+    helper.registerAllowedMethod('gh', [Map.class], {
+      return '''#1078	Enable to customise GitHub PR comments	feature/override-notify-message-template'''})
+    def ret = script.call(labels: ['foo', 'bar'])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('gh', 'label=foo,bar'))
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1079,6 +1079,23 @@ def pr = githubPrReviews(token: token, repo: 'org/repo', pr: env.CHANGE_ID)
 
 [Github API call](https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request)
 
+## githubPullRequests
+Look for the GitHub Pull Requests in the current project given the labels to be 
+filtered with. It returns a dictionary with the Pull Request id as primary key and
+then the title and branch values.
+
+```
+  // Look for all the open GitHub pull requests with titleContains: foo and 
+  // the foo and bar labels
+  githubPullRequests(labels: [ 'foo', 'bar' ], titleContains: 'foo')
+```
+
+* *labels*: Filter by labels. Optional
+* *titleContains*: Filter by title (contains format). Optional
+* *state*: Filter by state: {open|closed|merged|all}. Optional. Default "open"
+* *limit*: Maximum number of items to fetch . Optional. Default 200
+* credentialsId: The credentials to access the repo (repo permissions). Optional. Default: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7
+
 ## githubReleaseCreate
 Create a GitHub release for a project
 ```

--- a/vars/gh.groovy
+++ b/vars/gh.groovy
@@ -88,7 +88,7 @@ def runCommand(command, flagsCommand) {
 }
 
 def downloadInstaller(where) {
-  def url = 'https://github.com/cli/cli/releases/download/v1.1.0/gh_1.1.0_linux_amd64.tar.gz'
+  def url = 'https://github.com/cli/cli/releases/download/v1.9.2/gh_1.9.2_linux_amd64.tar.gz'
   def tarball = 'gh.tar.gz'
   if(isInstalled(tool: 'wget', flag: '--version')) {
     dir(where) {

--- a/vars/githubPullRequests.groovy
+++ b/vars/githubPullRequests.groovy
@@ -31,7 +31,7 @@ def call(Map args = [:]) {
   def output = [:]
   def issues
   try {
-    def flags = [ label: labels, limit: limit, state: state ]
+    def flags = [ label: labels.join(','), limit: limit, state: state ]
     if(titleContains.trim()) {
       flags['search'] = "'${titleContains}' in:title"
     }

--- a/vars/githubPullRequests.groovy
+++ b/vars/githubPullRequests.groovy
@@ -25,20 +25,23 @@
 def call(Map args = [:]) {
   def labels = args.get('labels', [])
   def titleContains = args.get('titleContains', '')
+  def state = args.get('state', 'open')
   def limit = args.get('limit', 200)
   def credentialsId = args.get('credentialsId', '2a9602aa-ab9f-4e52-baf3-b71ca88469c7')
   def output = [:]
   def issues
   try {
-    // filter all the PRs given those labels.
-    prs = gh(command: 'pr list', flags: [label: labels, limit: limit])
+    def flags = [ label: labels, limit: limit, state: state ]
+    if(titleContains.trim()) {
+      flags['search'] = "'${titleContains}' in:title"
+    }
+
+    // filter all the PRs given those flags
+    prs = gh(command: 'pr list', flags: flags)
     if (prs?.trim()) {
       prs.split('\n').each { line ->
         def data = line.split('\t')
-        def title = data[1]
-        if (title.contains(titleContains)) {
-          output.put("${data[0]}", [ title: data[1], branch: data[2] ])
-        }
+        output.put("${data[0].replace('#','')}", [ title: data[1], branch: data[2] ])
       }
     }
   } catch (err) {

--- a/vars/githubPullRequests.groovy
+++ b/vars/githubPullRequests.groovy
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Look for the GitHub Pull Requests in the current project given the labels to be 
+  filtered with. It returns a dictionary with the Pull Request id as primary key and
+  then the title and branch values.
+
+  githubPullRequests(labels: [ 'foo', 'bar' ])
+*/
+def call(Map args = [:]) {
+  def labels = args.get('labels', [])
+  def titleContains = args.get('titleContains', '')
+  def limit = args.get('limit', 200)
+  def credentialsId = args.get('credentialsId', '2a9602aa-ab9f-4e52-baf3-b71ca88469c7')
+  def output = [:]
+  def issues
+  try {
+    // filter all the PRs given those labels.
+    prs = gh(command: 'pr list', flags: [label: labels, limit: limit])
+    if (prs?.trim()) {
+      prs.split('\n').each { line ->
+        def data = line.split('\t')
+        def title = data[1]
+        if (title.contains(titleContains)) {
+          output.put("${data[0]}", [ title: data[1], branch: data[2] ])
+        }
+      }
+    }
+  } catch (err) {
+    // no issues to be reported.
+    log(level: 'WARN', text: "githubPullRequests: It failed but let's notify the error but keep going. gh command returned: '${issues}' with error: ${err.toString()}")
+  }
+  log(level: 'DEBUG', text: "githubPullRequests: output ${output}.")
+  return output
+}

--- a/vars/githubPullRequests.txt
+++ b/vars/githubPullRequests.txt
@@ -1,0 +1,15 @@
+Look for the GitHub Pull Requests in the current project given the labels to be 
+filtered with. It returns a dictionary with the Pull Request id as primary key and
+then the title and branch values.
+
+```
+  // Look for all the open GitHub pull requests with titleContains: foo and 
+  // the foo and bar labels
+  githubPullRequests(labels: [ 'foo', 'bar' ], titleContains: 'foo')
+```
+
+* *labels*: Filter by labels. Optional
+* *titleContains*: Filter by title (contains format). Optional
+* *state*: Filter by state: {open|closed|merged|all}. Optional. Default "open"
+* *limit*: Maximum number of items to fetch . Optional. Default 200
+* credentialsId: The credentials to access the repo (repo permissions). Optional. Default: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7


### PR DESCRIPTION
## What does this PR do?

Add a new step to query the existing PRs of the current workspace.
Support for the bump automation of either using an existing PR if only one, or create a new one.

## Why is it important?

This should help to drive the bumping automation requirements.

## Related issues
Closes #ISSUE

## Tasks

- [x] ITs

## Test

In order to run the ITs I created https://github.com/v1v/poc-bump-automation (using the apm-server docker-compose.yml and shell script)

Then I'll run a local pipeline similar to `.ci/bumpStackVersion.groovy` but without the need to checkout the source code from the internal github repository.

There is also a requirement to grant access to the service account to push changes to the above-mentioned github repo.
- `github-invitations`
- `github-accept-invitation id`

Caused

![image](https://user-images.githubusercontent.com/2871786/115709968-bb0cbd80-a369-11eb-8920-c897e2fe1b88.png)


#### New PR

![image](https://user-images.githubusercontent.com/2871786/115745068-01264900-a38b-11eb-9301-4c12b1a4db36.png)

https://github.com/v1v/poc-bump-automation/pull/10

#### Reused PR

https://github.com/v1v/poc-bump-automation/pull/9

![image](https://user-images.githubusercontent.com/2871786/115751287-f40c5880-a390-11eb-9ae9-dca3c754bdf7.png)

