### PR TITLE
Cache stage without public access and retry

### DIFF
--- a/vars/stageStatusCache.groovy
+++ b/vars/stageStatusCache.groovy
@@ -45,10 +45,13 @@ def call(Map args, Closure body){
 def saveStageStatus(Map args){
   def statusFileName = stageStatusId(args)
   writeFile(file: statusFileName, text: "OK")
-  googleStorageUploadExt(bucket: "gs://${args.bucket}/ci/cache/",
-    credentialsId: "${args.credentialsId}",
-    pattern: "${statusFileName}",
-    sharedPublicly: true)
+  // Retry in case the google storage is temporarily not accessible.
+  retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+    googleStorageUploadExt(bucket: "gs://${args.bucket}/ci/cache/",
+      credentialsId: "${args.credentialsId}",
+      pattern: "${statusFileName}",
+      sharedPublicly: false)
+  }
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Stages should not be accessible publicly. 

## Why is it important?

Fixes an environmental issue

![image](https://user-images.githubusercontent.com/2871786/127277669-8758d62f-a93f-4e8d-949b-f4b33dcf1d3d.png)

```
[2021-07-27T17:23:06.744Z] + gsutil -m -q cp -a public-read eC1wYWNrL29zcXVlcnliZWF0LXdpbmRvd3MtOC13aW5kb3dzLTg0MDVlMDczYjQ1ZGQyYWI5NDNkYTBkZjYxZTFhMTQ4NzkyNWQ4OTk0 gs://beats-ci-temp/ci/cache/
[2021-07-27T17:23:12.061Z] ServiceException: 401 Anonymous caller does not have storage.objects.create access to the Google Cloud Storage object.
[2021-07-27T17:23:12.061Z] CommandException: 1 file/object could not be transferred.
script returned exit code 1
```

Build logs -> [here](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats/detail/PR-27080/2/pipeline#step-29342-log-1)