### PR TITLE
feat: create/update clusters pipelines

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/create_oblt_cluster.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/create_oblt_cluster.groovy
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pipelineJob("apm-shared/oblt-test-env/create-oblt-cluster") {
+  displayName('Create oblt cluster')
+  description('Job to create a oblt cluster.')
+  parameters {
+    stringParam("branch_specifier", "master", "the Git branch specifier to build.")
+    stringParam("CLUSTER_CONFIG_FILE", "environments/CLUSTER_NAME/config-cluster.yml", "the Git branch specifier to build.")
+  }
+  disabled(false)
+  quietPeriod(10)
+  logRotator {
+    numToKeep(10)
+    daysToKeep(7)
+    artifactNumToKeep(10)
+    artifactDaysToKeep(-1)
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            github("elastic/observability-test-environments", "ssh")
+            credentials("f6c7695a-671e-4f4f-a331-acdce44ff9ba")
+          }
+          branch('${branch_specifier}')
+          extensions {
+            wipeOutWorkspace()
+          }
+        }
+      }
+      lightweight(false)
+      scriptPath(".ci/create.groovy")
+    }
+  }
+}

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/create_oblt_cluster.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/create_oblt_cluster.groovy
@@ -44,7 +44,7 @@ pipelineJob("apm-shared/oblt-test-env/create-oblt-cluster") {
           }
         }
       }
-      lightweight(false)
+      lightweight(true)
       scriptPath(".ci/create.groovy")
     }
   }

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/update_oblt_cluster.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/update_oblt_cluster.groovy
@@ -50,7 +50,7 @@ clusters.each{ cluster ->
             }
           }
         }
-        lightweight(false)
+        lightweight(true)
         scriptPath(".ci/update.groovy")
       }
     }

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/update_oblt_cluster.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/update_oblt_cluster.groovy
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+def clusters = ["edge", "dev", "release", "monitoring"]
+
+clusters.each{ cluster ->
+  pipelineJob("apm-shared/oblt-test-env/update-${cluster}-oblt-cluster") {
+    displayName("Update ${cluster}-oblt cluster")
+    description("Job to create a ${cluster} oblt cluster.")
+    parameters {
+      stringParam("branch_specifier", "master", "the Git branch specifier to build.")
+      stringParam("CLUSTER_CONFIG_FILE", "environments/${cluster}/config-cluster.yml", "the Git branch specifier to build.")
+    }
+    disabled(false)
+    quietPeriod(10)
+    logRotator {
+      numToKeep(10)
+      daysToKeep(7)
+      artifactNumToKeep(10)
+      artifactDaysToKeep(-1)
+    }
+    triggers {
+      cron('H H(3-4) * * 1-5')
+    }
+    definition {
+      cpsScm {
+        scm {
+          git {
+            remote {
+              github("elastic/observability-test-environments", "ssh")
+              credentials("f6c7695a-671e-4f4f-a331-acdce44ff9ba")
+            }
+            branch('${branch_specifier}')
+            extensions {
+              wipeOutWorkspace()
+            }
+          }
+        }
+        lightweight(false)
+        scriptPath(".ci/update.groovy")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* It adds create/update pipelines for the oblt-clusters

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
These pipelines replaces the branches and uses configuration files only to create/update pipelines
