### PR TITLE
Bump release versions for the azure-vm-extension

### DIFF
--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -32,3 +32,9 @@ projects:
       - release
     enabled: false
     labels: dependency
+  - repo: azure-vm-extension
+    script: .ci/bump-stack-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency


### PR DESCRIPTION
## What does this PR do?

Bump Elastic versions for the repo azure-vm-extension

## Why is it important?

To run the ITs in the cloud for the azure-vm-extension

## Related issues

Depends on https://github.com/elastic/azure-vm-extension/pull/13