### PR TITLE
goVersion step and automate the go bump when a new release is out

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -1,5 +1,5 @@
 ---
-## This is the file that contains what projects should bump their elastic stack
+## This is the file that contains what projects should bump their Golang
 ## release versions.
 ##
 ## The data structure:

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -8,6 +8,7 @@
 ##  branches: the list of branches that should benefit from this automation.
 ##  enabled: whether the automation has been enabled for this project.
 ##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
+##  title: the PR title, empty if you'd like to use the default one.
 ##
 projects:
   - repo: apm-pipeline-library

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -1,0 +1,24 @@
+---
+## This is the file that contains what projects should bump their elastic stack
+## release versions.
+##
+## The data structure:
+##  repo: the repository name
+##  script: the relative path to the script in charge to bump the version
+##  branches: the list of branches that should benefit from this automation.
+##  enabled: whether the automation has been enabled for this project.
+##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
+##
+projects:
+  - repo: apm-pipeline-library
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency
+  - repo: apm-integration-testing
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency

--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -21,7 +21,7 @@ else
 fi
 
 echo "Update go version ${GO_RELEASE_VERSION}"
-${SED} -E -e "s#(return) = '[0-9]+\.[0-9]+\.[0-9]'#\1 = '${GO_RELEASE_VERSION}'#g" vars/goDefaultVersion.groovy
+${SED} -E -e "s#(return) '[0-9]+\.[0-9]+\.[0-9]'#\1 '${GO_RELEASE_VERSION}'#g" vars/goDefaultVersion.groovy
 
 git add vars/goDefaultVersion.groovy
 git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"

