### PR TITLE
enable to disable a node allocation for flaky workers (disabled for time being)

### DIFF
--- a/src/test/groovy/WithNodeStepTests.groovy
+++ b/src/test/groovy/WithNodeStepTests.groovy
@@ -152,4 +152,30 @@ class WithNodeStepTests extends ApmBasePipelineTest {
     assertTrue(workspace == 'workspace/unknown-unknown-abcde')
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_with_disable_workers() throws Exception {
+    helper.registerAllowedMethod('isStaticWorker', [Map.class], { return false })
+    def isOK = true
+    script.call(labels: 'windows-7-32-bits', disableWorkers: true) {
+      isOK = false
+    }
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('node', 'windows-7-32-bits'))
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_disable_workers_and_another_worker() throws Exception {
+    helper.registerAllowedMethod('isStaticWorker', [Map.class], { return false })
+    def isOK = true
+    script.call(labels: 'windows-2019', disableWorkers: true) {
+      isOK = false
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('node', 'windows-2019'))
+    assertFalse(isOK)
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/withNode.txt
+++ b/vars/withNode.txt
@@ -21,3 +21,4 @@ Wrap the node call for three reasons:
 * sleepMax: whether to sleep and for how long maximum. Optional.
 * forceWorker: whether to allocate a new unique ephemeral worker. Optional. Default false
 * forceWorkspace: whether to allocate a new unique workspace. Optional. Default false
+* disableWorkers: whether to skip the run if the labels match one of the flaky workers. Default false


### PR DESCRIPTION
## What does this PR do?

The windows-7-32-bits workers are not working now, let's disable them from the ones we provision.

This is just a proposal and it's disabled now

## Why is it important?

Since this is something that affects the beats team, we would like to provide a quick workaround to disable what workers should be used when they are broken.

## Actions

- Keep it disable.
- If the issue still persists then we can enable and apply the filter for the given workers.

Thoughts?