### PR TITLE
Set GOARCH env variable when using the withGoEnvUnix step

### DIFF
--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -37,7 +37,8 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     script.call(version: "1.12.2"){
       if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
         && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS" ){
+        && binding.getVariable("GOPATH") == "WS"
+        && binding.getVariable("GOARCH") == "amd64"){
         isOK = true
       }
     }
@@ -54,13 +55,29 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     script.call(version: "1.12.2"){
       if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.arm64/bin:/foo/bin"
         && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.arm64"
-        && binding.getVariable("GOPATH") == "WS" ){
+        && binding.getVariable("GOPATH") == "WS"
+        && binding.getVariable("GOARCH") == "arm64"){
         isOK = true
       }
     }
     printCallStack()
     assertTrue(isOK)
     assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_arm64_with_different_GOARCH() throws Exception {
+    addEnvVar('GOARCH', 'amd64')
+    helper.registerAllowedMethod('isArm', { return true })
+    def isOK = false
+    script.call(version: "1.12.2"){
+      isOK = binding.getVariable("GOARCH") == "arm64"
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertTrue(assertMethodCallContainsPattern('log', "GOARCH env variable matches 'amd64' but it will be overridden to 'arm64'"))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -37,13 +37,13 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     script.call(version: "1.12.2"){
       if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.amd64/bin:/foo/bin"
         && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.amd64"
-        && binding.getVariable("GOPATH") == "WS"
-        && binding.getVariable("GOARCH") == "amd64"){
+        && binding.getVariable("GOPATH") == "WS" ){
         isOK = true
       }
     }
     printCallStack()
     assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOPATH=WS, GOARCH=amd64'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
     assertJobStatusSuccess()
   }
@@ -55,13 +55,13 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     script.call(version: "1.12.2"){
       if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.linux.arm64/bin:/foo/bin"
         && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.linux.arm64"
-        && binding.getVariable("GOPATH") == "WS"
-        && binding.getVariable("GOARCH") == "arm64"){
+        && binding.getVariable("GOPATH") == "WS" ){
         isOK = true
       }
     }
     printCallStack()
     assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOPATH=WS, GOARCH=arm64'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
     assertJobStatusSuccess()
   }
@@ -72,12 +72,13 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('isArm', { return true })
     def isOK = false
     script.call(version: "1.12.2"){
-      isOK = binding.getVariable("GOARCH") == "arm64"
+      isOK = true
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
     assertTrue(assertMethodCallContainsPattern('log', "GOARCH env variable matches 'amd64' but it will be overridden to 'arm64'"))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOPATH=WS, GOARCH=arm64'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
     assertJobStatusSuccess()
   }
 

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -41,11 +41,15 @@ def call(Map args = [:], Closure body) {
   def lastCoordinate = version[-2..-1]
   // gvm remove the last coordinate if it is 0
   def goDir = ".gvm/versions/go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.${arch}"
+  if (env.GOARCH?.trim() && env.GOARCH != arch) {
+    log(level: 'WARN', text: "withGoEnvUnix: GOARCH env variable matches '${env.GOARCH}' but it will be overridden to '${arch}'.")
+  }
   withEnv([
     "HOME=${env.WORKSPACE}",
     "PATH=${env.WORKSPACE}/bin:${env.WORKSPACE}/${goDir}/bin:${env.PATH}",
     "GOROOT=${env.WORKSPACE}/${goDir}",
-    "GOPATH=${env.WORKSPACE}"
+    "GOPATH=${env.WORKSPACE}",
+    "GOARCH=${arch}"
   ]){
     installGo(version: version)
     installPackages(pkgs: pkgs)


### PR DESCRIPTION
## What does this PR do?

Set `GOARCH` on the fly based on the current Worker platform.

## Why is it important?

The consumers won't need to configure the GOARCH but simply use the step

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1121