--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Given the Golang release version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+${SED} -E -e "s#(return) = '[0-9]+\.[0-9]+\.[0-9]'#\1 = '${GO_RELEASE_VERSION}'#g" vars/goDefaultVersion.groovy
+
+git add vars/goDefaultVersion.groovy
+git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -1,0 +1,149 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@master') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'apm-pipeline-library'
+    ORG_NAME = 'elastic'
+    HOME = "${env.WORKSPACE}"
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  parameters {
+    booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
+      }
+    }
+    stage('Fetch latest go release version') {
+      steps {
+        setEnvVar('GO_RELEASE_VERSION', goVersion(action: 'latest', unstable: false))
+      }
+    }
+    stage('Send Pull Request'){
+      options {
+        warnError('Pull Requests failed')
+      }
+      steps {
+        generateSteps()
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}
+
+def generateSteps(Map args = [:]) {
+  def projects = readYaml(file: '.ci/.bump-go-release-version.yml')
+  projects['projects'].each { project ->
+    matrix( agent: 'linux && immutable',
+            axes:[
+              axis('REPO', [project.repo]),
+              axis('BRANCH', project.branches),
+              axis('ENABLED', [project.get('enabled', true)])
+            ],
+            excludes: [ axis('ENABLED', [ false ]) ]
+    ) {
+      bumpStackVersion(repo: env.REPO,
+                       scriptFile: "${project.script}",
+                       branch: env.BRANCH,
+                       labels: project.get('labels', ''),
+                       title: project.get('title', ''))
+    }
+  }
+}
+
+def bumpStackVersion(Map args = [:]){
+  catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+    def arguments = prepareArguments(args)
+    createPullRequest(arguments)
+  }
+}
+
+def prepareArguments(Map args = [:]){
+  def repo = args.containsKey('repo') ? args.get('repo') : error('prepareArguments: repo argument is required')
+  def scriptFile = args.containsKey('scriptFile') ? args.get('scriptFile') : error('prepareArguments: scriptFile argument is required')
+  def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
+  def labels = args.get('labels', '').replaceAll('\\s','')
+  def title = args.get('title', '').trim() ? '[automation] update go release version' : args.title
+  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
+  def message = createPRDescription(env.GO_RELEASE_VERSION)
+  if (labels.trim() && !labels.contains('automation')) {
+    labels = "automation,${labels}"
+  }
+  return [repo: repo, branchName: branch, title: title, labels: labels, scriptFile: scriptFile, goReleaseVersion: env.GO_RELEASE_VERSION, message: message]
+}
+
+def createPullRequest(Map args = [:]) {
+  prepareContext(repo: args.repo, branchName: args.branchName)
+  if (!args?.goReleaseVersion?.trim()) {
+    error('createPullRequest: goReleaseVersion is empty. Review the goVersion for the branch ' + args.branchName)
+  }
+  sh(script: """git checkout -b "update-go-version-\$(date "+%Y%m%d%H%M%S")-${args.branchName}" """, label: "Git branch creation")
+  if(args.stackVersions.size() >= 2){
+    sh(script: "${args.scriptFile} '${args.goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
+  } else if (args.stackVersions.size() == 1){
+    sh(script: "${args.scriptFile} '${args.stackVersions[0]}' ''", label: "Prepare changes for ${args.repo}")
+  } else {
+    error("There is no release versions")
+  }
+
+  if (params.DRY_RUN_MODE) {
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
+    return
+  }
+  if (anyChangesToBeSubmitted("${args.branchName}")) {
+    githubCreatePullRequest(title: "${args.title} ${args.stackVersions}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+  } else {
+    log(level: 'INFO', text: "There are no changes to be submitted.")
+  }
+}
+
+def anyChangesToBeSubmitted(String branch) {
+  return sh(returnStatus: true, script: "git diff --quiet HEAD..${branch}") != 0
+}
+
+def prepareContext(Map args = [:]) {
+  deleteDir()
+  setupAPMGitEmail(global: true)
+  git(url: "https://github.com/${ORG_NAME}/${args.repo}.git",
+      branch: args.branchName,
+      credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken')
+}
+
+def createPRDescription(versionEntry) {
+  return """### What \n Bump go release version with the latest release. \n ### Further details \n ${versionEntry}"""
+}

--- a/.ci/jobs/apm-pipeline-library-mbp.yml
+++ b/.ci/jobs/apm-pipeline-library-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          head-filter-regex: '^(?!update-stack-version).*$'
+          head-filter-regex: '^(?!update-.*-version).*$'
           notification-context: 'apm-ci'
           repo: apm-pipeline-library
           repo-owner: elastic

--- a/.ci/jobs/bump-go-release-version-pipeline.yml
+++ b/.ci/jobs/bump-go-release-version-pipeline.yml
@@ -1,0 +1,25 @@
+---
+- job:
+    name: apm-shared/bump-go-release-version-pipeline
+    display-name: Bump Go Release Version
+    description: Send PRs to the subscribed observability repositories if a new go release version has been released.
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/bumpGoReleaseVersion.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/apm-pipeline-library.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/apm-pipeline-library.git
+            branches:
+              - $branch_specifier

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -56,6 +56,17 @@ pipeline {
         )
       }
     }
+    stage('Bump Go release') {
+      steps {
+        build(job: 'apm-shared/bump-go-release-version-pipeline',
+          parameters: [
+            booleanParam(name: 'DRY_RUN_MODE', value: false)
+          ],
+          propagate: false,
+          wait: false
+        )
+      }
+    }
   }
   post {
     cleanup {

--- a/src/test/groovy/GoVersionStepTests.groovy
+++ b/src/test/groovy/GoVersionStepTests.groovy
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class GoVersionStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/goVersion.groovy')
+  }
+
+  @Test
+  void test_windows() throws Exception {
+    testWindows() {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_missing_action() throws Exception {
+    testMissingArgument('action') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_unsupported_action() throws Exception {
+    try {
+      script.call(action: 'unknown')
+    } catch(e) {
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', "goVersion: unsupported action."))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_latest_unstable() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class],{'1.17beta1'})
+    def obj = script.call(action: 'latest', unstable: 'true')
+    assertTrue(obj.equals('1.17beta1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | sed "s#^go##g" | head -n1'))
+    printCallStack()
+  }
+
+  @Test
+  void test_latest() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class],{'1.16.5'})
+    def obj = script.call(action: 'latest')
+    assertTrue(obj.equals('1.16.5'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g" | head -n1'))
+    printCallStack()
+  }
+
+  @Test
+  void test_versions() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class],{'''1.16.5
+1.16.4
+1.16
+1.15.13
+1.15.12
+    '''})
+    def obj = script.call(action: 'versions')
+    assertTrue(obj.split(System.getProperty("line.separator")).length == 5)
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g"'))
+    assertFalse(assertMethodCallContainsPattern('sh', 'head -n1'))
+    printCallStack()
+  }
+}

--- a/src/test/groovy/GoVersionStepTests.groovy
+++ b/src/test/groovy/GoVersionStepTests.groovy
@@ -60,6 +60,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('sh', [Map.class],{'1.17beta1'})
     def obj = script.call(action: 'latest', unstable: 'true')
     assertTrue(obj.equals('1.17beta1'))
+    assertTrue(assertMethodCallContainsPattern('sh', '--refs git://github.com/golang/go'))
     assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | sed "s#^go##g" | head -n1'))
     printCallStack()
   }
@@ -70,6 +71,15 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     def obj = script.call(action: 'latest')
     assertTrue(obj.equals('1.16.5'))
     assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g" | head -n1'))
