### PR TITLE
[bump][automation] avoid branch creation if no changes to be pushed

### DIFF
--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -120,13 +120,21 @@ def createPullRequest(Map args = [:]) {
   if (args?.stackVersions?.size() == 0) {
     error('createPullRequest: stackVersions is empty. Review the artifacts-api for the branch ' + args.branchName)
   }
-  sh(script: """git checkout -b "update-stack-version-\$(date "+%Y%m%d%H%M%S")-${args.branchName}" """, label: "Git branch creations")
+  sh(script: """git checkout -b "update-stack-version-\$(date "+%Y%m%d%H%M%S")-${args.branchName}" """, label: "Git branch creation")
   sh(script: "${args.scriptFile} '${args.stackVersions[0]}' '${args.stackVersions[1]}'", label: "Prepare changes for ${args.repo}")
   if (params.DRY_RUN_MODE) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return
   }
-  githubCreatePullRequest(title: "${args.title} ${args.stackVersions}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+  if (anyChangesToBeSubmitted("${args.branchName}")) {
+    githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+  } else {
+    log(level: 'INFO', text: "There are no changes to be submitted.")
+  }
+}
+
+def anyChangesToBeSubmitted(String branch) {
+  return sh(returnStatus: true, script: "git diff --quiet HEAD..${branch}") != 0
 }
 
 def prepareContext(Map args = [:]) {

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -154,7 +154,15 @@ def createPullRequest(Map args = [:]) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return
   }
-  githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+  if (anyChangesToBeSubmitted("${args.branchName}")) {
+    githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+  } else {
+    log(level: 'INFO', text: "There are no changes to be submitted.")
+  }
+}
+
+def anyChangesToBeSubmitted(String branch) {
+  return sh(returnStatus: true, script: "git diff --quiet HEAD..${branch}") != 0
 }
 
 def prepareContext(Map args = [:]) {


### PR DESCRIPTION
## What does this PR do?

The PR creation does a `push` action before submitting the PR, therefore in case the base branch and new branch are equal the branch will be created anyway.

## Why is it important?

Keep the branches in a good shape.

## Test


Manually tested the git diff command:

```bash
➜  apm-pipeline-library git:(feature/avoid-branch-creation-if-no-changes-to-be-applied) git --no-pager log -2 --format=oneline  
283bfe8f9ad86b97fc3cab14bc0b66b0f1065281 (HEAD -> feature/avoid-branch-creation-if-no-changes-to-be-applied, origin/feature/avoid-branch-creation-if-no-changes-to-be-applied) [bump][automation] avoid branch creation if no changes to be pushed
1408eface8ffafcb8b40b6dcfacd4cd9b29c22b5 (upstream/update-stack-version-20210511050138-master, upstream/master, master) Add resilience when the github API is down (#1105)

➜  apm-pipeline-library git:(feature/avoid-branch-creation-if-no-changes-to-be-applied) git diff --quiet HEAD..master && echo 'no changes' || echo 'changes'
changes
➜  apm-pipeline-library git:(feature/avoid-branch-creation-if-no-changes-to-be-applied) git diff --quiet master..master && echo 'no changes' || echo 'changes'
no changes
```