### PR TITLE
Avoid to expose credentials in the process.args metadata

### DIFF
--- a/resources/scripts/apm-cli/README.md
+++ b/resources/scripts/apm-cli/README.md
@@ -96,9 +96,20 @@ Parent Transaction:
 
 APM connection details, Service name, and transaction name are mandatary so the basic command line is
 
-```
+```bash
 apm-cli.py --apm-server-url https://apm.example.com:8200 \
     --apm-token "${TOKEN}" \
     --service-name "DummyService" \
     --transaction-name "MyTS"
+```
+
+**IMPORTANT**: If you use `--apm-token` or `--apm-api-key` the transaction metadata might expose those arguments
+with their values. In order to avoid any credentials to be exposed, it's recommended to use the environment variables.
+For instance, given the above example, the similar one with environment variables can be seen below:
+
+```bash
+APM_CLI_SERVER_URL=https://apm.example.com:8200 \
+APM_CLI_TOKEN=ASWDCcCRFfr \
+apm-cli.py --apm-service-name 'DummyService' \
+       --transaction-name "MyTS"
 ```

--- a/resources/scripts/pytest_apm/README.md
+++ b/resources/scripts/pytest_apm/README.md
@@ -27,10 +27,10 @@ Usage
 
 pytest_apm is configured by adding some parameters to the pytest command line here are the descriptions
 
-* --apm-server-url: URL for the APM server(Required).
-* --apm-token: Token to access to APM server(Required if no API key passed).
-* --apm-api-key: API key to access to APM server(Required if no token passed).
-* --apm-service-name: Name of the service(Required).
+* --apm-server-url: URL for the APM server. (Required). Env variable `ELASTIC_APM_SERVER_URL`
+* --apm-token: Token to access to APM server. (Required if no API key passed). Env variable `ELASTIC_APM_SECRET_TOKEN`
+* --apm-api-key: API key to access to APM server. (Required if no token passed). Env variable `ELASTIC_APM_API_KEY`
+* --apm-service-name: Name of the service. (Required).
 * --apm-custom-context: Custom context for the current transaction in a JSON string.
 * --apm-labels: Labels to add to every transaction and span, it is a JSON string.
 * --apm-session-name: Name for the Main transaction reported to APM.(Default Session)
@@ -39,7 +39,7 @@ pytest_apm is configured by adding some parameters to the pytest command line he
   If is set, every test is a transaction.
 * --apm-trace-parent: The propagation of the trace context.
 
-```
+```bash
 cd pytest_apm
 pytest --apm-server-url https://apm.example.com:8200 \
        --apm-token ASWDCcCRFfr \
@@ -48,6 +48,17 @@ pytest --apm-server-url https://apm.example.com:8200 \
        --apm-session-name='My_Test_cases'
 ```
 
+**IMPORTANT**: If you use `--apm-token` or `--apm-api-key` the transaction metadata might expose those arguments
+with their values. In order to avoid any credentials to be exposed, it's recommended to use the environment variables.
+For instance, given the above example, the similar one with environment variables can be seen below:
+
+```bash
+ELASTIC_APM_SERVER_URL=https://apm.example.com:8200 \
+ELASTIC_APM_SECRET_TOKEN=ASWDCcCRFfr \
+pytest --apm-service-name pytest_apm \
+       --apm-labels '{"var01": "value01","var02": "value02"}' \
+       --apm-session-name='My_Test_cases'
+```
 License
 -------
 

--- a/resources/scripts/pytest_apm/pytest_apm.py
+++ b/resources/scripts/pytest_apm/pytest_apm.py
@@ -49,12 +49,15 @@ def pytest_addoption(parser):
 
     group.addoption('--apm-server-url',
                     dest='apm_server_url',
+                    env_var='ELASTIC_APM_SERVER_URL',
                     help='URL for the APM server.')
     group.addoption('--apm-token',
                     dest='apm_token',
+                    env_var='ELASTIC_APM_SECRET_TOKEN',
                     help='Token to access to APM server.')
     group.addoption('--apm-api-key',
                     dest='apm_api_key',
+                    env_var='ELASTIC_APM_API_KEY',
                     help='API key to access to APM server.')
     group.addoption('--apm-service-name',
                     dest='apm_service_name',


### PR DESCRIPTION
## What does this PR do?

Support env variables to pass the credentials instead of using the arguments in the CLI.

## Why is it important?

No issues to expose credentials in the APM UI when the process metadata provides the CLI arguments

## Now

![image](https://user-images.githubusercontent.com/2871786/118098800-43f8a100-b3cc-11eb-8595-515036a15fa8.png)

