### PR TITLE
Use the base branch to create the PR to

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -151,7 +151,7 @@ def createPullRequest(Map args = [:]) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}')")
     return
   }
-  githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}")
+  githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
 }
 
 def prepareContext(Map args = [:]) {


### PR DESCRIPTION
## What does this PR do?

Force the branch where the PR should be created to

## Why is it important?

Default branch will always use the git repository one instead where the PR was created from.


For instance https://github.com/elastic/beats/pull/25324 was created using a wrong base branch

