### PR TITLE
chore: bump stack version

### DIFF
--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -48,11 +48,11 @@ def edge(Map args = [:]){
 }
 
 def dev(Map args = [:]){
-  return version("7.12.1", args)
+  return version("7.13.0", args)
 }
 
 def release(Map args = [:]){
-  return version("7.12.0", args)
+  return version("7.12.1", args)
 }
 
 def isSnapshot(args){


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Bump the Elastic Stack versions
