### PR TITLE
Fix slackMessage when issues is empty

### DIFF
--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -1,7 +1,7 @@
 <% changes = changeSet?.find { true }%>
 <% steps = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit')}%>
 <% artifactsUrl = String.format("<%sartifacts|here>", jobUrl)%>
-<% commitUrl = String.format("<%s|%s>", changes?.issues?.first()?.url, changes?.msg)%>
+<% commitUrl = (changes?.issues?.isEmpty()) ? '' : String.format("<%s|%s>", changes?.issues?.first()?.url, changes?.msg)%>
 <% pipelineUrl = String.format("<%spipeline|#%s>", jobUrl, build?.id ?: 'build')%>
 <% testsUrl = String.format("<%stests|here>", jobUrl)%>
 <% changesMessage = (changes?.msg) ? "${commitUrl} (by `${changes?.author?.id}`)" : "No push event to branch ${build?.pipeline}" %>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -698,6 +698,21 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_slack_with_empty_change_issues() throws Exception {
+    script.notifySlack(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "SUCCESS",
+      changeSet: readJSON(file: "changeSet-info-empty-issues.json"),
+      channel: 'test',
+      credentialId: 'test',
+      enabled: true
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('slackSend', '*Changes*:  (by'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_analyzeFlakey_in_prs_with_empty_flaky_tests() throws Exception {
     helper.registerAllowedMethod('sendDataToElasticsearch', [Map.class], {readJSON(file: 'flake-empty-results.json')})
     helper.registerAllowedMethod('isPR', { return true })

--- a/src/test/resources/changeSet-info-empty-issues.json
+++ b/src/test/resources/changeSet-info-empty-issues.json
@@ -1,0 +1,19 @@
+[
+  {
+    "affectedPaths": [
+      "pipeline.yml"
+    ],
+    "author": {
+      "avatar": null,
+      "email": null,
+      "fullName": "Lola Flores",
+      "id": "Lola.Flores",
+      "permission": null
+    },
+    "checkoutCount": 0,
+    "commitId": "abcdefg",
+    "issues": [ ],
+    "msg": "indicator type url is in upper case (#1234)",
+    "timestamp": "2021-02-22T10:23:51.000+0000"
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Fixes

```
11:49:22  ERROR: notifySlack: Error with the slack comment
11:49:22  java.util.NoSuchElementException: Cannot access first() element from an empty List
11:49:22  Caused: groovy.text.TemplateExecutionException: Template execution error at line 4:
11:49:22           3: <% artifactsUrl = String.format("<%sartifacts|here>", jobUrl)%>
11:49:22       --> 4: <% commitUrl = String.format("<%s|%s>", changes?.issues?.first()?.url, changes?.msg)%>
11:49:22           5: <% pipelineUrl = String.format("<%spipeline|#%s>", jobUrl, build?.id ?: 'build')%>
```

## Why is it important?

In some cases the issues data structure is empty and the elvis operator does not work as expected


I've seen this error when working on https://github.com/elastic/azure-vm-extension/pull/23


![image](https://user-images.githubusercontent.com/2871786/123952366-d6b1c700-d99d-11eb-8f45-a79a2aad2131.png)
