### PR TITLE
artifacts-api is now returning values for the 7.x branch

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -147,7 +147,7 @@ def reusePullRequest(Map args = [:]) {
 def createPullRequest(Map args = [:]) {
   prepareContext(repo: args.repo, branchName: args.branchName)
   if (!args?.stackVersion?.trim()) {
-    error('createPullRequest: stackVersion is empty. Review the artifacts-api fro the branch ' + args.branchName)
+    error('createPullRequest: stackVersion is empty. Review the artifacts-api for the branch ' + args.branchName)
   }
   sh(script: "${args.scriptFile} '${args.stackVersion}' 'true'", label: "Prepare changes for ${args.repo}")
   if (params.DRY_RUN_MODE) {


### PR DESCRIPTION
## What does this PR do?

7.x branch is now back to business

```bash
➜  apm-pipeline-library git:(feature/7.xbranch) ./resources/scripts/artifacts-api-latest-versions.sh 
{
  "6.8": {
    "start_time": "Tue, 27 Apr 2021 17:11:59 GMT",
    "release_branch": "6.8",
    "prefix": "",
    "end_time": "Tue, 27 Apr 2021 21:11:47 GMT",
    "manifest_version": "2.0.0",
    "version": "6.8.16-SNAPSHOT",
    "branch": "6.8",
    "build_id": "6.8.16-b07c9d2a",
    "build_duration_seconds": 14388
  },
  "7.x": {
    "start_time": "Tue, 27 Apr 2021 22:57:52 GMT",
    "release_branch": "7.x",
    "prefix": "",
    "end_time": "Wed, 28 Apr 2021 03:37:24 GMT",
    "manifest_version": "2.0.0",
    "version": "7.14.0-SNAPSHOT",
    "branch": "7.x",
    "build_id": "7.14.0-a23c7676",
    "build_duration_seconds": 16772
  },

```

## Why is it important?

There were some bugs with the artifacts-api and the 7.x branch was pointing to 7.<minor>


Previously:

```bash
$ curl -s https://artifacts-api.elastic.co/v1/versions/7.x-SNAPSHOT/builds/latest | jq 'del(.build.projects,.manifests)' 
{
  "build": {
    "start_time": "Tue, 27 Apr 2021 07:44:42 GMT",
    "release_branch": "7.13",
    "prefix": "",
    "end_time": "Tue, 27 Apr 2021 12:37:49 GMT",
    "manifest_version": "2.0.0",
    "version": "7.13.0-SNAPSHOT",
    "branch": "7.13",
    "build_id": "7.13.0-7f24288c",
    "build_duration_seconds": 17587
  }
}
```