### PR TITLE
chore: enable MacOs worker tests again

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -82,7 +82,7 @@ pipeline {
               'worker-c07y20bcjyvy',
               'worker-c07mq25jdy3h',
               'worker-c07mq1u7dy3h',
-              //'worker-h2wdt2qxq6ny', // Caused by https://github.com/elastic/infra/issues/29456
+              'worker-h2wdt2qxq6ny',
               'worker-395930',  // metal workers https://beats-ci.elastic.co/label/metal/
               'worker-1244230'
             )


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
enable beats-ci test on a macOS workers that is again available.