### PR TITLE
Bump go version for the apm-its@7.x branch

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -21,5 +21,6 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - master
+      - 7.x
     enabled: true
     labels: dependency

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -8,6 +8,7 @@
 ##  branches: the list of branches that should benefit from this automation.
 ##  enabled: whether the automation has been enabled for this project.
 ##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
+##  title: the PR title, empty if you'd like to use the default one.
 ##
 projects:
   - repo: apm-pipeline-library


### PR DESCRIPTION
Enable support for the 7.x branch after merging https://github.com/elastic/apm-integration-testing/pulls