### PR TITLE
bump versions and add info details

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -104,9 +104,9 @@ pipeline {
           unstash 'source'
           dir("${BASE_DIR}"){
             retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-              sh './mvnw clean install --batch-mode -DskipTests'
+              sh './mvnw clean install -V --batch-mode -DskipTests'
             }
-            sh './mvnw clean test --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+            sh './mvnw clean test -V --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
           }
         }
       }

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
 distributionUrl=https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/lastSuccessfulBuild/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/resources/scripts/jenkins/release-perform.sh
+++ b/resources/scripts/jenkins/release-perform.sh
@@ -4,4 +4,4 @@ set -uxeo pipefail
 BRANCH_NAME=${BRANCH_NAME:?"missing BRANCH_NAME"}
 
 git checkout -f "${BRANCH_NAME}"
-./mvnw release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
+./mvnw release:prepare release:perform -V --batch-mode -Darguments="-DskipTests=true --batch-mode"


### PR DESCRIPTION
## What does this PR do?

Minor changes to use the latest maven wrapper and show the toolchain versions

## Why is it important?

Since we use the latest maven4 snapshot, this should help to know what's the commit attached to that particular version and be able to report any bugs, if any.

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/issues/1117


## UI

```bash
./mvnw --show-version clean
```

```
Apache Maven 4.0.0-alpha-1-SNAPSHOT (b08e4d277e02abe9455e6c05e8fc6ae2b12a68fe)
Maven home: /Users/vmartinez/.m2/wrapper/dists/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin/s0m0e7mg6h9hr8umuisf0sdq9/apache-maven
Java version: 1.8.0_282, vendor: AdoptOpenJDK, runtime: /Users/vmartinez/.sdkman/candidates/java/8.0.282.j9-adpt/jre
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.7", arch: "x86_64", family: "mac"
```