### PR TITLE
fix: select the last 2 releases

### DIFF
--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -121,7 +121,14 @@ def createPullRequest(Map args = [:]) {
     error('createPullRequest: stackVersions is empty. Review the artifacts-api for the branch ' + args.branchName)
   }
   sh(script: """git checkout -b "update-stack-version-\$(date "+%Y%m%d%H%M%S")-${args.branchName}" """, label: "Git branch creation")
-  sh(script: "${args.scriptFile} '${args.stackVersions[0]}' '${args.stackVersions[1]}'", label: "Prepare changes for ${args.repo}")
+  if(args.stackVersions.size() >= 2){
+    sh(script: "${args.scriptFile} '${args.stackVersions[args.stackVersions.size() - 2]}' '${args.stackVersions[args.stackVersions.size() - 1]}'", label: "Prepare changes for ${args.repo}")
+  } else if (args.stackVersions.size() == 1){
+    sh(script: "${args.scriptFile} '${args.stackVersions[0]}' ''", label: "Prepare changes for ${args.repo}")
+  } else {
+    error("There is no release versions")
+  }
+
   if (params.DRY_RUN_MODE) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Select the two latest releases.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
Right now there are three releases in the artifactory (6.8.16, 7.13.0, 7.13.0), this causes the script to try to bump to 6.8.x which is incorrect. This PR takes the latest 2 versions.

related to https://github.com/elastic/observability-test-environments/pull/1437 https://github.com/elastic/apm-integration-testing/pull/1161 https://github.com/elastic/apm-integration-testing/pull/1160 https://github.com/elastic/apm-pipeline-library/pull/1136 

