### PR TITLE
Support go bump for beats, fleet-server and golang-crossbuild

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -23,3 +23,9 @@ projects:
       - master
     enabled: true
     labels: dependency
+  - repo: fleet-server
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -35,3 +35,9 @@ projects:
       - master
     enabled: true
     labels: dependency
+  - repo: golang-crossbuild
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -23,6 +23,12 @@ projects:
       - master
     enabled: true
     labels: dependency
+  - repo: beats
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - master
+    enabled: true
+    labels: dependency
   - repo: fleet-server
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Enable go version automation for the fleet-server and beats.

## Why is it important?

No hand

## Related issues

Requires 
- https://github.com/elastic/fleet-server/pull/465
- https://github.com/elastic/beats/pull/26343
- https://github.com/elastic/golang-crossbuild/pull/108
