### PR TITLE
Bump automation to detect if a similar open PR already exists

### DIFF
--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -119,6 +119,14 @@ def createPullRequest(Map args = [:]) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return
   }
+
+  // If a similar PR was already created then do nothing.
+  // This should avoid duplicated PRs when they have not been merged yet.
+  if (githubPrExists(args)) {
+    log(level: 'INFO', text: 'A similar Pull Request already exists.')
+    return
+  }
+
   if (anyChangesToBeSubmitted("${args.branchName}")) {
     githubCreatePullRequest(title: "${args.title} ${args.goReleaseVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
   } else {

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -133,6 +133,14 @@ def createPullRequest(Map args = [:]) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return
   }
+
+  // If a similar PR was already created then do nothing.
+  // This should avoid duplicated PRs when they have not been merged yet.
+  if (githubPrExists(args)) {
+    log(level: 'INFO', text: 'A similar Pull Request already exists.')
+    return
+  }
+
   if (anyChangesToBeSubmitted("${args.branchName}")) {
     githubCreatePullRequest(title: "${args.title} ${args.stackVersions}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
   } else {

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -154,6 +154,15 @@ def createPullRequest(Map args = [:]) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}')")
     return
   }
+
+  // If a similar PR was already created then do nothing.
+  // This should avoid duplicated PRs when they have not been merged yet.
+  // Though reusePullRequest argument allows to reuse existing open PRs.
+  if (githubPrExists(args)) {
+    log(level: 'INFO', text: 'A similar Pull Request already exists.')
+    return
+  }
+
   if (anyChangesToBeSubmitted("${args.branchName}")) {
     githubCreatePullRequest(title: "${args.title} ${args.stackVersion}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
   } else {

--- a/src/test/groovy/GithubPrExistsStepTests.groovy
+++ b/src/test/groovy/GithubPrExistsStepTests.groovy
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class GithubPrExistsStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/githubPrExists.groovy')
+  }
+
+  @Test
+  void test_missing_title() throws Exception {
+    testMissingArgument('title') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_with_match() throws Exception {
+    helper.registerAllowedMethod('githubPullRequests', [Map.class], {
+      return [ 1: 1, 2: 2]
+    })
+    def ret = script.call(title: 'foo')
+    printCallStack()
+    assertTrue(ret)
+  }
+
+  @Test
+  void test_without_match() throws Exception {
+    helper.registerAllowedMethod('githubPullRequests', [Map.class], {
+      return [:]
+    })
+    def ret = script.call(title: 'bar')
+    printCallStack()
+    assertFalse(ret)
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1026,6 +1026,21 @@ Arguments:
 
 [Pipeline GitHub plugin](https://plugins.jenkins.io/pipeline-github)
 
+## githubPrExists
+Search if there are any Pull Request that matches the given
+Pull Request details.
+
+```
+  whenTrue(githubPrExists(title: 'my-title')) {
+    echo "I'm a Pull Request"
+  }
+```
+
+* *labels*: Filter by labels. Optional
+* *title*: Filter by title (contains format). Mandatory
+
+NOTE: It uses `githubPullRequests`
+
 ## githubPrInfo
 Get the Pull Request details from the Github REST API.
 
@@ -1340,7 +1355,6 @@ def latestGo115Releases = goVersion(action: 'versions', unstable: false, glob: '
 * action: What's the action to be triggered. Mandatory
 * glob: What's the filter, glob format, to be applied to the list of versions. Optional. Default 'none'
 * unstable: Whether to list the rc/beta releases. Optional. Default false.
-
 
 ## googleStorageUploadExt
 Upload the given pattern files to the given bucket.

--- a/vars/githubPrExists.groovy
+++ b/vars/githubPrExists.groovy
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Whether the build is based on a Pull Request or no
+
+  whenTrue(githubPrExists(title: 'my-title')) {
+    echo "I'm a Pull Request"
+  }
+*/
+def call(Map args = [:]){
+  def title = args.containsKey('title') ? args.title : error('githubPrExists: title parameter is required.')
+  def labels = args.containsKey('labels') ? args.labels.split(',') : ''
+  def pullRequests = githubPullRequests(labels: labels, titleContains: title)
+  return (pullRequests && pullRequests.size() > 1)
+}

--- a/vars/githubPrExists.groovy
+++ b/vars/githubPrExists.groovy
@@ -26,5 +26,5 @@ def call(Map args = [:]){
   def title = args.containsKey('title') ? args.title : error('githubPrExists: title parameter is required.')
   def labels = args.containsKey('labels') ? args.labels.split(',') : ''
   def pullRequests = githubPullRequests(labels: labels, titleContains: title)
-  return (pullRequests && pullRequests.size() > 1)
+  return (pullRequests && pullRequests.size() > 0)
 }

--- a/vars/githubPrExists.txt
+++ b/vars/githubPrExists.txt
@@ -1,0 +1,13 @@
+Search if there are any Pull Request that matches the given
+Pull Request details.
+
+```
+  whenTrue(githubPrExists(title: 'my-title')) {
+    echo "I'm a Pull Request"
+  }
+```
+
+* *labels*: Filter by labels. Optional
+* *title*: Filter by title (contains format). Mandatory
+
+NOTE: It uses `githubPullRequests`


### PR DESCRIPTION
## What does this PR do?

If there is need to create a PR for a specific bump, and there is already an open PR for the same bump, then let's skip the PR creation.

## Why is it important?

Sometimes, teams don't merge those PRs immediately, and therefore the next bump execution might detect that changes were not merged yet and create a new PR for a similar open one.

For instance:

![image](https://user-images.githubusercontent.com/2871786/123607547-e68ea700-d7f5-11eb-841d-22b4b3e1fde3.png)


## Related issues
Closes #ISSUE
