### PR TITLE
fix: add a JAVA_OPTS env var to fix the container start

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.elastic.co/infra/jenkins:202102102240.c37e3f69e293
+FROM docker.elastic.co/infra/jenkins:202104291643.e55184166455
+
 
 COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         -Dhudson.slaves.NodeProvisioner.MARGIN0=1.0
         -Dhudson.model.LoadStatistics.decay=0.5
         -Dhudson.model.LoadStatistics.clock=5000
+        -cp /usr/share/jenkins/jenkins.war:/usr/share/jenkins/extraLib/*
     volumes:
       - type: volume
         source: jenkins_home


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* It add a JAVA_OPT with the classpath to allow to use the latest Infra image.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The new image uses ECS and APM and those jar files are in a folder outside the classpath so you need to pass the classpath.
