### PR TITLE
[test-infra] disable worker-c07c6107jyw0 and use docker-machine if possible

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -73,7 +73,7 @@ pipeline {
               'immutable && windows-7',
               'ubuntu-18',
               'ubuntu-20',
-              'worker-c07c6107jyw0',
+              // 'worker-c07c6107jyw0', 10.15.7 has docker desktop and it gets stalled
               'worker-c07jc1nzdwym',
               'worker-c07l34n6dwym',
               'worker-c07y20b6jyvy',

--- a/resources/scripts/jenkins/beats-ci/test-mac.sh
+++ b/resources/scripts/jenkins/beats-ci/test-mac.sh
@@ -23,9 +23,11 @@ virtualenv venv
 source venv/bin/activate
 pip install testinfra
 
-## Prepare the docker for mac
-docker-machine start default || true
-eval "$(docker-machine env default)"
+## Prepare the docker for mac if docker-machine is installed
+if command -v docker-machine ; then
+  docker-machine start default || true
+  eval "$(docker-machine env default)"
+fi
 set -x
 
 ## Run test-infra and trap error to notify when required


### PR DESCRIPTION
## What does this PR do?

Disable MacOS worker with some docker environmental issues

## Why is it important?

When using docker https://beats-ci.elastic.co/computer/worker-c07c6107jyw0/ gets stalled 

## Related issues
Relates https://github.com/elastic/beats/pull/26789
