### PR TITLE
fix: set some old settings to detect PRs

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/test_mbp.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/test_mbp.groovy
@@ -35,6 +35,12 @@ multibranchPipelineJob('apm-shared/test-mbp') {
           repository('apm-pipeline-library')
           repositoryUrl('https://github.com/elastic/apm-pipeline-library.git')
           configuredByUrl(true)
+          buildForkPRHead(true)
+          buildForkPRMerge(true)
+          buildOriginBranch(true)
+          buildOriginBranchWithPR(false)
+          buildOriginPRHead(true)
+          buildOriginPRMerge(true)
           // The behaviours control what is discovered from the GitHub repository.
           traits {
             checkoutOptionTrait {


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* It uses some old-style settings to configure the detection of PRs

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The configure block does not work after jobDSL 1.74 due to a security patch, so we have to rely on deprecated setting until there is another solution.
