### PR TITLE
Bump automation to set the assignee and reviewer if defined

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -9,6 +9,8 @@
 ##  enabled: whether the automation has been enabled for this project.
 ##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
 ##  title: the PR title, empty if you'd like to use the default one.
+##  assign: A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request. Optional.
+##  reviewer: A comma-separated list (no spaces around the comma) of GitHub handles to request a review from. Optional.
 ##
 projects:
   - repo: apm-pipeline-library

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -17,6 +17,8 @@ projects:
       - master
     enabled: true
     labels: dependency
+    assignee: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-go-release-version.sh
     branches:
@@ -24,6 +26,8 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
+    assignee: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: beats
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -19,7 +19,7 @@ projects:
       - master
     enabled: true
     labels: dependency
-    assignee: elastic/observablt-robots-on-call
+    assign: elastic/observablt-robots-on-call
     reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-go-release-version.sh
@@ -28,7 +28,7 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
-    assignee: elastic/observablt-robots-on-call
+    assign: elastic/observablt-robots-on-call
     reviewer: elastic/observablt-robots
   - repo: beats
     script: .ci/bump-go-release-version.sh

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -19,8 +19,7 @@ projects:
       - master
     enabled: true
     labels: dependency
-    assign: elastic/observablt-robots-on-call
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-robots-on-call
   - repo: apm-integration-testing
     script: .ci/bump-go-release-version.sh
     branches:
@@ -28,8 +27,7 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
-    assign: elastic/observablt-robots-on-call
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-robots-on-call
   - repo: beats
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -28,6 +28,8 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
+    assign: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: observability-test-environments
     script: .ci/bump-stack-release-version.sh
     branches:

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -19,8 +19,7 @@ projects:
       - master
     enabled: true
     labels: dependency
-    assign: elastic/observablt-robots-on-call
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-robots-on-call
   - repo: apm-integration-testing
     script: .ci/bump-stack-release-version.sh
     branches:
@@ -28,8 +27,7 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
-    assign: elastic/observablt-robots-on-call
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-robots-on-call
   - repo: observability-test-environments
     script: .ci/bump-stack-release-version.sh
     branches:
@@ -39,8 +37,7 @@ projects:
       - release
     enabled: false
     labels: dependency
-    assign: elastic/observablt-robots-on-call
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-robots-on-call
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh
     branches:

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -19,7 +19,7 @@ projects:
       - master
     enabled: true
     labels: dependency
-    assignee: elastic/observablt-robots-on-call
+    assign: elastic/observablt-robots-on-call
     reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-stack-release-version.sh
@@ -37,7 +37,7 @@ projects:
       - release
     enabled: false
     labels: dependency
-    assignee: elastic/observablt-robots-on-call
+    assign: elastic/observablt-robots-on-call
     reviewer: elastic/observablt-robots
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -9,6 +9,8 @@
 ##  enabled: whether the automation has been enabled for this project.
 ##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
 ##  title: the PR title, empty if you'd like to use the default one.
+##  assign: A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request. Optional.
+##  reviewer: A comma-separated list (no spaces around the comma) of GitHub handles to request a review from. Optional.
 ##
 projects:
   - repo: apm-pipeline-library

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -17,6 +17,8 @@ projects:
       - master
     enabled: true
     labels: dependency
+    assignee: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-stack-release-version.sh
     branches:
@@ -33,6 +35,8 @@ projects:
       - release
     enabled: false
     labels: dependency
+    assignee: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh
     branches:

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -134,7 +134,16 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
+    def arguments = [
+      title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}"
+    ]
+    if (args.assign?.trim()) {
+      arguments['assign'] = args.assign
+    }
+    if (args.reviewer?.trim()) {
+      arguments['reviewer'] = args.reviewer
+    }
+    githubCreatePullRequest(arguments)
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -104,7 +104,7 @@ def prepareArguments(Map args = [:]){
   def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
 
-  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
+  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
   def message = createPRDescription(env.GO_RELEASE_VERSION)
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -73,7 +73,7 @@ def generateSteps(Map args = [:]) {
             axes:[
               axis('REPO', [project.repo]),
               axis('BRANCH', project.branches),
-              axis('ENABLED', [project.get('enabled', true)])
+              axis('ENABLED', [project.get('enabled', 'true').equals('true')])
             ],
             excludes: [ axis('ENABLED', [ false ]) ]
     ) {

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -82,7 +82,7 @@ def generateSteps(Map args = [:]) {
                        branch: env.BRANCH,
                        labels: project.get('labels', ''),
                        title: project.get('title', ''),
-                       assignee: project.get('assignee', ''),
+                       assign: project.get('assign', ''),
                        reviewer: project.get('reviewer', ''))
     }
   }
