### PR TITLE
Remove retry param from gitCheckout

### DIFF
--- a/vars/README.md
+++ b/vars/README.md
@@ -772,7 +772,6 @@ gitCheckout(basedir: 'sub-folder', branch: 'master',
 * *githubNotifyFirstTimeContributor*: Whether to notify the status if first time contributor. Default: false
 * *shallow*: Whether to enable the shallow cloning. Default: false
 * *depth*: Set shallow clone depth. Default: 5
-* *retry*: Set the number of retries if there are issues when cloning. Default: 3
 
 _NOTE_: 'shallow' is forced to be disabled when running on Pull Requests
 
@@ -3054,7 +3053,7 @@ _NOTE:_
 
 ## withNode
 Wrap the node call for three reasons:
-  1. with some latency to avoid the known issue with the scalability in gobld.
+  1. with some latency to avoid the known issue with the scalability in gobld. It requires sleepMax > 0
   2. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
   3. allocate a new workspace to workaround the flakiness of windows workers with deleteDir.
 
@@ -3072,8 +3071,8 @@ Wrap the node call for three reasons:
 ```
 
 * labels: what's the labels to be used. Mandatory
-* sleepMin: whether to sleep and for how long at least. Optional.
-* sleepMax: whether to sleep and for how long maximum. Optional.
+* sleepMin: whether to sleep and for how long at least. Optional. By default `0`
+* sleepMax: whether to sleep and for how long maximum. Optional. By default `0`
 * forceWorker: whether to allocate a new unique ephemeral worker. Optional. Default false
 * forceWorkspace: whether to allocate a new unique workspace. Optional. Default false
 * disableWorkers: whether to skip the run if the labels match one of the flaky workers. Default false

--- a/vars/gitCheckout.groovy
+++ b/vars/gitCheckout.groovy
@@ -40,7 +40,6 @@ def call(Map args = [:]){
   def notify = args.containsKey('githubNotifyFirstTimeContributor') ? args.get('githubNotifyFirstTimeContributor') : false
   def shallowValue = args.containsKey('shallow') ? args.get('shallow') : false
   def depthValue = args.containsKey('depth') ? args.get('depth') : 5
-  def retryValue = args.containsKey('retry') ? args.get('retry') : 3
   def refspec = '+refs/pull/*/head:refs/remotes/origin/pr/*'
   def noTags = args.containsKey('noTags') ? args.get('noTags') : false
 

--- a/vars/gitCheckout.txt
+++ b/vars/gitCheckout.txt
@@ -29,6 +29,5 @@ gitCheckout(basedir: 'sub-folder', branch: 'master',
 * *githubNotifyFirstTimeContributor*: Whether to notify the status if first time contributor. Default: false
 * *shallow*: Whether to enable the shallow cloning. Default: false
 * *depth*: Set shallow clone depth. Default: 5
-* *retry*: Set the number of retries if there are issues when cloning. Default: 3
 
 _NOTE_: 'shallow' is forced to be disabled when running on Pull Requests


### PR DESCRIPTION

## What does this PR do?

retry param is not needed/used, in fact, it's now delegated to the built-in git/checkout steps

## Why is it important?

It was a leftover from https://github.com/elastic/apm-pipeline-library/pull/352


## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1205
