### PR TITLE
Revert "[opbeans-php] Add docker build and cache (#888)"

### DIFF
--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -75,16 +75,6 @@ pipeline {
               push: true)
           }
         }
-        stage('Opbeans-php') {
-          agent { label 'docker' }
-          options { skipDefaultCheckout() }
-          steps {
-            buildDockerImage(repo: 'https://github.com/elastic/opbeans-php.git',
-              tag: "opbeans-php",
-              version: "${params.version}",
-              push: true)
-          }
-        }
         stage('Opbeans-python') {
           agent { label 'docker' }
           options { skipDefaultCheckout() }

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -13,7 +13,6 @@ source /usr/local/bin/bash_standard_lib.sh
 # docker.elastic.co/observability-ci/it_dotnet
 # docker.elastic.co/observability-ci/it_opbeans-rum
 # docker.elastic.co/observability-ci/it_opbeans-ruby
-# docker.elastic.co/observability-ci/it_opbeans-php
 # docker.elastic.co/observability-ci/it_opbeans-python
 # docker.elastic.co/observability-ci/it_opbeans-node
 # docker.elastic.co/observability-ci/it_opbeans-java

--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -52,7 +52,7 @@ def call(Map pipelineParams) {
       quietPeriod(10)
     }
     triggers {
-      issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test(?:\\W+.*)?$)')
+      issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
     }
     stages {
       /**


### PR DESCRIPTION
This reverts commit 2bc37595ee87c3d9dc4f6993788f048f6ec09f10.

## What does this PR do?
This is a full revert of https://github.com/elastic/apm-pipeline-library/pull/888

I believe that there should not actually be a build step for the Opbeans PHP application. I'll explain my reasoning below.

For the past several builds (and likely since [this PR was merged on January 5](https://github.com/elastic/apm-pipeline-library/pull/888)), the [builds for the Opbeans applications have been failing in the APM CI](https://apm-ci.elastic.co/job/apm-shared/job/apm-docker-opbeans-pipeline/). The reason for this appears to be that [the pipeline expects the existence of a Dockerfile](https://github.com/elastic/apm-pipeline-library/blob/master/.ci/dockerImagesOpbeans.groovy#L78-L87) and [none is found](https://github.com/elastic/observability-dev/issues/1511).

In looking at the way that the way that [the PHP Opbean is designed](https://github.com/elastic/opbeans-php/), it appears that there is a docker-compose file but no Dockerfile. In looking at [the docker-compose file](https://github.com/elastic/opbeans-php/blob/master/docker-compose.yml), it appears that the application is designed to run using [an off-the-shelf imagine which simply mounts the application](https://github.com/elastic/opbeans-php/blob/master/docker-compose.yml#L11-L21).

As such, we don't gain anything by pre-baking a Docker image because this has been done for us. Therefore, I believe we should remove this step which should resolve the failures in the pipeline.



## Related issues
Closes #ISSUE