@@ -101,7 +101,7 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def labels = args.get('labels', '').replaceAll('\\s','')
   def title = args.get('title', '').trim() ? args.title : '[automation] Update go release version'
-  def assignee = args.get('assignee', '')
+  def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
 
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
@@ -110,7 +110,7 @@ def prepareArguments(Map args = [:]){
     labels = "automation,${labels}"
   }
   return [repo: repo, branchName: branch, title: "${title} ${env.GO_RELEASE_VERSION}", labels: labels, scriptFile: scriptFile,
-          goReleaseVersion: env.GO_RELEASE_VERSION, message: message, assignee: assignee, reviewer: reviewer]
+          goReleaseVersion: env.GO_RELEASE_VERSION, message: message, assign: assign, reviewer: reviewer]
 }
 
 def createPullRequest(Map args = [:]) {
@@ -122,7 +122,7 @@ def createPullRequest(Map args = [:]) {
   sh(script: "${args.scriptFile} '${args.goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
 
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assignee: '${args.reviewer}', assignee: '${args.reviewer}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
     return
   }
 
@@ -134,7 +134,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assignee: "${args.assignee}", reviewer: "${args.reviewer}")
+    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -81,7 +81,9 @@ def generateSteps(Map args = [:]) {
                        scriptFile: "${project.script}",
                        branch: env.BRANCH,
                        labels: project.get('labels', ''),
-                       title: project.get('title', ''))
+                       title: project.get('title', ''),
+                       assignee: project.get('assignee', ''),
+                       reviewer: project.get('reviewer', ''))
     }
   }
 }
@@ -99,12 +101,16 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def labels = args.get('labels', '').replaceAll('\\s','')
   def title = args.get('title', '').trim() ? args.title : '[automation] Update go release version'
+  def assignee = args.get('assignee', '')
+  def reviewer = args.get('reviewer', '')
+
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
   def message = createPRDescription(env.GO_RELEASE_VERSION)
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"
   }
-  return [repo: repo, branchName: branch, title: "${title} ${env.GO_RELEASE_VERSION}", labels: labels, scriptFile: scriptFile, goReleaseVersion: env.GO_RELEASE_VERSION, message: message]
+  return [repo: repo, branchName: branch, title: "${title} ${env.GO_RELEASE_VERSION}", labels: labels, scriptFile: scriptFile,
+          goReleaseVersion: env.GO_RELEASE_VERSION, message: message, assignee: assignee, reviewer: reviewer]
 }
 
 def createPullRequest(Map args = [:]) {
@@ -116,7 +122,7 @@ def createPullRequest(Map args = [:]) {
   sh(script: "${args.scriptFile} '${args.goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
 
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assignee: '${args.reviewer}', assignee: '${args.reviewer}')")
     return
   }
 
@@ -128,7 +134,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assignee: "${args.assignee}", reviewer: "${args.reviewer}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -111,7 +111,7 @@ def prepareArguments(Map args = [:]){
   def title = args.get('title', '').trim() ? args.title : '[automation] Update Elastic stack release version'
   def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
-  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
+  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
   def message = createPRDescription(latestVersions)
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -147,7 +147,16 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
+    def arguments = [
+      title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}"
+    ]
+    if (args.assign?.trim()) {
+      arguments['assign'] = args.assign
+    }
+    if (args.reviewer?.trim()) {
+      arguments['reviewer'] = args.reviewer
+    }
+    githubCreatePullRequest(arguments)
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -90,7 +90,7 @@ def generateSteps(Map args = [:]) {
                        branch: env.BRANCH,
                        labels: project.get('labels', ''),
                        title: project.get('title', ''),
-                       assignee: project.get('assignee', ''),
+                       assign: project.get('assign', ''),
                        reviewer: project.get('reviewer', ''))
     }
   }
@@ -109,7 +109,7 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def labels = args.get('labels', '').replaceAll('\\s','')
   def title = args.get('title', '').trim() ? args.title : '[automation] Update Elastic stack release version'
-  def assignee = args.get('assignee', '')
+  def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}')")
   def message = createPRDescription(latestVersions)
@@ -117,7 +117,7 @@ def prepareArguments(Map args = [:]){
     labels = "automation,${labels}"
   }
   return [repo: repo, branchName: branch, title: "${title} ${latestVersions}", labels: labels, scriptFile: scriptFile, stackVersions: latestVersions,
-          message: message, assignee: assignee, reviewer: reviewer]
+          message: message, assign: assign, reviewer: reviewer]
 }
 
 def createPullRequest(Map args = [:]) {
@@ -135,7 +135,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assignee: '${args.reviewer}', assignee: '${args.reviewer}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersions}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
     return
   }
 
