### PR TITLE
Add resilience when the github API is down

### DIFF
--- a/src/test/groovy/WithGithubStatusStepTests.groovy
+++ b/src/test/groovy/WithGithubStatusStepTests.groovy
@@ -75,7 +75,7 @@ class WithGithubStatusStepTests extends ApmBasePipelineTest {
   void testFailure() throws Exception {
     def isOK = false
     try{
-      script.call(context: 'failed') {
+      script.call(context: 'failed', ignoreGitHubFailures: false) {
         isOK = true
       }
     } catch(e){
@@ -138,7 +138,7 @@ class WithGithubStatusStepTests extends ApmBasePipelineTest {
       }
     })
     try {
-      script.call(context: 'foo', description: 'bar') {
+      script.call(context: 'foo', description: 'bar', ignoreGitHubFailures: false){
         throw new Exception('Force failure')
       }
     } catch(e) {
@@ -147,5 +147,25 @@ class WithGithubStatusStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', '2 of 2 tries'))
     assertJobStatusFailure()
+  }
+
+  @Test
+  void test_when_github_is_not_accessible_then_retry_with_some_sleep_with_ignore_github_failures() throws Exception {
+    helper.registerAllowedMethod('githubNotify', [Map.class], { m ->
+      if (m.status == 'FAILURE') {
+        throw new Exception("Server returned HTTP response code: 500, message: '500 Internal Server Error'")
+      }
+    })
+    try {
+      script.call(context: 'foo', description: 'bar', ignoreGitHubFailures: true) {
+        throw new Exception('Force failure')
+      }
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('log', '1 of 2 tries'))
+    assertFalse(assertMethodCallContainsPattern('log', '2 of 2 tries'))
+    assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/WithGithubStatusStepTests.groovy
+++ b/src/test/groovy/WithGithubStatusStepTests.groovy
@@ -164,8 +164,7 @@ class WithGithubStatusStepTests extends ApmBasePipelineTest {
       //NOOP
     }
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('log', '1 of 2 tries'))
-    assertFalse(assertMethodCallContainsPattern('log', '2 of 2 tries'))
+    assertTrue(assertMethodCallContainsPattern('log', '2 of 2 tries'))
     assertJobStatusSuccess()
   }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -2831,6 +2831,7 @@ withGithubStatus(context: 'Release', tab: 'artifacts') {
 * description: Description of the GitHub status check. If unset then it will use the description.
 * tab: What kind of details links will be used. Enum type: tests, changes, artifacts, pipeline or an `<URL>`). Default pipeline.
 * isBlueOcean: Whether to use the BlueOcean URLs. Default `false`.
+* ignoreGitHubFailures: Whether to ignore when the github integration failed. Default `true`.
 
 [Pipeline GitHub Notify Step plugin](https://plugins.jenkins.io/pipeline-githubnotify-step)
 

--- a/vars/withGithubStatus.groovy
+++ b/vars/withGithubStatus.groovy
@@ -31,23 +31,37 @@ def call(Map args = [:], Closure body) {
   def description = args.get('description', context)
   def tab = args.get('tab', 'pipeline')
   def isBlueOcean = args.get('isBlueOcean', false)
+  def ignoreGitHubFailures = args.get('ignoreGitHubFailures', true)
 
   def redirect = detailsURL(tab: tab, isBlueOcean: isBlueOcean)
 
   try {
-    notify(context, "${description} ...", 'PENDING', redirect)
+    notifyMap(context: context, description: "${description} ...", status: 'PENDING', redirect: redirect, ignoreGitHubFailures: ignoreGitHubFailures)
     withAPM(){
       body()
     }
-    notify(context, "${description} passed", 'SUCCESS', redirect)
+    notifyMap(context: context, description: "${description} passed", status: 'SUCCESS', redirect: redirect, ignoreGitHubFailures: ignoreGitHubFailures)
   } catch (err) {
-    notify(context, "${description} failed", 'FAILURE', redirect)
+    notifyMap(context: context, description: "${description} failed", status: 'FAILURE', redirect: redirect, ignoreGitHubFailures: ignoreGitHubFailures)
     throw err
   }
 }
 
+// This is consumed by elastic/kibana.git@master:.ci/end2end.groovy
 def notify(String context, String description, String status, String redirect) {
+  notifyMap(context: context, description: description, status: status, redirect: redirect)
+}
+
+def notifyMap(Map args = [:]) {
   retryWithSleep(retries: 2, seconds: 5, backoff: true) {
-    githubNotify(context: "${context}", description: "${description}", status: "${status}", targetUrl: "${redirect}")
+    try {
+      githubNotify(context: "${args.context}", description: "${args.description}", status: "${args.status}", targetUrl: "${args.redirect}")
+    } catch (err) {
+      if (args.get('ignoreGitHubFailures', false)) {
+        log(level: 'WARN', text: "withGithubStatus: failed with error '${err.toString()}'. But 'ignoreGitHubFailures' has been enabled.")
+      } else {
+        throw err
+      }
+    }
   }
 }

--- a/vars/withGithubStatus.groovy
+++ b/vars/withGithubStatus.groovy
@@ -53,11 +53,15 @@ def notify(String context, String description, String status, String redirect) {
 }
 
 def notifyMap(Map args = [:]) {
-  retryWithSleep(retries: 2, seconds: 5, backoff: true) {
+  def i = 0
+  def numberOfRetries = 2
+  retryWithSleep(retries: numberOfRetries, seconds: 5, backoff: true) {
     try {
+      i++
       githubNotify(context: "${args.context}", description: "${args.description}", status: "${args.status}", targetUrl: "${args.redirect}")
     } catch (err) {
-      if (args.get('ignoreGitHubFailures', false)) {
+      // Let's retry at least as many times as possible otherwise, ignore the failure and avoid the notification in GitHub
+      if (args.get('ignoreGitHubFailures', false) && i == numberOfRetries) {
         log(level: 'WARN', text: "withGithubStatus: failed with error '${err.toString()}'. But 'ignoreGitHubFailures' has been enabled.")
       } else {
         throw err

--- a/vars/withGithubStatus.groovy
+++ b/vars/withGithubStatus.groovy
@@ -49,7 +49,8 @@ def call(Map args = [:], Closure body) {
 
 // This is consumed by elastic/kibana.git@master:.ci/end2end.groovy
 def notify(String context, String description, String status, String redirect) {
-  notifyMap(context: context, description: description, status: status, redirect: redirect)
+  // Fail in case the GitHub API calls fail for any reason
+  notifyMap(context: context, description: description, status: status, redirect: redirect, ignoreGitHubFailures: false)
 }
 
 def notifyMap(Map args = [:]) {

--- a/vars/withGithubStatus.groovy
+++ b/vars/withGithubStatus.groovy
@@ -63,7 +63,7 @@ def notifyMap(Map args = [:]) {
     } catch (err) {
       // Let's retry at least as many times as possible otherwise, ignore the failure and avoid the notification in GitHub
       if (args.get('ignoreGitHubFailures', false) && i == numberOfRetries) {
-        log(level: 'WARN', text: "withGithubStatus: failed with error '${err.toString()}'. But 'ignoreGitHubFailures' has been enabled.")
+        log(level: 'WARN', text: "withGithubStatus: failed with error '${err.toString()}' but 'ignoreGitHubFailures' has been enabled.")
       } else {
         throw err
       }

--- a/vars/withGithubStatus.txt
+++ b/vars/withGithubStatus.txt
@@ -19,5 +19,6 @@ withGithubStatus(context: 'Release', tab: 'artifacts') {
 * description: Description of the GitHub status check. If unset then it will use the description.
 * tab: What kind of details links will be used. Enum type: tests, changes, artifacts, pipeline or an `<URL>`). Default pipeline.
 * isBlueOcean: Whether to use the BlueOcean URLs. Default `false`.
+* ignoreGitHubFailures: Whether to ignore when the github integration failed. Default `true`.
 
 [Pipeline GitHub Notify Step plugin](https://plugins.jenkins.io/pipeline-githubnotify-step)

--- a/vars/withGithubStatus.txt
+++ b/vars/withGithubStatus.txt
@@ -19,6 +19,6 @@ withGithubStatus(context: 'Release', tab: 'artifacts') {
 * description: Description of the GitHub status check. If unset then it will use the description.
 * tab: What kind of details links will be used. Enum type: tests, changes, artifacts, pipeline or an `<URL>`). Default pipeline.
 * isBlueOcean: Whether to use the BlueOcean URLs. Default `false`.
-* ignoreGitHubFailures: Whether to ignore when the github integration failed. Default `true`.
+* ignoreGitHubFailures: Whether to ignore when the GitHub integration failed. Default `true`.
 
 [Pipeline GitHub Notify Step plugin](https://plugins.jenkins.io/pipeline-githubnotify-step)


### PR DESCRIPTION
## What does this PR do?

A proposal to avoid any build failures when the GitHub API service is down, for such it adds a new argument called `ignoreGitHubFailures` (default true) that will avoid any build failures if the GitHub API call failed for whatever reason.

Downside:
- It might hide some other misconfiguration in the project though, but users might detect it in case the GitHub commit checks are not reported.

## Why is it important?

There were some GitHub API issues caused by the GitHub API service (see https://www.githubstatus.com/incidents/fm3pp6t2ytlh) and as a GitHub notify step in the CI pipelines failed

![image](https://user-images.githubusercontent.com/2871786/117660159-ba12c300-b194-11eb-957a-cba89dc840f8.png)

This is a proposal to avoid waste of time to debug failures which are caused by the third-party systems. 

## Questions

- What do you think? 
