### PR TITLE
chore: do not impact Elastic's download metrics

### DIFF
--- a/resources/scripts/artifacts-api-latest-release-versions.sh
+++ b/resources/scripts/artifacts-api-latest-release-versions.sh
@@ -28,8 +28,8 @@
 set -eo pipefail
 
 URL="https://artifacts-api.elastic.co/v1"
-NO_KPI_URL_PARAMS="x-elastic-no-kpi=true"
+NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
 OUTPUT=latest-release-versions.json
 
-curl -s "${URL}/versions?${NO_KPI_URL_PARAMS}" | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | tee ${OUTPUT}
+curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | tee ${OUTPUT}

--- a/resources/scripts/artifacts-api-latest-release-versions.sh
+++ b/resources/scripts/artifacts-api-latest-release-versions.sh
@@ -28,7 +28,8 @@
 set -eo pipefail
 
 URL="https://artifacts-api.elastic.co/v1"
+NO_KPI_URL_PARAMS="x-elastic-no-kpi=true"
 
 OUTPUT=latest-release-versions.json
 
-curl -s ${URL}/versions | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | tee ${OUTPUT}
+curl -s "${URL}/versions?${NO_KPI_URL_PARAMS}" | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | tee ${OUTPUT}

--- a/resources/scripts/artifacts-api-latest-versions.sh
+++ b/resources/scripts/artifacts-api-latest-versions.sh
@@ -28,11 +28,11 @@
 set -eo pipefail
 
 URL="https://artifacts-api.elastic.co/v1"
-NO_KPI_URL_PARAMS="x-elastic-no-kpi=true"
+NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 TEMP_FILE=$(mktemp)
 OUTPUT=latest-versions.json
 
-QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAMS}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
 LENGTH=$(echo "$QUERY_OUTPUT" | wc -l)
 i=0
 echo "{" > "${TEMP_FILE}"
@@ -45,7 +45,7 @@ for version in ${QUERY_OUTPUT}; do
     elif  [ "${i}" -ge "${LENGTH}" ] ; then
         comma=""
     fi
-    LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAMS}" | jq 'del(.build.projects,.manifests) | . |= .build')
+    LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
     BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
     {
         echo "${comma}\"$BRANCH\":"

--- a/resources/scripts/artifacts-api-latest-versions.sh
+++ b/resources/scripts/artifacts-api-latest-versions.sh
@@ -28,10 +28,11 @@
 set -eo pipefail
 
 URL="https://artifacts-api.elastic.co/v1"
+NO_KPI_URL_PARAMS="x-elastic-no-kpi=true"
 TEMP_FILE=$(mktemp)
 OUTPUT=latest-versions.json
 
-QUERY_OUTPUT=$(curl -s ${URL}/versions | jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAMS}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
 LENGTH=$(echo "$QUERY_OUTPUT" | wc -l)
 i=0
 echo "{" > "${TEMP_FILE}"
@@ -44,7 +45,7 @@ for version in ${QUERY_OUTPUT}; do
     elif  [ "${i}" -ge "${LENGTH}" ] ; then
         comma=""
     fi
-    LATEST_OUTPUT=$(curl -s ${URL}/versions/"${version}"/builds/latest | jq 'del(.build.projects,.manifests) | . |= .build')
+    LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAMS}" | jq 'del(.build.projects,.manifests) | . |= .build')
     BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
     {
         echo "${comma}\"$BRANCH\":"


### PR DESCRIPTION
## What does this PR do?
It adds an URL param to Elastic's artifacts endpoint.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
With this parameter, the download metrics won't be impacted by internal-automated hits.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->