### PR TITLE
[jjbb] avoid building the update stack branches and remove them with mergify

### DIFF
--- a/.ci/jobs/apm-pipeline-library-mbp.yml
+++ b/.ci/jobs/apm-pipeline-library-mbp.yml
@@ -13,6 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
+          head-filter-regex: '^(?!update-stack-version).*$'
           notification-context: 'apm-ci'
           repo: apm-pipeline-library
           repo-owner: elastic

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,3 +32,10 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart+fasttrack
+  - name: delete upstream branch after merging changes
+    conditions:
+      - merged
+      - label=automation
+      - base~=^update-stack-version
+    actions:
+      delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Keep the branches in a good shape

## Follow ups

If the PR creation failed since there are no changes to do so, then the push should not happen, and therefore the branch creation should not be there.