### PR TITLE
Automate the release stack version for the apm-agent-rum-js

### DIFF
--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -44,3 +44,4 @@ projects:
       - master
     enabled: true
     labels: dependency
+    title: "chore: update elastic stack release version"

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -38,3 +38,9 @@ projects:
       - master
     enabled: true
     labels: dependency
+  - repo: apm-agent-rum-js
+    script: .ci/bump-stack-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -88,7 +88,8 @@ def generateSteps(Map args = [:]) {
       bumpStackVersion(repo: env.REPO,
                        scriptFile: "${project.script}",
                        branch: env.BRANCH,
-                       labels: project.get('labels', ''))
+                       labels: project.get('labels', ''),
+                       title: project.get('title', ''))
     }
   }
 }
@@ -106,8 +107,7 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def labels = args.get('labels', '').replaceAll('\\s','')
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}')")
-
-  def title = '[automation] update elastic stack release version'
+  def title = args.get('title', '').trim() ? '[automation] update elastic stack release version' : args.title
   def message = createPRDescription(latestVersions)
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"


### PR DESCRIPTION
## What does this PR do?

Support the bump of the elastic stack version for the apm-agent-rum-js
Support to customise the title since the apm-agent-rum-js uses some commit-linting and PR title linting

## Why is it important?

Automate the bump

## Related issues
Requires https://github.com/elastic/apm-agent-rum-js/pull/1038
