### PR TITLE
[dependabot] change reviewer for the oncall person

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots"
+      - "elastic/observablt-robots-on-call"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -18,4 +18,4 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots"
+      - "elastic/observablt-robots-on-call"


### PR DESCRIPTION
## What does this PR do?

Add the oncall team instead of the obs-robots 

## Why is it important?

Reduce the notifications that are handled by the oncall person
