### PR TITLE
Add 7.x-version action

### DIFF
--- a/resources/scripts/artifacts-api-7.x-version.sh
+++ b/resources/scripts/artifacts-api-7.x-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# It queries the artifacts-api entry point to fetch the version
+# that matches the branch 7.x
+# It prints the output in the console
+#
+# Since it prints the output in the console avoid any cosmetic changes
+# with echo or set -x
+#
+set -eo pipefail
+
+URL="https://artifacts-api.elastic.co/v1"
+NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
+
+curl -s "${URL}/versions/7.x-SNAPSHOT/builds/latest?${NO_KPI_URL_PARAM}" | jq -r 'del(.build.projects,.manifests)| . |= .build | .version'

--- a/vars/artifactsApi.groovy
+++ b/vars/artifactsApi.groovy
@@ -34,6 +34,10 @@ def call(Map args = [:]) {
       def output = sh(label: "${action}", script: libraryResource('scripts/artifacts-api-latest-release-versions.sh'), returnStdout: true)
       return readJSON(text: output)
       break
+    case '7.x-version':
+      def output = sh(label: "${action}", script: libraryResource('scripts/artifacts-api-7.x-version.sh'), returnStdout: true).trim()
+      return output
+      break
     default:
       error('artifactsApi: unsupported action.')
       break


### PR DESCRIPTION
## What does this PR do?

Helper to given the branch 7.x name returns the elastic version.

## Why is it important?

This will help with some of the automation we have done to bump versions, since 7.x branch is not an easy one.

## Related issues

Required by https://github.com/elastic/azure-vm-extension/pull/13
