### PR TITLE
[bump][pinned][version] Validate snapshot versions

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -191,6 +191,8 @@ def createPullRequest(Map args = [:]) {
 }
 
 def isVersionAvailable(stackVersion) {
+  // pinned snapshot versions use -SNAPSHOT suffix.
+  def version = stackVersion.endsWith('SNAPSHOT') ? stackVersion : "${stackVersion}-SNAPSHOT"
   return dockerImageExists(image: "docker.elastic.co/elasticsearch/elasticsearch:${stackVersion}")
 }
 


### PR DESCRIPTION
## What does this PR do?

Pinned snapshot versions use -SNAPSHOT suffix, while the version retrieved does not contain the SNAPSHOT suffix, let's ensure it's there otherwise the validation will report the docker image is not yet available.

## Why is it important?

Otherwise the automation won't work

![image](https://user-images.githubusercontent.com/2871786/124970372-ba59fe00-e01f-11eb-8caa-71563949d61c.png)

Build logs https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fbump-stack-version-pipeline/detail/bump-stack-version-pipeline/67/pipeline/59 for a wrong validation
