### PR TITLE
[pytest] Support --apm-trace-parent

### DIFF
--- a/resources/scripts/pytest_apm/README.md
+++ b/resources/scripts/pytest_apm/README.md
@@ -18,7 +18,7 @@ You can install "pytest-apm" via `pip` or using the `setup.py` script.
 
 ```
 git checkout https://github.com/elastic/apm-pipeline-library
-cd apm-pipeline-library/resources/scripts/apm-cli
+cd apm-pipeline-library/resources/scripts
 pip install ./pytest_apm
 ```
 

--- a/resources/scripts/pytest_apm/README.md
+++ b/resources/scripts/pytest_apm/README.md
@@ -37,9 +37,15 @@ pytest_apm is configured by adding some parameters to the pytest command line he
 * --apm-transaction-mode: Change the way to capture transactiona and spans.
   By default the session is a transaction and the tests are spans.
   If is set, every test is a transaction.
+* --apm-trace-parent: The propagation of the trace context.
 
 ```
-pytest --apm-server-url https://apm.example.com:8200 --apm-token ASWDCcCRFfr --apm-service-name pytest_apm --apm-labels '{"var01": "value01","var02": "value02"}' --apm-session-name='My_Test_cases'
+cd pytest_apm
+pytest --apm-server-url https://apm.example.com:8200 \
+       --apm-token ASWDCcCRFfr \
+       --apm-service-name pytest_apm \
+       --apm-labels '{"var01": "value01","var02": "value02"}' \
+       --apm-session-name='My_Test_cases'
 ```
 
 License

--- a/resources/scripts/pytest_apm/pytest_apm.py
+++ b/resources/scripts/pytest_apm/pytest_apm.py
@@ -77,6 +77,10 @@ def pytest_addoption(parser):
                     help='Change the way to capture transactiona and spans. '
                          'By default the session is a transaction and the tests are spans.'
                          'If is set, every test is a transaction.')
+    group.addoption('--apm-trace-parent',
+                    dest='apm_parent_id',
+                    default='Session',
+                    help='APM trace parent id.')
 
 def begin_transaction(transaction_name):
     global apm_cli, apm_parent_id
@@ -131,6 +135,7 @@ def pytest_sessionstart(session):
     apm_custom_context = config.getoption("apm_custom_context", default=None)
     apm_session_name = config.getoption("apm_session_name")
     apm_labels = json.loads(config.getoption("apm_labels"))
+    apm_parent_id = config.getoption("apm_parent_id", default=None)
     apm_cli = init_apm_client()
     if apm_cli:
         LOGGER.debug("Session transaction starts.")

--- a/resources/scripts/pytest_apm/setup.py
+++ b/resources/scripts/pytest_apm/setup.py
@@ -25,7 +25,7 @@ setup(
     entry_points={"pytest11": ["apm = pytest_apm"]},
     install_requires=["setuptools>=40.0", "pytest >= 5.0", "elastic-apm >= 5.7"],
     python_requires=">=3.5",
-    url='https://github.com/elastic/apm-pipeline-library/tree/master/resources/scripts/apm-cli',
+    url='https://github.com/elastic/apm-pipeline-library/tree/master/resources/scripts/pytest_apm',
     license='Apache License Version 2.0',
     description='APM pytest plugin for report APM traces about test executed.',
     classifiers=["Framework :: Pytest"],


### PR DESCRIPTION
## What does this PR do?

Support the apm-trace-parent as parameter to use an existing trace context. In this case the one provided by the Jenkins OpenTelemetry