### PR TITLE
[mergify] clean up branches for the bump automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,6 +36,6 @@ pull_request_rules:
     conditions:
       - merged
       - label=automation
-      - base~=^update-stack-version
+      - base~=^update-.*-version
     actions:
       delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Delete branches with mergify that were created as part of the bump automation

## Issues

https://github.com/elastic/apm-pipeline-library/pull/1160