### PR TITLE
Fix null value in the PRs created with the bumpStackReleaseVersion pipeline

### DIFF
--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -127,7 +127,7 @@ def createPullRequest(Map args = [:]) {
     return
   }
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+    githubCreatePullRequest(title: "${args.title} ${args.stackVersions}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }


### PR DESCRIPTION
## What does this PR do?

Regression caused by https://github.com/elastic/apm-pipeline-library/pull/1108 that used an undeclared variable.
