### PR TITLE
tools: fix the chocolatey version

### DIFF
--- a/resources/scripts/install-with-choco.ps1
+++ b/resources/scripts/install-with-choco.ps1
@@ -5,8 +5,13 @@ $tool=$args[0]
 $pattern=$args[1]
 $exclude=$args[2]
 
-Write-Host("Downgrade chocolatey to the latest known version with --all support. See https://github.com/chocolatey/choco/issues/1843")
-& choco install chocolatey -y --version 0.10.13 --allow-downgrade
+$ChocoVersion = $(choco --version)
+if ($ChocoVersion -eq '0.10.13') {
+  Write-Host("Chocolatey version matches the expected one. ({0})" -f $ChocoVersion)
+} else {
+  Write-Host("Downgrade chocolatey to the latest known version with --all support. See https://github.com/chocolatey/choco/issues/1843")
+  & choco install chocolatey -y --version 0.10.13 --allow-downgrade
+}
 
 if ($exclude) {
   Write-Host("Getting latest {0} version for {1} (and exclude {2})..." -f $tool,$pattern,$exclude)

--- a/resources/scripts/install-with-choco.ps1
+++ b/resources/scripts/install-with-choco.ps1
@@ -5,6 +5,9 @@ $tool=$args[0]
 $pattern=$args[1]
 $exclude=$args[2]
 
+Write-Host("Downgrade chocolatey to the latest known version with --all support. See https://github.com/chocolatey/choco/issues/1843")
+& choco install chocolatey -y --version 0.10.13 --allow-downgrade
+
 if ($exclude) {
   Write-Host("Getting latest {0} version for {1} (and exclude {2})..." -f $tool,$pattern,$exclude)
   & choco list $tool --exact --by-id-only --all | Select-String -Pattern "$tool $pattern" | Select-String -Pattern "$exclude" -NotMatch


### PR DESCRIPTION
## What does this PR do?

Delegate the requirement to use 10.0.13 to the script instead to the workers configuration

## Why is it important?

Unblock the issues with the apm-agent-python and apm-agent-nodejs build sicne the `--all` flag does not report all the versions. See https://github.com/chocolatey/choco/issues/1843

## Tests


The proposal works like a charm

```
PS C:\Users\vmartinez> choco install chocolatey -y --version 0.10.13 --allow-downgrade                                                                                                                                                 
Chocolatey v0.10.15                                                                                                                                                                                                                    
Installing the following packages:                                                                                                                                                                                                     
chocolatey                                                                                                                                                                                                                             
By installing you accept licenses for the packages.                                                                                                                                                                                    
Progress: Downloading chocolatey 0.10.13... 100%                                                                                                                                                                                       
chocolatey v0.10.13 [Approved]                                                                                                                                                                                                         
chocolatey package files install completed. Performing other installation steps.                                                                                                                                                       
Creating ChocolateyInstall as an environment variable (targeting 'Machine')                                                                                                                                                            
  Setting ChocolateyInstall to 'C:\ProgramData\chocolatey'                                                                                                                                                                             
WARNING: It's very likely you will need to close and reopen your shell                                                                                                                                                                 
  before you can use choco.                                                                                                                                                                                                            
Restricting write permissions to Administrators                                                                                                                                                                                        
We are setting up the Chocolatey package repository.                                                                                                                                                                                   
The packages themselves go to 'C:\ProgramData\chocolatey\lib'                                                                                                                                                                          
  (i.e. C:\ProgramData\chocolatey\lib\yourPackageName).                                                                                                                                                                                
A shim file for the command line goes to 'C:\ProgramData\chocolatey\bin'                                                                                                                                                               
  and points to an executable in 'C:\ProgramData\chocolatey\lib\yourPackageName'.                                                                                                                                                      
Creating Chocolatey folders if they do not already exist.                                                                                                                                                                              
WARNING: You can safely ignore errors related to missing log files when                                                                                                                                                                
  upgrading from a version of Chocolatey less than 0.9.9.                                                                                                                                                                              
  'Batch file could not be found' is also safe to ignore.                                                                                                                                                                              
  'The system cannot find the file specified' - also safe.                                                                                                                                                                             
WARNING: Not setting tab completion: Profile file does not exist at 'C:\Users\vmartinez\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'.                                                                                 
Chocolatey (choco.exe) is now ready.                                                                                                                                                                                                   
You can call choco from anywhere, command line or powershell by typing choco.                                                                                                                                                          
Run choco /? for a list of functions.                                                                                                                                                                                                  
You may need to shut down and restart powershell and/or consoles                                                                                                                                                                       
 first prior to using choco.                                                                                                                                                                                                           
Environment Vars (like PATH) have changed. Close/reopen your shell to                                                                                                                                                                  
 see the changes (or in powershell/cmd.exe just type `refreshenv`).                                                                                                                                                                    
 The install of chocolatey was successful.                                                                                                                                                                                             
  Software install location not explicitly set, could be in package or                                                                                                                                                                 
  default install location if installer.                                                                                                                                                                                               
Chocolatey installed 1/1 packages.                                                                                                                                                                                                     
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).                                                                                                                                                              
PS C:\Users\vmartinez> choco --version                                                                                                                                                                                                 
0.10.13
PS C:\Users\vmartinez> choco list python3 --exact --by-id-only --all                                                                                                                                                                   
Chocolatey v0.10.13                                                                                                                                                                                                                    
python3 3.10.0-a7 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a6 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a5 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a4 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a3 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a2 [Approved]                                                                                                                                                                                                           
python3 3.10.0-a1 [Approved]         
```

Manual tests for the changes:

```
PS C:\Users\vmartinez> choco --version                                                                                                                                                                                                 
0.10.13                                                                                                                                                                                                                                
PS C:\Users\vmartinez> $ChocoVersion = $(choco --version)                                                                                                                                                                                                                                                                                                                                                        
PS C:\Users\vmartinez> if ($ChocoVersion -eq '0.10.13') { Write-Host("Chocolatey version matches the expected one. ({0})"  -f $ChocoVersion) } else { Write-Host("foo") }                                                              
Chocolatey version matches the expected one. (0.10.13)                                                
```

```
PS C:\Users\vmartinez> choco install chocolatey -y --version 0.10.14 --allow-downgradee                                                                                                                                                
Chocolatey v0.10.13                                                                                                                                                                                                                    
Installing the following packages:                                                                                                                                                                                                     
chocolatey                                                                                                                                                                                                                             
By installing you accept licenses for the packages.                                                                                                                                                                                    
Progress: Downloading chocolatey 0.10.14... 100%                                                                                                                                                                                       
                                                                                                                                                                                                                                       
chocolatey v0.10.14 [Approved]                                                                                                                                                                                                         
chocolatey package files install completed. Performing other installation steps.                                                                                                                                                       
Creating ChocolateyInstall as an environment variable (targeting 'Machine')                                                                                                                                                            
  Setting ChocolateyInstall to 'C:\ProgramData\chocolatey'                                                                                                                                                                             
WARNING: It's very likely you will need to close and reopen your shell                                                                                                                                                                 
  before you can use choco.                                                                                                                                                                                                            
Restricting write permissions to Administrators                                                                                                                                                                                        
We are setting up the Chocolatey package repository.                                                                                                                                                                                   
The packages themselves go to 'C:\ProgramData\chocolatey\lib'                                                                                                                                                                          
  (i.e. C:\ProgramData\chocolatey\lib\yourPackageName).                                                                                                                                                                                
A shim file for the command line goes to 'C:\ProgramData\chocolatey\bin'                                                                                                                                                               
  and points to an executable in 'C:\ProgramData\chocolatey\lib\yourPackageName'.                                                                                                                                                      
                                                                                                                                                                                                                                       
Creating Chocolatey folders if they do not already exist.                                                                                                                                                                              
                                                                                                                                                                                                                                       
WARNING: You can safely ignore errors related to missing log files when                                                                                                                                                                
  upgrading from a version of Chocolatey less than 0.9.9.                                                                                                                                                                              
  'Batch file could not be found' is also safe to ignore.                                                                                                                                                                              
  'The system cannot find the file specified' - also safe.                                                                                                                                                                             
WARNING: Not setting tab completion: Profile file does not exist at 'C:\Users\vmartinez\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'.                                                                                 
Chocolatey (choco.exe) is now ready.                                                                                                                                                                                                   
You can call choco from anywhere, command line or powershell by typing choco.                                                                                                                                                          
Run choco /? for a list of functions.                                                                                                                                                                                                  
You may need to shut down and restart powershell and/or consoles                                                                                                                                                                       
 first prior to using choco.                                                                                                                                                                                                           
Environment Vars (like PATH) have changed. Close/reopen your shell to                                                                                                                                                                  
 see the changes (or in powershell/cmd.exe just type `refreshenv`).                                                                                                                                                                    
 The install of chocolatey was successful.                                                                                                                                                                                             
  Software install location not explicitly set, could be in package or                                                                                                                                                                 
  default install location if installer.                                                                                                                                                                                               
                                                                                                                                                                                                                                       
Chocolatey installed 1/1 packages.                                                                                                                                                                                                     
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log). 
PS C:\Users\vmartinez> choco --version                                                                                                                                                                                                 
0.10.14                                                                                                                                                                                                                                
PS C:\Users\vmartinez> $ChocoVersion = $(choco --version)                                                                                                                                                                              
PS C:\Users\vmartinez> if ($ChocoVersion -eq '0.10.13') { Write-Host("Chocolatey version matches the expected one. ({0})"  -f $ChocoVersion) } else { Write-Host("foo") }                                                              
foo                            

```

