### PR TITLE
Validate elastic stack versions are available

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -168,6 +168,12 @@ def createPullRequest(Map args = [:]) {
     return
   }
 
+  // In case docker image is not available yet, let's skip the PR automation.
+  if (!isVersionAvailable(args.stackVersion)) {
+    log(level: 'INFO', text: "Version '${args.stackVersion}' is not available yet.")
+    return
+  }
+
   if (anyChangesToBeSubmitted("${args.branchName}")) {
     def arguments = [
       title: "${args.title}", labels: "${args.labels}", description: "${args.message}", base: "${args.branchName}"
@@ -182,6 +188,10 @@ def createPullRequest(Map args = [:]) {
   } else {
     log(level: 'INFO', text: "There are no changes to be submitted.")
   }
+}
+
+def isVersionAvailable(stackVersion) {
+  return dockerImageExists(image: "docker.elastic.co/elasticsearch/elasticsearch:${stackVersion}")
 }
 
 def anyChangesToBeSubmitted(String branch) {


### PR DESCRIPTION
## What does this PR do?

Validate if the docker images are accessible. Test at least elasticsearch, though we might need to validate kibana too and apm-server

## Why is it important?

Avoid creating PRs https://github.com/elastic/apm-integration-testing/pull/1198 that should not be created if those docker images are not available yet.

```
[2021-07-05T15:15:32.362Z] ERROR: for elasticsearch  manifest for docker.elastic.co/elasticsearch/elasticsearch:7.13.3 not found: manifest unknown: manifest unknown
```
