### PR TITLE
Enable automation for observability-test-environments

### DIFF
--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -31,7 +31,7 @@ projects:
       - edge
       - master
       - release
-    enabled: false
+    enabled: true
     labels: dependency
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh


### PR DESCRIPTION
## What does this PR do?

Enable the automation for the obs-clusters

## Why is it important?

It was disabled
