### PR TITLE
Use maven 3.8 to fix issues with the release

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/lastSuccessfulBuild/artifact/org/apache/maven/apache-maven/4.0.0-alpha-1-SNAPSHOT/apache-maven-4.0.0-alpha-1-SNAPSHOT-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
I see some errors recently with the maven release process.


```
[2021-06-07T14:59:56.074Z] [INFO] ------------------------------------------------------------------------
[2021-06-07T14:59:56.074Z] [INFO] BUILD SUCCESS
[2021-06-07T14:59:56.074Z] [INFO] ------------------------------------------------------------------------
[2021-06-07T14:59:56.074Z] [INFO] Total time:  35.002 s
[2021-06-07T14:59:56.074Z] [INFO] Finished at: 2021-06-07T14:59:55Z
[2021-06-07T14:59:56.074Z] [INFO] ------------------------------------------------------------------------
[2021-06-07T14:59:56.074Z] java.lang.NullPointerException
[2021-06-07T14:59:56.074Z] 	at org.fusesource.jansi.AnsiPrintStream.uninstall(AnsiPrintStream.java:79)
[2021-06-07T14:59:56.074Z] 	at org.fusesource.jansi.AnsiConsole.systemUninstall(AnsiConsole.java:524)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.shared.utils.logging.MessageUtils.doSystemUninstall(MessageUtils.java:101)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.shared.utils.logging.MessageUtils.systemUninstall(MessageUtils.java:80)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:203)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-06-07T14:59:56.074Z] 	at java.lang.reflect.Method.invoke(Method.java:498)
[2021-06-07T14:59:56.074Z] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[2021-06-07T14:59:56.074Z] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[2021-06-07T14:59:56.074Z] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[2021-06-07T14:59:56.074Z] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[2021-06-07T14:59:56.074Z] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-06-07T14:59:56.074Z] 	at java.lang.reflect.Method.invoke(Method.java:498)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
[2021-06-07T14:59:56.074Z] 	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:60)
script returned exit code 100
```

Let's discard the issue is related to the maven 4 alpha version
