### PR TITLE
download maven dependencies earlier and fix GCE configuration

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -103,6 +103,9 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
+            retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+              sh './mvnw clean install --batch-mode -DskipTests'
+            }
             sh './mvnw clean test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
           }
         }

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -47,4 +47,4 @@ if [ -x "$(command -v docker)" ]; then
 fi
 
 ## Let's cache the maven dependencies
- ./mvnw clean test --fail-never
+ ./mvnw clean install --batch-mode -DskipTests --fail-never

--- a/local/configs/google.yaml
+++ b/local/configs/google.yaml
@@ -45,12 +45,12 @@ jenkins:
             subnetwork: "https://www.googleapis.com/compute/v1/projects/elastic-observability/regions/us-central1/subnetworks/default"
         numExecutors: 1
         numExecutorsStr: "1"
-        oneShot: true
+        oneShot: false
         preemptible: true
         region: "https://www.googleapis.com/compute/v1/projects/elastic-observability/regions/us-central1"
-        retentionTimeMinutes: 6
-        retentionTimeMinutesStr: "6"
+        retentionTimeMinutes: 20
+        retentionTimeMinutesStr: "20"
         runAsUser: "jenkins"
         serviceAccountEmail: "jenkins-gce@elastic-observability.iam.gserviceaccount.com"
-        template: "https://www.googleapis.com/compute/v1/projects/elastic-observability/global/instanceTemplates/elastic-apm-ci-ubuntu-1804-lts-20210302222932"
+        template: "https://www.googleapis.com/compute/v1/projects/elastic-observability/global/instanceTemplates/elastic-apm-ci-ubuntu-1804-lts"
         zone: "https://www.googleapis.com/compute/v1/projects/elastic-observability/zones/us-central1-a"


### PR DESCRIPTION
## What does this PR do?

Reduce maven central issues

Fix GCE configuration

```
jenkins-lint |     "message" : "Invalid value for field 'resource.disks[0].initializeParams.sourceImage': 'projects/elastic-images-prod/global/images/elastic-apm-ci-ubuntu-1804-lts-20210302222932'. The referenced image resource cannot be found.",
jenkins-lint |     "reason" : "invalid"
```

Enable to reuse GCE workers and stay alive for 20 minutes.