@@ -147,7 +147,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assignee: "${args.assignee}", reviewer: "${args.reviewer}")
+    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -81,7 +81,7 @@ def generateSteps(Map args = [:]) {
             axes:[
               axis('REPO', [project.repo]),
               axis('BRANCH', project.branches),
-              axis('ENABLED', [project.get('enabled', true)])
+              axis('ENABLED', [project.get('enabled', 'true').equals('true')])
             ],
             excludes: [ axis('ENABLED', [ false ]) ]
     ) {

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -90,7 +90,7 @@ def generateSteps(Map args = [:]) {
                        branch: env.BRANCH,
                        reusePullRequest: project.get('reusePullRequest', false),
                        labels: project.get('labels', ''),
-                       assignee: project.get('assignee', ''),
+                       assign: project.get('assign', ''),
                        reviewer: project.get('reviewer', ''))
     }
   }
@@ -113,7 +113,7 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def reusePullRequest = args.get('reusePullRequest', false)
   def labels = args.get('labels', '').replaceAll('\\s','')
-  def assignee = args.get('assignee', '')
+  def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, reusePullRequest: ${reusePullRequest}, labels: '${labels}')")
 
@@ -126,7 +126,7 @@ def prepareArguments(Map args = [:]){
     labels = "automation,${labels}"
   }
   return [reusePullRequest: reusePullRequest, repo: repo, branchName: branchName, title: "${title} ${stackVersion}", labels: labels,
-          scriptFile: scriptFile, stackVersion: stackVersion, message: message, assignee: assignee, reviewer: reviewer]
+          scriptFile: scriptFile, stackVersion: stackVersion, message: message, assign: assign, reviewer: reviewer]
 }
 
 def reusePullRequest(Map args = [:]) {
@@ -156,7 +156,7 @@ def createPullRequest(Map args = [:]) {
   }
   sh(script: "${args.scriptFile} '${args.stackVersion}' 'true'", label: "Prepare changes for ${args.repo}")
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assignee: '${args.reviewer}', assignee: '${args.reviewer}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
     return
   }
 
@@ -169,7 +169,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assignee: "${args.assignee}", reviewer: "${args.reviewer}")
+    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -135,7 +135,7 @@ def reusePullRequest(Map args = [:]) {
     try {
       sh(script: "${args.scriptFile} '${args.stackVersion}' 'false'", label: "Prepare changes for ${args.repo}")
       if (params.DRY_RUN_MODE) {
-        log(level: 'INFO', text: "DRY-RUN: reusePullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', title: '${args.title}')")
+        log(level: 'INFO', text: "DRY-RUN: reusePullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', title: '${args.title}', assign: '${assign}', reviewer: '${reviewer}')")
         return true
       }
       withEnv(["REPO_NAME=${args.repo}"]){

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -89,7 +89,9 @@ def generateSteps(Map args = [:]) {
                        scriptFile: "${project.script}",
                        branch: env.BRANCH,
                        reusePullRequest: project.get('reusePullRequest', false),
-                       labels: project.get('labels', ''))
+                       labels: project.get('labels', ''),
+                       assignee: project.get('assignee', ''),
+                       reviewer: project.get('reviewer', ''))
     }
   }
 }
@@ -111,6 +113,8 @@ def prepareArguments(Map args = [:]){
   def branch = args.containsKey('branch') ? args.get('branch') : error('prepareArguments: branch argument is required')
   def reusePullRequest = args.get('reusePullRequest', false)
   def labels = args.get('labels', '').replaceAll('\\s','')
+  def assignee = args.get('assignee', '')
+  def reviewer = args.get('reviewer', '')
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, reusePullRequest: ${reusePullRequest}, labels: '${labels}')")
 
   def title = '[automation] update elastic stack version for testing'
@@ -121,7 +125,8 @@ def prepareArguments(Map args = [:]){
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"
   }
-  return [reusePullRequest: reusePullRequest, repo: repo, branchName: branchName, title: "${title} ${stackVersion}", labels: labels, scriptFile: scriptFile, stackVersion: stackVersion, message: message]
+  return [reusePullRequest: reusePullRequest, repo: repo, branchName: branchName, title: "${title} ${stackVersion}", labels: labels,
+          scriptFile: scriptFile, stackVersion: stackVersion, message: message, assignee: assignee, reviewer: reviewer]
 }
 
 def reusePullRequest(Map args = [:]) {
@@ -151,7 +156,7 @@ def createPullRequest(Map args = [:]) {
   }
   sh(script: "${args.scriptFile} '${args.stackVersion}' 'true'", label: "Prepare changes for ${args.repo}")
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assignee: '${args.reviewer}', assignee: '${args.reviewer}')")
     return
   }
 