+    printCallStack()
+  }
+
+  @Test
+  void test_latest_with_glob() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class],{'1.15.13'})
+    def obj = script.call(action: 'latest', glob: '1.15')
+    assertTrue(obj.equals('1.15.13'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | grep "1.15" | sed "s#^go##g" | head -n1'))
     printCallStack()
   }
 

--- a/vars/README.md
+++ b/vars/README.md
@@ -1322,6 +1322,26 @@ pipeline {
 }
 ```
 
+## goVersion
+This step helps to query what golang versions have been released.
+
+```
+
+// Get the latest stable release
+def latestGoRelease = goVersion(action: 'latest', unstable: false)
+
+// Get the latest release
+def latestGoVersion = goVersion(action: 'latest', unstable: true)
+
+// Get all the latest releases for the go1.15
+def latestGo115Releases = goVersion(action: 'versions', unstable: false, glob: '1.15')
+```
+
+* action: What's the action to be triggered. Mandatory
+* glob: What's the filter, glob format, to be applied to the list of versions. Optional. Default 'none'
+* unstable: Whether to list the rc/beta releases. Optional. Default false.
+
+
 ## googleStorageUploadExt
 Upload the given pattern files to the given bucket.
 
@@ -3127,3 +3147,4 @@ writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secre
 
 * secret: Name of the secret on the the vault root path. Mandatory
 * data: What's the data to be written. Mandatory
+

--- a/vars/goVersion.groovy
+++ b/vars/goVersion.groovy
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ This step helps to query what golang versions have been released.
+*/
+def call(Map args = [:]) {
+  if(!isUnix()){
+    error('goVersion: windows is not supported yet.')
+  }
+  def action = args.containsKey('action') ? args.action : error('goVersion: action parameter is required.')
+  def glob = args.get('glob', null)
+
+  switch(action) {
+    case 'latest-version':
+      cloneAndRun() {
+        def output = sh(label: "${action}", script: firstOne(getAllGoVersions()), returnStdout: true)
+        return output.trim()
+      }
+      break
+    case 'latest-versions':
+      cloneAndRun() {
+        def output = sh(label: "${action}", script: getAllGoVersions(), returnStdout: true)
+        return output.trim()
+      }
+      break
+    case 'latest-release-version':
+      cloneAndRun() {
+        def output = sh(label: "${action}", script: firstOne(getLatestVersionCommand(glob)), returnStdout: true)
+        return output.trim()
+      }
+      break
+    default:
+      error('goVersion: unsupported action.')
+      break
+  }
+}
+
+def firstOne(String command) {
+  return command + ' | head -n1'
+}
+
+/**
+* Query the tags with the form `go*`.
+* Golang/go releases follow the format goMajor.Minor.Patch<rc|beta
+*/
+def getAllGoVersions() {
+  return 'git tag --list --sort=-version:refname "go*"'
+}
+
+def getLatestVersionCommand(String glob = null) {
+  def command = getAllGoVersions + ' | grep -v "[beta|rc]"'
+  if (glob) {
+    command = command + ' | grep "' + glob + '"'
+  }
+  command = command + ' | head -n'
+  return command
+}
+
+def cloneAndRun(Closure body) {
+  def workspaceLocation = pwd(tmp: true)
+  dir(workspaceLocation) {
+    sh(label: 'git clone golang/go',
+       script: '''
+        git clone git@github.com:golang/go
+        git fetch --tags
+       ''')
+    body()
+  }
+}

--- a/vars/goVersion.txt
+++ b/vars/goVersion.txt
@@ -1,0 +1,17 @@
+This step helps to query what golang versions have been released.
+
+```
+
+// Get the latest stable release
+def latestGoRelease = goVersion(action: 'latest', unstable: false)
+
+// Get the latest release
+def latestGoVersion = goVersion(action: 'latest', unstable: true)
+
+// Get all the latest releases for the go1.15
+def latestGo115Releases = goVersion(action: 'versions', unstable: false, glob: '1.15')
+```
+
+* action: What's the action to be triggered. Mandatory
+* glob: What's the filter, glob format, to be applied to the list of versions. Optional. Default 'none'
+* unstable: Whether to list the rc/beta releases. Optional. Default false.


### PR DESCRIPTION
## What does this PR do?

* `goVersion` step to interact with the go releases. It supports unstable and stable releases and also filter releases with some glob format.
* Enable the go bump automation pipeline on a weekly basis.
* Add go bump automation in the apm-pipeline-library.

## Why is it important?

First step to automate other projects similar what we have done already with the elastic stack versions.

## Test

```bash
$ .ci/bump-go-release-version.sh 1.16.1
[feature/go-versions f97a3d4] [Automation] Update go release version to 1.16.1
 1 file changed, 1 insertion(+), 1 deletion(-)
commit f97a3d47529cc9142505999de7587d7afd91859e (HEAD -> feature/go-versions)
Author: Victor Martinez <VictorMartinezRubio@gmail.com>
Date:   Tue Jun 15 16:15:28 2021 +0100

    [Automation] Update go release version to 1.16.1
You can now push and create a Pull Request
```

produces

```diff
diff --git a/vars/goDefaultVersion.groovy b/vars/goDefaultVersion.groovy
index 725e93a..f343565 100644
--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -38,5 +38,5 @@ def isGoVersionEnvVarSet(){
 }
 
 def defaultVersion(){
-  return '1.15.8'
+  return '1.16.1'
 }
```
