### PR TITLE
Fix Nexus integration

### DIFF
--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -28,12 +28,14 @@ private static HttpURLConnection createConnection(String baseUrl, String usernam
     String creds = "${username}:${password}"
     URL url = new URL("${baseUrl}/${path}")
     HttpURLConnection conn = (HttpURLConnection)url.openConnection()
-    conn.addRequestProperty("Authorization", "Basic " + new String(Base64.encoder.encode(creds.getBytes())))
+    String encoded_auth = new String(Base64.encoder.encode(creds.getBytes()))
+    conn.addRequestProperty("Authorization", "Basic ${encoded_auth}"
     conn.addRequestProperty("Accept", "application/json")
     System.out.println(baseUrl);
     System.out.println(username);
     System.out.println(password);
     System.out.println(path);
+    System.out.println(encoded_auth);
     return conn
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -55,7 +55,7 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
-    Object data = null;
+    // Object data = null;
 	BufferedReader in = new BufferedReader(new InputStreamReader(
 			conn.getInputStream()));
 	String inputLine;
@@ -69,9 +69,9 @@ private static Object getData(HttpURLConnection conn) {
 	// print result
 	System.out.println(response.toString());
 
-    conn.inputStream.withReader('UTF-8') { Reader reader ->
-        data = new JsonSlurperClassic().parse(reader)
-    }
+    // conn.inputStream.withReader('UTF-8') { Reader reader ->
+    //     data = new JsonSlurperClassic().parse(reader)
+    // }
     return data
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -29,7 +29,7 @@ private static HttpURLConnection createConnection(String baseUrl, String usernam
     URL url = new URL("${baseUrl}/${path}")
     HttpURLConnection conn = (HttpURLConnection)url.openConnection()
     String encoded_auth = new String(Base64.encoder.encode(creds.getBytes()))
-    conn.addRequestProperty("Authorization", "Basic ${encoded_auth}"
+    conn.addRequestProperty("Authorization", "Basic ${encoded_auth}")
     conn.addRequestProperty("Accept", "application/json")
     System.out.println(baseUrl);
     System.out.println(username);

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -54,6 +54,19 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 private static Object getData(HttpURLConnection conn) {
     Object data = null
     conn.inputStream.withReader('UTF-8') { Reader reader -> System.out.println(reader)}
+	BufferedReader in = new BufferedReader(new InputStreamReader(
+			conn.getInputStream()));
+	String inputLine;
+	StringBuffer response = new StringBuffer();
+
+	while ((inputLine = in.readLine()) != null) {
+		response.append(inputLine);
+	}
+	in.close();
+
+	// print result
+	System.out.println(response.toString());
+
     conn.inputStream.withReader('UTF-8') { Reader reader ->
         data = new JsonSlurperClassic().parse(reader)
     }

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -34,11 +34,6 @@ private static HttpURLConnection createConnection(String baseUrl, String usernam
     String encoded_auth = new String(Base64.encoder.encode(creds.getBytes()))
     conn.addRequestProperty("Authorization", "Basic ${encoded_auth}")
     conn.addRequestProperty("Accept", "application/json")
-    System.out.println(baseUrl);
-    System.out.println(username);
-    System.out.println(password);
-    System.out.println(path);
-    System.out.println(encoded_auth);
     return conn
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -60,7 +60,7 @@ private static Object getData(HttpURLConnection conn) {
 	String inputLine;
 	StringBuffer response = new StringBuffer();
 
-	while ((inputLine = in.readLine()) != null) {
+	while ((inputLine = inpt.readLine()) != null) {
 		response.append(inputLine);
 	}
 	inpt.close();

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -66,6 +66,7 @@ private static Object getData(HttpURLConnection conn) {
 
 	// print result
 	System.out.println(response.toString());
+    }   
 
     conn.inputStream.withReader('UTF-8') { Reader reader ->
         data = new JsonSlurperClassic().parse(reader)

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -30,6 +30,10 @@ private static HttpURLConnection createConnection(String baseUrl, String usernam
     HttpURLConnection conn = (HttpURLConnection)url.openConnection()
     conn.addRequestProperty("Authorization", "Basic " + new String(Base64.encoder.encode(creds.getBytes())))
     conn.addRequestProperty("Accept", "application/json")
+    System.out.println(baseUrl);
+    System.out.println(username);
+    System.out.println(password);
+    System.out.println(path);
     return conn
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -22,6 +22,9 @@ import java.net.HttpURLConnection
 import java.security.MessageDigest
 import java.util.Base64
 
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
 import groovy.json.JsonSlurperClassic
 
 private static HttpURLConnection createConnection(String baseUrl, String username, String password, String path) {

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -51,9 +51,7 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
     Object data = null;
-
     String response = conn.getInputStream().getText('UTF-8') 
-	System.out.println(response)
     def slurper = new groovy.json.JsonSlurperClassic()
     data = slurper.parseText(response)
     return data

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -53,6 +53,7 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
     Object data = null
+    conn.inputStream.withReader('UTF-8') { Reader reader -> System.out.println(reader)}
     conn.inputStream.withReader('UTF-8') { Reader reader ->
         data = new JsonSlurperClassic().parse(reader)
     }

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -53,7 +53,6 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
     Object data = null
-    conn.inputStream.withReader('UTF-8') { Reader reader -> System.out.println(reader)}
 	BufferedReader in = new BufferedReader(new InputStreamReader(
 			conn.getInputStream()));
 	String inputLine;

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -56,16 +56,9 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
     Object data = null;
-	BufferedReader inpt = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-	String inputLine;
-	StringBuffer response = new StringBuffer();
 
-	while ((inputLine = inpt.readLine()) != null) {
-		response.append(inputLine);
-	}
-	inpt.close();
-
-	System.out.println(response.toString());
+    String response = conn.getInputStream().getText('UTF-8') 
+	System.out.println(response)
 
 //     // conn.inputStream.withReader('UTF-8') { Reader reader ->
 //     //     data = new JsonSlurperClassic().parse(reader)

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -55,23 +55,21 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
-    // Object data = null;
-	BufferedReader in = new BufferedReader(new InputStreamReader(
-			conn.getInputStream()));
+    Object data = null;
+	BufferedReader inpt = new BufferedReader(new InputStreamReader(conn.getInputStream()));
 	String inputLine;
 	StringBuffer response = new StringBuffer();
 
 	while ((inputLine = in.readLine()) != null) {
 		response.append(inputLine);
 	}
-	in.close();
+	inpt.close();
 
-	// print result
 	System.out.println(response.toString());
 
-    // conn.inputStream.withReader('UTF-8') { Reader reader ->
-    //     data = new JsonSlurperClassic().parse(reader)
-    // }
+//     // conn.inputStream.withReader('UTF-8') { Reader reader ->
+//     //     data = new JsonSlurperClassic().parse(reader)
+//     // }
     return data
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -59,10 +59,8 @@ private static Object getData(HttpURLConnection conn) {
 
     String response = conn.getInputStream().getText('UTF-8') 
 	System.out.println(response)
-
-//     // conn.inputStream.withReader('UTF-8') { Reader reader ->
-//     //     data = new JsonSlurperClassic().parse(reader)
-//     // }
+    def slurper = new groovy.json.JsonSlurperClassic()
+    data = slurper.parseText(response)
     return data
 }
 

--- a/src/co/elastic/Nexus.groovy
+++ b/src/co/elastic/Nexus.groovy
@@ -52,7 +52,7 @@ private static void addData(HttpURLConnection conn, String method, byte[] bytes)
 
 // make the request, and parse the response as json
 private static Object getData(HttpURLConnection conn) {
-    Object data = null
+    Object data = null;
 	BufferedReader in = new BufferedReader(new InputStreamReader(
 			conn.getInputStream()));
 	String inputLine;
@@ -65,7 +65,6 @@ private static Object getData(HttpURLConnection conn) {
 
 	// print result
 	System.out.println(response.toString());
-    }   
 
     conn.inputStream.withReader('UTF-8') { Reader reader ->
         data = new JsonSlurperClassic().parse(reader)

--- a/src/test/groovy/NexusFindStagingIdTests.groovy
+++ b/src/test/groovy/NexusFindStagingIdTests.groovy
@@ -30,9 +30,9 @@ class NexusFindStagingIdTests extends ApmBasePipelineTest {
     return """
     {
       "data": [{
-        "description": "coelasticapm-1010",
-          "type": "open",
-          "repositoryId": "my id"
+        "repositoryId": "coelasticapm-1010",
+         "type": "open",
+         "description": "my description"
         }]
     }
     """
@@ -82,9 +82,8 @@ class NexusFindStagingIdTests extends ApmBasePipelineTest {
     def ret = script.call(
       url: 'http://localhost:9999',
       stagingProfileId: 'pid',
-      secret: '/nexus/production',
       groupId: 'co.elastic.apm')
-    assertTrue(ret.equals('my id'))
+    assertTrue(ret.equals('coelasticapm-1010'))
   }
 
   @Test

--- a/vars/nexusCloseStagingRepository.groovy
+++ b/vars/nexusCloseStagingRepository.groovy
@@ -108,15 +108,6 @@ def call(Map args = [:]){
               }
           }
           Exception exception = new Exception(msg.join('\n'))
-          conn = Nexus.createConnection(url, username, password, "profiles/${stagingProfileId}/drop")
-          data = toJSON(['data': ['stagedRepositoryId': stagingId]])
-          Nexus.addData(conn, 'POST', data.getBytes('UTF-8'))
-          try {
-              Nexus.checkResponse(conn, 201)
-          } catch (Exception dropFailure) {
-              exception.addSuppressed(dropFailure)
-          }
-
           throw exception
       }
 

--- a/vars/nexusCloseStagingRepository.groovy
+++ b/vars/nexusCloseStagingRepository.groovy
@@ -20,7 +20,6 @@
 
   nexusCloseStagingRepository
     url: "https://oss.sonatype.org",
-    secret: "secret/release/nexus",
     stagingProfileId: "comexampleapplication-1010",
     stagingId: "staging_id"
     username: "nexus"
@@ -35,7 +34,6 @@ def call(Map args = [:]){
   String url = args.get('url', 'https://oss.sonatype.org')
   String username = args.get('username')
   String password = args.get('password')
-  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
   String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String groupId = args.containsKey('stagingId') ? args.groupId : error('Must supply groupId')

--- a/vars/nexusCloseStagingRepository.txt
+++ b/vars/nexusCloseStagingRepository.txt
@@ -10,6 +10,8 @@ nexusCreateStagingRepository(
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
+* username: The username to auth to the repository
+* password: The password to auth to the repository
 * secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging

--- a/vars/nexusCloseStagingRepository.txt
+++ b/vars/nexusCloseStagingRepository.txt
@@ -3,7 +3,6 @@ Close a Nexus staging repository
 ```
 nexusCreateStagingRepository(
   url: "https://oss.sonatype.org",
-  secret: "secret/release/nexus"
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "staging_id"
   )
@@ -12,7 +11,6 @@ nexusCreateStagingRepository(
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * username: The username to auth to the repository
 * password: The password to auth to the repository
-* secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
 

--- a/vars/nexusCloseStagingRepository.txt
+++ b/vars/nexusCloseStagingRepository.txt
@@ -4,13 +4,19 @@ Close a Nexus staging repository
 nexusCreateStagingRepository(
   url: "https://oss.sonatype.org",
   stagingProfileId: "comexampleapplication-1010",
-  stagingId: "staging_id"
+  stagingId: "staging_id",
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
   )
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
+* secret: Vault secret (Optional)
+* role_id: vault role ID (Optional)
+* secret_id: vault secret ID (Optional)
 
 
 [Nexus staging documentation](https://help.sonatype.com/repomanager2/staging-releases)

--- a/vars/nexusCloseStagingRepository.txt
+++ b/vars/nexusCloseStagingRepository.txt
@@ -9,8 +9,6 @@ nexusCreateStagingRepository(
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
-* username: The username to auth to the repository
-* password: The password to auth to the repository
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
 

--- a/vars/nexusCreateStagingRepository.groovy
+++ b/vars/nexusCreateStagingRepository.groovy
@@ -29,10 +29,21 @@ import net.sf.json.JSONArray
 
 def call(Map args = [:]){
   String url = args.get('url', 'https://oss.sonatype.org')
-  String username = args.get('username')
-  String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String description = args.containsKey('description') ? args.description : error('Must supply description')
+  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
+  String role_id = args.containsKey('role_id') ? args.role_id : 'apm-vault-role-id'
+  String secret_id = args.containsKey('secret_id') ? args.secret_id : 'apm-vault-secret-id'
+
+  def props = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
+
+  if(props?.errors){
+    error "Unable to get credentials from the vault: " + props.errors.toString()
+  }
+
+  def vault_data = props?.data
+  def username = vault_data?.username
+  def password = vault_data?.password
 
   int retries = args.get('retries', 20)
 
@@ -41,7 +52,11 @@ def call(Map args = [:]){
   int attemptNumber = 0
 
   while (attemptNumber <= retries) {
-      conn = Nexus.createConnection(Nexus.getStagingURL(url), username, password, "profiles/${stagingProfileId}/start")
+      withEnvMask(vars: [
+      [var: "NEXUS_username", password: username],
+      [var: "NEXUS_password", password: password]    ]){
+        conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, ,env.NEXUS_password, "profiles/${stagingProfileId}/start")
+      }
       Nexus.addData(conn, 'POST', data.getBytes('UTF-8'))
       if (Nexus.is5xxError(conn.responseCode)) {
           log(level: "WARN", text: "Received a ${conn.responseCode} HTTP response code while trying to create a staging repository in nexus, trying again.")
@@ -63,10 +78,18 @@ def call(Map args = [:]){
   // Reset retry counter
   attemptNumber = 0
   
-  conn = Nexus.createConnection(Nexus.getStagingURL(url), username, password, "repository/${stagingId}")
+  withEnvMask(vars: [
+  [var: "NEXUS_username", password: username],
+  [var: "NEXUS_password", password: password]    ]){
+    conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, env.NEXUS_password, "repository/${stagingId}")
+  }
   while (conn.responseCode != 200 && attemptNumber <= retries) {
       Thread.sleep(500)
-      conn = Nexus.createConnection(Nexus.getStagingURL(url), username, password, "repository/${stagingId}")
+      withEnvMask(vars: [
+      [var: "NEXUS_username", password: username],
+      [var: "NEXUS_password", password: password]    ]){
+        conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, env.NEXUS_password, "repository/${stagingId}")
+      }
   }
 
   return stagingId

--- a/vars/nexusCreateStagingRepository.groovy
+++ b/vars/nexusCreateStagingRepository.groovy
@@ -22,7 +22,6 @@
     stagingProfileId: my_profile,
     description: "My new staging repo")
     stagingProfileId: "foo-bar-baz"
-    secret: "secret/release/nexus"
 **/
 
 import co.elastic.Nexus
@@ -34,7 +33,6 @@ def call(Map args = [:]){
   String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String description = args.containsKey('description') ? args.description : error('Must supply description')
-  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
 
   int retries = args.get('retries', 20)
 

--- a/vars/nexusCreateStagingRepository.groovy
+++ b/vars/nexusCreateStagingRepository.groovy
@@ -55,7 +55,7 @@ def call(Map args = [:]){
       withEnvMask(vars: [
       [var: "NEXUS_username", password: username],
       [var: "NEXUS_password", password: password]    ]){
-        conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, ,env.NEXUS_password, "profiles/${stagingProfileId}/start")
+        conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, env.NEXUS_password, "profiles/${stagingProfileId}/start")
       }
       Nexus.addData(conn, 'POST', data.getBytes('UTF-8'))
       if (Nexus.is5xxError(conn.responseCode)) {

--- a/vars/nexusCreateStagingRepository.txt
+++ b/vars/nexusCreateStagingRepository.txt
@@ -5,16 +5,12 @@ nexusCreateStagingRepository(
   stagingProfileId: my_profile,
   description: "My new staging repo",
   url: https://oss.sonatype.org,
-  username: nexus
-  password: my_password
   retries: 20
 ```
 
 * stagingProfileId: The staging identifier to use when creating the repository
 * description: A description of the new staging repository
 * url: Nexus URL (default: https://oss.sonatype.org)
-* username: The username to auth to the repository
-* password: The password to auth to the repository
 * retries: Number of times to retry the remote API before giving up
 
 

--- a/vars/nexusCreateStagingRepository.txt
+++ b/vars/nexusCreateStagingRepository.txt
@@ -4,7 +4,6 @@ Create a Nexus staging repository
 nexusCreateStagingRepository(
   stagingProfileId: my_profile,
   description: "My new staging repo",
-  secret: "secret/release/nexus",
   url: https://oss.sonatype.org,
   username: nexus
   password: my_password
@@ -13,7 +12,6 @@ nexusCreateStagingRepository(
 
 * stagingProfileId: The staging identifier to use when creating the repository
 * description: A description of the new staging repository
-* secret: Vault secret to retrieve Nexus credentials
 * url: Nexus URL (default: https://oss.sonatype.org)
 * username: The username to auth to the repository
 * password: The password to auth to the repository

--- a/vars/nexusCreateStagingRepository.txt
+++ b/vars/nexusCreateStagingRepository.txt
@@ -6,6 +6,8 @@ nexusCreateStagingRepository(
   description: "My new staging repo",
   secret: "secret/release/nexus",
   url: https://oss.sonatype.org,
+  username: nexus
+  password: my_password
   retries: 20
 ```
 
@@ -13,6 +15,8 @@ nexusCreateStagingRepository(
 * description: A description of the new staging repository
 * secret: Vault secret to retrieve Nexus credentials
 * url: Nexus URL (default: https://oss.sonatype.org)
+* username: The username to auth to the repository
+* password: The password to auth to the repository
 * retries: Number of times to retry the remote API before giving up
 
 

--- a/vars/nexusCreateStagingRepository.txt
+++ b/vars/nexusCreateStagingRepository.txt
@@ -5,13 +5,19 @@ nexusCreateStagingRepository(
   stagingProfileId: my_profile,
   description: "My new staging repo",
   url: https://oss.sonatype.org,
-  retries: 20
+  retries: 20,
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
 ```
 
 * stagingProfileId: The staging identifier to use when creating the repository
 * description: A description of the new staging repository
 * url: Nexus URL (default: https://oss.sonatype.org)
 * retries: Number of times to retry the remote API before giving up
+* secret: Vault secret (Optional)
+* role_id: vault role ID (Optional)
+* secret_id: vault secret ID (Optional)
 
 
 [Nexus staging documentation](https://help.sonatype.com/repomanager2/staging-releases)

--- a/vars/nexusDropStagingRepository.groovy
+++ b/vars/nexusDropStagingRepository.groovy
@@ -29,10 +29,21 @@ import net.sf.json.JSONArray
 
 def call(Map args = [:]) {
     String url = args.get('url', 'https://oss.sonatype.org')
-    String username = args.get('username')
-    String password = args.get('password')
     String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
     String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
+    String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
+    String role_id = args.containsKey('role_id') ? args.role_id : 'apm-vault-role-id'
+    String secret_id = args.containsKey('secret_id') ? args.secret_id : 'apm-vault-secret-id'
+
+    def props = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
+
+    if(props?.errors){
+      error "Unable to get credentials from the vault: " + props.errors.toString()
+    }
+
+    def vault_data = props?.data
+    def username = vault_data?.username
+    def password = vault_data?.password
   
     String data = toJSON(['data': ['stagedRepositoryId': stagingId]])
     HttpURLConnection conn
@@ -40,7 +51,11 @@ def call(Map args = [:]) {
     int attemptNumber = 0
 
     while (attemptNumber < retries) {
-        conn = Nexus.createConnection(Nexus.getStagingURL(url), username, password, "profiles/${stagingProfileId}/drop")
+        withEnvMask(vars: [
+        [var: "NEXUS_username", password: username],
+        [var: "NEXUS_password", password: password]    ]){
+            conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, env.NEXUS_password, "profiles/${stagingProfileId}/drop")
+        }
         Nexus.addData(conn, 'POST', data.getBytes('UTF-8'))
         if (Nexus.is5xxError(conn.responseCode)) {
             log(level: "WARN", text: "Received a ${conn.responseCode} HTTP response code while trying to drop a staging repository in nexus, trying again.")

--- a/vars/nexusDropStagingRepository.groovy
+++ b/vars/nexusDropStagingRepository.groovy
@@ -20,7 +20,6 @@
 
   nexusDropStagingRepository(
     url: "https://oss.sonatype.org",
-    secret: "secret/release/nexus"
     stagingProfileId: "comexampleapplication-1010",
     stagingId: "staging_id"
     )
@@ -34,7 +33,6 @@ def call(Map args = [:]) {
     String password = args.get('password')
     String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
     String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
-    String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
   
     String data = toJSON(['data': ['stagedRepositoryId': stagingId]])
     HttpURLConnection conn

--- a/vars/nexusDropStagingRepository.txt
+++ b/vars/nexusDropStagingRepository.txt
@@ -2,16 +2,12 @@ Drop a Nexus staging repository
 ```
 nexusDropStagingRepository(
   url: "https://oss.sonatype.org",
-  username: nexus,
-  password: my_password,
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "staging_id",
   )
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
-* username: The username to auth to the repository
-* password: The password to auth to the repository
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
 

--- a/vars/nexusDropStagingRepository.txt
+++ b/vars/nexusDropStagingRepository.txt
@@ -2,6 +2,8 @@ Drop a Nexus staging repository
 ```
 nexusDropStagingRepository(
   url: "https://oss.sonatype.org",
+  username: nexus,
+  password: my_password,
   secret: "secret/release/nexus",
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "staging_id",
@@ -9,6 +11,8 @@ nexusDropStagingRepository(
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
+* username: The username to auth to the repository
+* password: The password to auth to the repository
 * secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging

--- a/vars/nexusDropStagingRepository.txt
+++ b/vars/nexusDropStagingRepository.txt
@@ -4,7 +4,6 @@ nexusDropStagingRepository(
   url: "https://oss.sonatype.org",
   username: nexus,
   password: my_password,
-  secret: "secret/release/nexus",
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "staging_id",
   )
@@ -13,7 +12,6 @@ nexusDropStagingRepository(
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * username: The username to auth to the repository
 * password: The password to auth to the repository
-* secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
 

--- a/vars/nexusDropStagingRepository.txt
+++ b/vars/nexusDropStagingRepository.txt
@@ -4,12 +4,18 @@ nexusDropStagingRepository(
   url: "https://oss.sonatype.org",
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "staging_id",
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
   )
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier for staging
+* secret: Vault secret (Optional)
+* role_id: vault role ID (Optional)
+* secret_id: vault secret ID (Optional)
 
 
 [Nexus staging documentation](https://help.sonatype.com/repomanager2/staging-releases)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -23,6 +23,8 @@
     secret: "secret/release/nexus"
     stagingProfileId: "1234-1455-1242",
     groupId: co.elastic.apm
+    username: nexus
+    password: my_password
     )
 **/
 import co.elastic.Nexus
@@ -35,20 +37,9 @@ def call(Map args = [:]) {
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
   String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
 
-  //def props = getVaultSecret(secret: secret)
-
-  //if(props?.errors){
-  //  error "Unable to get credentials from the vault: " + props.errors.toString()
-  //}
-
-  //def data = props?.data
-  //def username = data?.username
-  //def password = data?.password
-  
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)
-  // conn = Nexus.createConnection(stagingURL, env.NEXUS_username, env.NEXUS_password, "profile_repositories/${stagingProfileId}")
   conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
   Nexus.checkResponse(conn, 200)
   Object response = Nexus.getData(conn)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -36,15 +36,7 @@ def call(Map args = [:]) {
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
   String role_id = args.get('role_id')
   String secret_id = args.get('secret_id')
-
-  def HttpURLConnection conn
-  String stagingURL = Nexus.getStagingURL(url)
-  conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
-  Nexus.checkResponse(conn, 200)
-  Object response = Nexus.getData(conn)
-  String repositoryId = null
-  String mungeGroupId = groupId.replace(".", "")
-
+  
   def props = getVaultSecret(secret: secret, role_id, secret_id)
 
   if(props?.errors){
@@ -54,6 +46,15 @@ def call(Map args = [:]) {
   def data = props?.data
   def username = data?.username
   def password = data?.password
+
+  def HttpURLConnection conn
+  String stagingURL = Nexus.getStagingURL(url)
+  conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
+  Nexus.checkResponse(conn, 200)
+  Object response = Nexus.getData(conn)
+  String repositoryId = null
+  String mungeGroupId = groupId.replace(".", "")
+
 
 
   for (def repository : response['data']) {

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -36,7 +36,8 @@ def call(Map args = [:]) {
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
   String role_id = args.get('role_id')
   String secret_id = args.get('secret_id')
-  
+  String secret = args.get('secret')
+
   def props = getVaultSecret(secret: secret, role_id, secret_id)
 
   if(props?.errors){

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -22,7 +22,6 @@
     url: "https://oss.sonatype.org",
     stagingProfileId: "1234-1455-1242",
     groupId: co.elastic.apm
-    secret: /my/vault/secret
     )
 **/
 import co.elastic.Nexus
@@ -41,9 +40,9 @@ def call(Map args = [:]) {
     error "Unable to get credentials from the vault: " + props.errors.toString()
   }
 
-  def data = props?.data
-  def username = data?.username
-  def password = data?.password
+  def vault_data = props?.data
+  def username = vault_data?.username
+  def password = vault_data?.password
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -44,6 +44,7 @@ def call(Map args = [:]) {
   //def data = props?.data
   //def username = data?.username
   //def password = data?.password
+  
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -34,7 +34,8 @@ def call(Map args = [:]) {
   String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
-
+  String role_id = args.get('role_id')
+  String secret_id = args.get('secret_id')
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)
@@ -43,6 +44,17 @@ def call(Map args = [:]) {
   Object response = Nexus.getData(conn)
   String repositoryId = null
   String mungeGroupId = groupId.replace(".", "")
+
+  def props = getVaultSecret(secret: secret, role_id, secret_id)
+
+  if(props?.errors){
+    error "Unable to get credentials from the vault: " + props.errors.toString()
+  }
+
+  def data = props?.data
+  def username = data?.username
+  def password = data?.password
+
 
   for (def repository : response['data']) {
       // We can't look for the description if we didn't actually open the staging repo

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -38,7 +38,7 @@ def call(Map args = [:]) {
   String secret_id = args.get('secret_id')
   String secret = args.get('secret')
 
-  def props = getVaultSecret(secret: secret, role_id, secret_id)
+  def props = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
 
   if(props?.errors){
     error "Unable to get credentials from the vault: " + props.errors.toString()

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -51,7 +51,7 @@ def call(Map args = [:]) {
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)
   System.println(username)
-  System.prinln(stagingURL)
+  System.println(stagingURL)
   conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
   Nexus.checkResponse(conn, 200)
   Object response = Nexus.getData(conn)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -30,8 +30,8 @@ import co.elastic.Nexus
 
 def call(Map args = [:]) {
   String url = args.get('url', 'https://oss.sonatype.org')
-  String username = args.get('username')
-  String password = args.get('password')
+//   String username = args.get('username')
+//   String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
   String role_id = args.get('role_id')

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -29,19 +29,21 @@ import co.elastic.Nexus
 
 def call(Map args = [:]) {
   String url = args.get('url', 'https://oss.sonatype.org')
+  String username = args.get('username')
+  String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
   String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
 
-  def props = getVaultSecret(secret: secret)
+  //def props = getVaultSecret(secret: secret)
 
-  if(props?.errors){
-    error "Unable to get credentials from the vault: " + props.errors.toString()
-  }
+  //if(props?.errors){
+  //  error "Unable to get credentials from the vault: " + props.errors.toString()
+  //}
 
-  def data = props?.data
-  def username = data?.username
-  def password = data?.password
+  //def data = props?.data
+  //def username = data?.username
+  //def password = data?.password
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -48,11 +48,8 @@ def call(Map args = [:]) {
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)
-  withEnvMask(vars: [
-    [var: "NEXUS_username", password: username],
-    [var: "NEXUS_password", password: password]    ]){
-        conn = Nexus.createConnection(stagingURL, env.NEXUS_username, env.NEXUS_password, "profile_repositories/${stagingProfileId}")
-    }
+  // conn = Nexus.createConnection(stagingURL, env.NEXUS_username, env.NEXUS_password, "profile_repositories/${stagingProfileId}")
+  conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
   Nexus.checkResponse(conn, 200)
   Object response = Nexus.getData(conn)
   String repositoryId = null

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -50,6 +50,8 @@ def call(Map args = [:]) {
 
   def HttpURLConnection conn
   String stagingURL = Nexus.getStagingURL(url)
+  System.println(username)
+  System.prinln(stagingURL)
   conn = Nexus.createConnection(stagingURL, username, password, "profile_repositories/${stagingProfileId}")
   Nexus.checkResponse(conn, 200)
   Object response = Nexus.getData(conn)

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -60,7 +60,7 @@ def call(Map args = [:]) {
       // because they are automatically generated.
       // https://central.sonatype.org/pages/releasing-the-deployment.html
       // This is a workaround to just look for open repos that begin with our groupId
-      if (repository['description'].startsWith(mungeGroupId)) {
+      if (repository['repositoryId'].startsWith(mungeGroupId)) {
           if (repository['type'] != 'open') {
                error "Staging repository ${repository['repositoryId']} for '${groupId}' is not open. " +
                       "It should have been kept open when staging the release."

--- a/vars/nexusFindStagingId.groovy
+++ b/vars/nexusFindStagingId.groovy
@@ -20,7 +20,6 @@
 
   nexusFindStagingId(
     url: "https://oss.sonatype.org",
-    secret: "secret/release/nexus"
     stagingProfileId: "1234-1455-1242",
     groupId: co.elastic.apm
     username: nexus
@@ -35,7 +34,6 @@ def call(Map args = [:]) {
   String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply group id')
-  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
 
 
   def HttpURLConnection conn

--- a/vars/nexusFindStagingId.txt
+++ b/vars/nexusFindStagingId.txt
@@ -4,13 +4,19 @@ Find a Nexus staging repository
 nexusFindStagingRepository(
   url: "https://oss.sonatype.org",
   stagingProfileId: "comexampleapplication-1010",
-  groupId: "co.elastic.apm"
+  groupId: "co.elastic.apm",
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
   )
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * stagingProfileId: Identifier for the staging profile
 * groupid: Our group id
+* secret: Vault secret (Optional)
+* role_id: vault role ID (Optional)
+* secret_id: vault secret ID (Optional)
 
 
 [Nexus staging documentation](https://help.sonatype.com/repomanager2/staging-releases)

--- a/vars/nexusFindStagingId.txt
+++ b/vars/nexusFindStagingId.txt
@@ -5,7 +5,6 @@ nexusFindStagingRepository(
   url: "https://oss.sonatype.org",
   username: nexus
   password: my_password
-  secret: "secret/release/nexus",
   stagingProfileId: "comexampleapplication-1010",
   groupId: "co.elastic.apm"
   )

--- a/vars/nexusFindStagingId.txt
+++ b/vars/nexusFindStagingId.txt
@@ -3,6 +3,8 @@ Find a Nexus staging repository
 ```
 nexusFindStagingRepository(
   url: "https://oss.sonatype.org",
+  username: nexus
+  password: my_password
   secret: "secret/release/nexus",
   stagingProfileId: "comexampleapplication-1010",
   groupId: "co.elastic.apm"

--- a/vars/nexusFindStagingId.txt
+++ b/vars/nexusFindStagingId.txt
@@ -3,16 +3,12 @@ Find a Nexus staging repository
 ```
 nexusFindStagingRepository(
   url: "https://oss.sonatype.org",
-  username: nexus
-  password: my_password
   stagingProfileId: "comexampleapplication-1010",
   groupId: "co.elastic.apm"
   )
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
-* username: The username to auth to the repository
-* password: The password to auth to the repository
 * stagingProfileId: Identifier for the staging profile
 * groupid: Our group id
 

--- a/vars/nexusReleaseStagingRepository.groovy
+++ b/vars/nexusReleaseStagingRepository.groovy
@@ -22,8 +22,6 @@
     url: "https://oss.sonatype.org",
     stagingProfileId: "comexampleapplication-1010",
     stagingId: "co.elastic.foo"
-    username: nexus
-    password: my_password
     )
 **/
 import co.elastic.Nexus
@@ -32,10 +30,21 @@ import net.sf.json.JSONArray
 def call(Map args = [:]) {
 
   String url = args.get('url', 'https://oss.sonatype.org')
-  String username = args.get('username')
-  String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
+  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
+  String role_id = args.containsKey('role_id') ? args.role_id : 'apm-vault-role-id'
+  String secret_id = args.containsKey('secret_id') ? args.secret_id : 'apm-vault-secret-id'
+
+  def props = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
+
+  if(props?.errors){
+    error "Unable to get credentials from the vault: " + props.errors.toString()
+  }
+
+  def vault_data = props?.data
+  def username = vault_data?.username
+  def password = vault_data?.password
 
   String data = toJSON(['data': ['stagedRepositoryId': stagingId]])
   HttpURLConnection conn
@@ -44,7 +53,11 @@ def call(Map args = [:]) {
   int attemptNumber = 0
 
   while (attemptNumber < retries) {
-      conn = Nexus.createConnection(Nexus.getStagingURL(url), username, password, "profiles/${stagingProfileId}/promote")
+      withEnvMask(vars: [
+      [var: "NEXUS_username", password: username],
+      [var: "NEXUS_password", password: password]    ]){
+        conn = Nexus.createConnection(Nexus.getStagingURL(url), env.NEXUS_username, env.NEXUS_password, "profiles/${stagingProfileId}/promote")
+      }
       Nexus.addData(conn, 'POST', data.getBytes('UTF-8'))
       if (Nexus.is5xxError(conn.responseCode)) {
           log(level: "WARN", "Received a ${conn.responseCode} HTTP response code while trying to release a staging repository, trying again.")

--- a/vars/nexusReleaseStagingRepository.groovy
+++ b/vars/nexusReleaseStagingRepository.groovy
@@ -20,7 +20,6 @@
 
   nexusReleaseStagingRepository(
     url: "https://oss.sonatype.org",
-    secret: "secret/release/nexus",
     stagingProfileId: "comexampleapplication-1010",
     stagingId: "co.elastic.foo"
     username: nexus
@@ -37,7 +36,6 @@ def call(Map args = [:]) {
   String password = args.get('password')
   String stagingProfileId = args.containsKey('stagingProfileId') ? args.stagingProfileId : error('Must supply stagingProfileId')
   String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
-  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
 
   String data = toJSON(['data': ['stagedRepositoryId': stagingId]])
   HttpURLConnection conn

--- a/vars/nexusReleaseStagingRepository.txt
+++ b/vars/nexusReleaseStagingRepository.txt
@@ -3,12 +3,16 @@ Release a Nexus staging repository
 ```
 nexusReleaseStagingRepository(
   url: "https://oss.sonatype.org",
+  username: nexus
+  password: my_password
   secret: "secret/release/nexus"
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "co.elastic.foo"
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
+* username: The username to auth to the repository
+* password: The password to auth to the repository
 * secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier of staging repository

--- a/vars/nexusReleaseStagingRepository.txt
+++ b/vars/nexusReleaseStagingRepository.txt
@@ -5,7 +5,6 @@ nexusReleaseStagingRepository(
   url: "https://oss.sonatype.org",
   username: nexus
   password: my_password
-  secret: "secret/release/nexus"
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "co.elastic.foo"
 ```
@@ -13,7 +12,6 @@ nexusReleaseStagingRepository(
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * username: The username to auth to the repository
 * password: The password to auth to the repository
-* secret: Vault secret to retrieve Nexus credentials
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier of staging repository
 

--- a/vars/nexusReleaseStagingRepository.txt
+++ b/vars/nexusReleaseStagingRepository.txt
@@ -4,12 +4,18 @@ Release a Nexus staging repository
 nexusReleaseStagingRepository(
   url: "https://oss.sonatype.org",
   stagingProfileId: "comexampleapplication-1010",
-  stagingId: "co.elastic.foo"
+  stagingId: "co.elastic.foo",
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier of staging repository
+* secret: Vault secret (Optional)
+* role_id: vault role ID (Optional)
+* secret_id: vault secret ID (Optional)
 
 
 [Nexus staging documentation](https://help.sonatype.com/repomanager2/staging-releases)

--- a/vars/nexusReleaseStagingRepository.txt
+++ b/vars/nexusReleaseStagingRepository.txt
@@ -3,15 +3,11 @@ Release a Nexus staging repository
 ```
 nexusReleaseStagingRepository(
   url: "https://oss.sonatype.org",
-  username: nexus
-  password: my_password
   stagingProfileId: "comexampleapplication-1010",
   stagingId: "co.elastic.foo"
 ```
 
 * url: The URL to the repository. Usually https://oss.sonatype.org
-* username: The username to auth to the repository
-* password: The password to auth to the repository
 * stagingProfileId: Identifier for the staging profile
 * stagingId: Identifier of staging repository
 

--- a/vars/nexusUploadStagingArtifact.groovy
+++ b/vars/nexusUploadStagingArtifact.groovy
@@ -22,7 +22,6 @@
     url: "https://oss.sonatype.org",
     username: nexus,
     password: my_password,
-    secret: "secret/release/nexus",
     stagingId: "comexampleapplication-1010",
     groupId: "com.example.applications",
     artifactId: "my_tasty_artifact",
@@ -36,7 +35,6 @@ def call(Map args = [:]){
   String url = args.get('url', 'https://oss.sonatype.org')
   String username = args.get('username')
   String password = args.get('password')
-  String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
   String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply groupId')
   String artifactId = args.containsKey('artifactId') ? args.groupId : error('Must supply artifactId')

--- a/vars/nexusUploadStagingArtifact.groovy
+++ b/vars/nexusUploadStagingArtifact.groovy
@@ -20,6 +20,8 @@
 
   nexusUploadStagingArtifact(
     url: "https://oss.sonatype.org",
+    username: nexus,
+    password: my_password,
     secret: "secret/release/nexus",
     stagingId: "comexampleapplication-1010",
     groupId: "com.example.applications",
@@ -32,22 +34,14 @@ import co.elastic.Nexus
 
 def call(Map args = [:]){
   String url = args.get('url', 'https://oss.sonatype.org')
+  String username = args.get('username')
+  String password = args.get('password')
   String secret = args.containsKey('secret') ? args.secret : 'secret/release/nexus'
   String stagingId = args.containsKey('stagingId') ? args.stagingId : error('Must supply stagingId')
   String groupId = args.containsKey('groupId') ? args.groupId : error('Must supply groupId')
   String artifactId = args.containsKey('artifactId') ? args.groupId : error('Must supply artifactId')
   String version = args.containsKey('version') ? args.version : error('Must supply version')
   String file_path = args.containsKey('file_path') ? args.file_path : error('Must supply file_path')
-
-  def props = getVaultSecret(secret: secret)
-  
-  if(props?.errors){
-     error "Unable to get credentials from the vault: " + props.errors.toString()
-  }
-
-  def vault_data = props?.data
-  def username = vault_data?.user
-  def password = vault_data?.password
 
   String stagingURL = Nexus.getStagingURL(url)
   log(level: "INFO", text: "Load artifact for staging from " + file_path)
@@ -58,11 +52,7 @@ def call(Map args = [:]){
 
   File md5_f = Nexus.generateHashFile(fh, 'md5')
   File sha1_f = Nexus.generateHashFile(fh, 'sha1')
-  withEnvMask(vars: [
-    [var: "NEXUS_username", password: username],
-    [var: "NEXUS_password", password: password]    ]){
-      Nexus.upload(stagingURL, env.NEXUS_username, env.NEXUS_password, path, fh)
-    }
+  Nexus.upload(stagingURL, username, password, path, fh)
 
   // The *.asc upload has been disabled because it doesn't seem necessary but there is a chance
   // that oss.sonatype.org will require it so I am keeping it here for the time being just in case

--- a/vars/nexusUploadStagingArtifact.txt
+++ b/vars/nexusUploadStagingArtifact.txt
@@ -3,6 +3,8 @@ Upload an artifact to the Nexus staging repository
 ```
 nexusUploadStagingArtifact(
   url: "https://oss.sonatype.org",
+  username: nexus,
+  password: my_password,
   secret: "secret/release/nexus",
   stagingId: "comexampleapplication-1010",
   groupId: "com.example.applications",
@@ -15,6 +17,8 @@ nexusUploadStagingArtifact(
   https://central.sonatype.org/pages/releasing-the-deployment.html
 
   * url: The base URL of the staging repo. (Usually oss.sonatype.org)
+  * username: The username to auth to the repository
+  * password: The password to auth to the repository
   * secret: Vault secret to retrieve Nexus credentials
   * stagingId: The ID for the staging repository.
   * groupId: The group ID for the artifacts.

--- a/vars/nexusUploadStagingArtifact.txt
+++ b/vars/nexusUploadStagingArtifact.txt
@@ -6,8 +6,11 @@ nexusUploadStagingArtifact(
   stagingId: "comexampleapplication-1010",
   groupId: "com.example.applications",
   artifactId: "my_tasty_artifact",
-  version: "v1.0.0"
-  file_path: "/tmp/my_local_artifact"
+  version: "v1.0.0",
+  file_path: "/tmp/my_local_artifact",
+  secret: secret/release/nexus,
+  role_id: apm-vault-role-id,
+  secret_id: apm-vault-secret-id
 ```
 
   For additional information, please read the OSSRH guide from Sonatype:
@@ -19,3 +22,6 @@ nexusUploadStagingArtifact(
   * artifactId: The ID for the artifact to be uploaded
   * version: The release version
   * file_path: The location on local disk where the artifact to be uploaded can be found.
+  * secret: Vault secret (Optional)
+  * role_id: vault role ID (Optional)
+  * secret_id: vault secret ID (Optional)

--- a/vars/nexusUploadStagingArtifact.txt
+++ b/vars/nexusUploadStagingArtifact.txt
@@ -3,8 +3,6 @@ Upload an artifact to the Nexus staging repository
 ```
 nexusUploadStagingArtifact(
   url: "https://oss.sonatype.org",
-  username: nexus,
-  password: my_password,
   stagingId: "comexampleapplication-1010",
   groupId: "com.example.applications",
   artifactId: "my_tasty_artifact",
@@ -16,8 +14,6 @@ nexusUploadStagingArtifact(
   https://central.sonatype.org/pages/releasing-the-deployment.html
 
   * url: The base URL of the staging repo. (Usually oss.sonatype.org)
-  * username: The username to auth to the repository
-  * password: The password to auth to the repository
   * stagingId: The ID for the staging repository.
   * groupId: The group ID for the artifacts.
   * artifactId: The ID for the artifact to be uploaded

--- a/vars/nexusUploadStagingArtifact.txt
+++ b/vars/nexusUploadStagingArtifact.txt
@@ -5,7 +5,6 @@ nexusUploadStagingArtifact(
   url: "https://oss.sonatype.org",
   username: nexus,
   password: my_password,
-  secret: "secret/release/nexus",
   stagingId: "comexampleapplication-1010",
   groupId: "com.example.applications",
   artifactId: "my_tasty_artifact",
@@ -19,7 +18,6 @@ nexusUploadStagingArtifact(
   * url: The base URL of the staging repo. (Usually oss.sonatype.org)
   * username: The username to auth to the repository
   * password: The password to auth to the repository
-  * secret: Vault secret to retrieve Nexus credentials
   * stagingId: The ID for the staging repository.
   * groupId: The group ID for the artifacts.
   * artifactId: The ID for the artifact to be uploaded


### PR DESCRIPTION
## What does this PR do?

Fixes an error with JSON de-serialization and refactor all Nexus steps to accept a username/password instead of using Vault internally.

## Why is it important?

We want to be able to control the Vault retrieval from the pipeline in a single location instead of letting each step manage it to simplify things and to avoid errors which were happening with authentication.

Additionally, we fixed an issue that was found when de-serializing JSON responses on-the-fly. 

## Related issues
Refs https://github.com/elastic/observability-robots/issues/584
