### PR TITLE
Skip sleep by default in the withNode step

### DIFF
--- a/src/test/groovy/WithNodeStepTests.groovy
+++ b/src/test/groovy/WithNodeStepTests.groovy
@@ -132,6 +132,18 @@ class WithNodeStepTests extends ApmBasePipelineTest {
     assertJobStatusSuccess()
   }
 
+ @Test
+  void test_with_sleep_default() throws Exception {
+    def isOK = false
+    script.call(labels: 'foo') {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPatternOccurrences('sleep', 0))
+    assertJobStatusSuccess()
+  }
+
   @Test
   void test_getWorkspace_with_variables() throws Exception {
     addEnvVar('JOB_BASE_NAME', 'foo')

--- a/src/test/groovy/WithNodeStepTests.groovy
+++ b/src/test/groovy/WithNodeStepTests.groovy
@@ -47,7 +47,7 @@ class WithNodeStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPatternOccurrences('sleep', 0))
+    assertTrue(assertMethodCallOccurrences('sleep', 0))
     assertFalse(assertMethodCallContainsPattern('node', 'foo && extra/'))
     assertTrue(assertMethodCallOccurrences('ws', 0))
     assertJobStatusSuccess()

--- a/src/test/groovy/WithNodeStepTests.groovy
+++ b/src/test/groovy/WithNodeStepTests.groovy
@@ -47,6 +47,7 @@ class WithNodeStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPatternOccurrences('sleep', 0))
     assertFalse(assertMethodCallContainsPattern('node', 'foo && extra/'))
     assertTrue(assertMethodCallOccurrences('ws', 0))
     assertJobStatusSuccess()
@@ -129,18 +130,6 @@ class WithNodeStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(isOK)
     assertTrue(assertMethodCallContainsPattern('randomNumber', '100'))
-    assertJobStatusSuccess()
-  }
-
- @Test
-  void test_with_sleep_default() throws Exception {
-    def isOK = false
-    script.call(labels: 'foo') {
-      isOK = true
-    }
-    printCallStack()
-    assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPatternOccurrences('sleep', 0))
     assertJobStatusSuccess()
   }
 

--- a/vars/withNode.groovy
+++ b/vars/withNode.groovy
@@ -41,7 +41,11 @@ def call(Map args = [:], Closure body) {
   def disableSomeWorkers = args.get('disableWorkers', false)
 
   // Sleep to smooth the ram up with the provisioner
-  sleep(randomNumber(min: sleepMin, max: sleepMax))
+  if (sleepMin == sleepMax && sleepMax == 0) {
+    log(level: 'DEBUG', text: "Skip sleep")
+  } else {
+    sleep(randomNumber(min: sleepMin, max: sleepMax))
+  }
 
   // In case of ephemeral workers then use the uuid
   def newLabels = labels

--- a/vars/withNode.txt
+++ b/vars/withNode.txt
@@ -1,5 +1,5 @@
 Wrap the node call for three reasons:
-  1. with some latency to avoid the known issue with the scalability in gobld.
+  1. with some latency to avoid the known issue with the scalability in gobld. It requires sleepMax > 0
   2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
   3. allocate a new workspace to workaround the flakiness of windows workers with deleteDir.
 
@@ -17,8 +17,8 @@ Wrap the node call for three reasons:
 ```
 
 * labels: what's the labels to be used. Mandatory
-* sleepMin: whether to sleep and for how long at least. Optional.
-* sleepMax: whether to sleep and for how long maximum. Optional.
+* sleepMin: whether to sleep and for how long at least. Optional. By default `0`
+* sleepMax: whether to sleep and for how long maximum. Optional. By default `0`
 * forceWorker: whether to allocate a new unique ephemeral worker. Optional. Default false
 * forceWorkspace: whether to allocate a new unique workspace. Optional. Default false
 * disableWorkers: whether to skip the run if the labels match one of the flaky workers. Default false


### PR DESCRIPTION
## What does this PR do?

Avoid sleep when provisioning a new node by default and delegate that responsibility to the provisioner

## Why is it important?

Slowness to provision seems to be fixed after the Improve performance when creating or deleting nodes by reducing queue-lock contention. (pull https://github.com/jenkinsci/jenkins/pull/5402, pull https://github.com/jenkinsci/jenkins/pull/540 12) that was backported in 2.289.1

## Related issues

Notifies https://github.com/elastic/beats/pull/26613
