### PR TITLE
chore: add observer metadata for MB/FB

### DIFF
--- a/resources/scripts/beats/filebeat.yml
+++ b/resources/scripts/beats/filebeat.yml
@@ -9,6 +9,7 @@ filebeat.autodiscover:
               - /var/lib/docker/containers/${data.docker.container.id}/*.log
 processors:
   - add_host_metadata: ~
+  - add_observer_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
   - add_kubernetes_metadata: ~

--- a/resources/scripts/beats/metricbeat.yml
+++ b/resources/scripts/beats/metricbeat.yml
@@ -27,6 +27,7 @@ metricbeat.modules:
 
 processors:
   - add_host_metadata: ~
+  - add_observer_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
   - add_kubernetes_metadata: ~


### PR DESCRIPTION
## What does this PR do?
It adds the observer metadata processor for metricbeat and filebeat

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
As explained in [docs](https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html), it recommends using `add_observer_metadata` if the beat is being used to monitor external systems. My question is: are Docker containers running in the host considered external systems?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->