@@ -164,7 +169,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}")
+    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assignee: "${args.assignee}", reviewer: "${args.reviewer}")
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -169,7 +169,16 @@ def createPullRequest(Map args = [:]) {
   }
 
   if (anyChangesToBeSubmitted("${args.branchName}")) {
-    githubCreatePullRequest(title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}", assign: "${args.assign}", reviewer: "${args.reviewer}")
+    def arguments = [
+      title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}"
+    ]
+    if (args.assign?.trim()) {
+      arguments['assign'] = args.assign
+    }
+    if (args.reviewer?.trim()) {
+      arguments['reviewer'] = args.reviewer
+    }
+    githubCreatePullRequest(arguments)
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -81,7 +81,7 @@ def generateSteps(Map args = [:]) {
             axes:[
               axis('REPO', [project.repo]),
               axis('BRANCH', project.branches),
-              axis('ENABLED', [project.get('enabled', true)])
+              axis('ENABLED', [project.get('enabled', 'true').equals('true')])
             ],
             excludes: [ axis('ENABLED', [ false ]) ]
     ) {

--- a/src/test/groovy/GithubCreatePullRequestStepTests.groovy
+++ b/src/test/groovy/GithubCreatePullRequestStepTests.groovy
@@ -92,6 +92,25 @@ class GithubCreatePullRequestStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_with_empty_assign() throws Exception {
+    script.call(title: 'foo', credentialsId: 'bar', assign: '')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "hub pull-request"))
+    assertFalse(assertMethodCallContainsPattern('sh', '--assign'))
+    assertJobStatusSuccess()
+
+  }
+
+  @Test
+  void test_with_empty_reviewer() throws Exception {
+    script.call(title: 'foo', credentialsId: 'bar', reviewer: '')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "hub pull-request"))
+    assertFalse(assertMethodCallContainsPattern('sh', '--reviewer'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_with_sh_error() throws Exception {
     helper.registerAllowedMethod('sh', [Map.class], { s ->
       if(s.script.contains('hub pull-request')) {

--- a/vars/githubCreatePullRequest.groovy
+++ b/vars/githubCreatePullRequest.groovy
@@ -30,8 +30,10 @@ def call(Map args = [:]) {
   }
   def titleValue = args.containsKey('title') ? args.title : error('githubCreatePullRequest: title parameter is required.')
   def descriptionValue = args.get('description', '')
-  def assign = args.containsKey('assign') ? "--assign ${args.assign}" : ''
-  def reviewer = args.containsKey('reviewer') ? "--reviewer ${args.reviewer}" : ''
+  def assign = args.get('assign', '')
+  assign = (assign.trim()) ? "--assign ${args.assign}" : ''
+  def reviewer = args.get('reviewer', '')
+  reviewer = (reviewer.trim()) ? "--reviewer ${args.reviewer}" : ''
   def milestone = args.containsKey('milestone') ? "--milestone ${args.milestone}" : ''
   def labels = args.containsKey('labels') ? "--labels ${args.labels}" : ''
   def draft = args.containsKey('draft') ? args.draft : false


### PR DESCRIPTION
## What does this PR do?

Set assignee and reviewer if they are defined in the configuration files, otherwise keep the same behaviour as usual.
Assign the `@observability-robots-on-call` reviewer.

**IMPORTANT**: Assignees cannot be a team but a user. While reviewers can be teams also.

## Why is it important?

More fine granularity to avoid PRs getting stalled or miss them.

Try out the `on-call` approach we discussed recently, where the person who is `on-call` will be assigned to the `on-call` github team and then all the notifications should be sent correctly as expected.

## Actions

- [x] Test it works as expected before merging them

See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-pipeline-library-mbp/detail/test%2Fchanges-assign-and-reviewers/6/pipeline) that was created to verify if `.ci/bumpStackReleaseVersion.groovy` works as expected


https://github.com/elastic/apm-integration-testing/pull/1197 was created

## Further details

Since I'm a member of `@observability-robots-on-call`

I can see the PRs that have been assigned to be reviewed in my main GitHub view in https://github.com/pulls/review-requested

![image](https://user-images.githubusercontent.com/2871786/124149579-a09d4180-da88-11eb-9d6f-2454c9cdcc6a.png)

![image](https://user-images.githubusercontent.com/2871786/124149610-ab57d680-da88-11eb-90b4-ef5daf009cc9.png)

