### PR TITLE
fix: set BUILD_TS_REFS_DISABLE=true

### DIFF
--- a/resources/scripts/build-kibana-docker-image.sh
+++ b/resources/scripts/build-kibana-docker-image.sh
@@ -27,6 +27,7 @@ unset NVM_DIR
 export BABEL_DISABLE_CACHE=true
 export FORCE_COLOR=1
 export NODE_OPTIONS=" --max-old-space-size=4096"
+export BUILD_TS_REFS_DISABLE="true"
 
 if [ -z "$(command -v nvm)" ]; then
   curl -Sso- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash


### PR DESCRIPTION
## What does this PR do?

* set BUILD_TS_REFS_DISABLE=true

## Why is it important?

it fixes the issue 

```
[2021-07-08T23:50:54.174Z] ERROR [bootstrap] failed:
[2021-07-08T23:50:54.174Z] ERROR Error: Command failed with exit code 1: /var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/.nvm/versions/node/v14.17.3/lib/node_modules/yarn/bin/yarn.js run kbn:bootstrap
[2021-07-08T23:50:54.174Z]       error Command failed with exit code 1.
[2021-07-08T23:50:54.174Z]       $ node scripts/build_ts_refs --ignore-type-failures
[2021-07-08T23:50:54.174Z]        info ensuring we have the latest changelog from upstream master
[2021-07-08T23:50:54.174Z]        info determining merge base with upstream
[2021-07-08T23:50:54.174Z]       ERROR UNHANDLED ERROR
[2021-07-08T23:50:54.174Z]       ERROR Error: Command failed with exit code 1: git merge-base HEAD FETCH_HEAD
[2021-07-08T23:50:54.174Z]                 at makeError (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/node_modules/execa/lib/error.js:59:11)
[2021-07-08T23:50:54.174Z]                 at handlePromise (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/node_modules/execa/index.js:114:26)
[2021-07-08T23:50:54.174Z]                 at processTicksAndRejections (internal/process/task_queues.js:95:5)
[2021-07-08T23:50:54.174Z]                 at RepoInfo.git (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/src/dev/typescript/ref_output_cache/repo_info.ts:49:18)
[2021-07-08T23:50:54.174Z]                 at RepoInfo.getMergeBase (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/src/dev/typescript/ref_output_cache/repo_info.ts:34:23)
[2021-07-08T23:50:54.174Z]                 at Function.create (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/src/dev/typescript/ref_output_cache/ref_output_cache.ts:60:23)
[2021-07-08T23:50:54.174Z]                 at description (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/src/dev/typescript/build_ts_refs_cli.ts:53:23)
[2021-07-08T23:50:54.175Z]                 at /var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/node_modules/packages/kbn-dev-utils/src/run/run.ts:63:7
[2021-07-08T23:50:54.175Z]                 at Object.withProcRunner (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/node_modules/packages/kbn-dev-utils/src/proc_runner/with_proc_runner.ts:28:5)
[2021-07-08T23:50:54.175Z]                 at run (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/node_modules/packages/kbn-dev-utils/src/run/run.ts:62:5)
[2021-07-08T23:50:54.175Z]       info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[2021-07-08T23:50:54.175Z]           at makeError (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/packages/kbn-pm/dist/index.js:35184:11)
[2021-07-08T23:50:54.175Z]           at handlePromise (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/packages/kbn-pm/dist/index.js:34095:26)
[2021-07-08T23:50:54.175Z]           at runMicrotasks (<anonymous>)
[2021-07-08T23:50:54.175Z]           at processTicksAndRejections (internal/process/task_queues.js:95:5)
[2021-07-08T23:50:54.175Z]           at async /var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/packages/kbn-pm/dist/index.js:9022:9
[2021-07-08T23:50:54.175Z]           at async scheduleItem (/var/lib/jenkins/workspace/apm-shared/oblt-test-env/custom-kibana-deploy/src/github.com/elastic/kibana/build/packages/kbn-pm/dist/index.js:22732:9)
[2021-07-08T23:50:54.175Z] error Command failed with exit code 1.
```
