### PR TITLE
Use sort semver until git version support the --sort flag

### DIFF
--- a/src/test/groovy/GoVersionStepTests.groovy
+++ b/src/test/groovy/GoVersionStepTests.groovy
@@ -61,7 +61,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     def obj = script.call(action: 'latest', unstable: 'true')
     assertTrue(obj.equals('1.17beta1'))
     assertTrue(assertMethodCallContainsPattern('sh', '--refs git://github.com/golang/go'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | sed "s#^go##g" | head -n1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | sed "s#^go##g" | sort --version-sort -r | head -n1'))
     printCallStack()
   }
 
@@ -70,7 +70,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('sh', [Map.class],{'1.16.5'})
     def obj = script.call(action: 'latest')
     assertTrue(obj.equals('1.16.5'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g" | head -n1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g" | sort --version-sort -r | head -n1'))
     printCallStack()
   }
 
@@ -79,7 +79,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('sh', [Map.class],{'1.15.13'})
     def obj = script.call(action: 'latest', glob: '1.15')
     assertTrue(obj.equals('1.15.13'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | grep "1.15" | sed "s#^go##g" | head -n1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | grep "1.15" | sed "s#^go##g" | sort --version-sort -r | head -n1'))
     printCallStack()
   }
 
@@ -93,7 +93,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     '''})
     def obj = script.call(action: 'versions')
     assertTrue(obj.split(System.getProperty("line.separator")).length == 5)
-    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g"'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | grep -v "[beta|rc]" | sed "s#^go##g" | sort --version-sort -r'))
     assertFalse(assertMethodCallContainsPattern('sh', 'head -n1'))
     printCallStack()
   }

--- a/vars/goVersion.groovy
+++ b/vars/goVersion.groovy
@@ -54,7 +54,8 @@ def firstOne(String command) {
 * Golang/go releases follow the format go<Major>.<Minor>(.<Patch>|rc[0-9]|beta[0-9])?
 */
 def getAllGoVersions() {
-  return 'git ls-remote --sort=-version:refname --tags --refs git://github.com/golang/go | sed "s#.*refs/tags/##g" | grep "go*"'
+  // --sort=-version:refname is not supported in git version 2.17 yet
+  return 'git ls-remote --tags --refs git://github.com/golang/go | sed "s#.*refs/tags/##g" | grep "go*"'
 }
 
 def getVersionsCommand(Map args = [:]) {
@@ -64,5 +65,9 @@ def getVersionsCommand(Map args = [:]) {
   if (glob?.trim()) {
     command = command + ' | grep "' + glob + '"'
   }
-  return removeGoPrefix(command)
+  return sortSemVer(removeGoPrefix(command))
+}
+
+def sortSemVer(String command) {
+  return command + ' | sort --version-sort -r'
 }


### PR DESCRIPTION
## What does this PR do?

Use sort pipe

## Why is it important?

Otherwise the pipeline won't work

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1162
