### PR TITLE
[automation] Update go release version 1.16.6

### DIFF
--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -38,5 +38,5 @@ def isGoVersionEnvVarSet(){
 }
 
 def defaultVersion(){
-  return '1.16.5'
+  return '1.16.6'
 }


### PR DESCRIPTION
### What 
 Bump go release version with the latest release. 
 ### Further details 
 1.16.6

### Issues

Blocked by https://github.com/elastic/beats/pull/26860