### PR TITLE
fix: add a new constructor to BuildException

### DIFF
--- a/src/co/elastic/BuildException.groovy
+++ b/src/co/elastic/BuildException.groovy
@@ -32,16 +32,21 @@ public class BuildException extends InterruptedException {
     }
 
     public BuildException(String number, Result result, CauseOfInterruption... causes) {
-        this.number = number
-        this.result = result
-        this.causes = Arrays.asList(causes)
-        this.actualInterruption = true
+        this(number, result, true, Arrays.asList(causes))
     }
 
     public BuildException(String number, Result result, boolean actualInterruption, CauseOfInterruption... causes) {
+        this(number, result, actualInterruption, Arrays.asList(causes))
+    }
+
+    public BuildException(String number, Result result, List<CauseOfInterruption> causes) {
+        this(number, result, true, causes)
+    }
+
+    public BuildException(String number, Result result, boolean actualInterruption, List<CauseOfInterruption> causes) {
         this.number = number
         this.result = result
-        this.causes = Arrays.asList(causes)
+        this.causes = causes
         this.actualInterruption = actualInterruption
     }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It adds a new constructor for BuildException and refactor all to use the sme constructor

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

We have detected that build causes now is a List

```
[2021-07-29T06:31:23.330Z] groovy.lang.GroovyRuntimeException: Could not find matching constructor for: co.elastic.BuildException(java.lang.String, hudson.model.Result, java.util.Arrays$ArrayList)
[2021-07-29T06:31:23.330Z] 	at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1732)
[2021-07-29T06:31:23.330Z] 	at groovy.lang.MetaClassImpl.invokeConstructor(MetaClassImpl.java:1532)
[2021-07-29T06:31:23.330Z] 	at org.codehaus.groovy.runtime.callsite.MetaClassConstructorSite.callConstructor(MetaClassConstructorSite.java:49)
[2021-07-29T06:31:23.330Z] 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
[2021-07-29T06:31:23.330Z] 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
[2021-07-29T06:31:23.330Z] 	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.constructorCall(DefaultInvoker.java:25)
```
