### PR TITLE
randomString without starting with -

### DIFF
--- a/src/test/groovy/RandomStringStepTest.groovy
+++ b/src/test/groovy/RandomStringStepTest.groovy
@@ -54,11 +54,18 @@ class RandomStringStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_manipulateString_with_dash() throws Exception {
+  void test_manipulateString_with_ending_dash() throws Exception {
     def ret = script.manipulateString('a-b-c-d-e-', 6)
     printCallStack()
     println ret
     assertTrue(ret == 'a-b-ca')
   }
 
+  @Test
+  void test_manipulateString_with_starting_dash() throws Exception {
+    def ret = script.manipulateString('-a-b-c-d-e', 6)
+    printCallStack()
+    println ret
+    assertTrue(ret == 'aa-b-c')
+  }
 }

--- a/vars/randomString.groovy
+++ b/vars/randomString.groovy
@@ -41,5 +41,5 @@ def call(Map args = [:]) {
   Alphanumeric and dash are allowed but not ending with dash
 */
 def manipulateString(String value, int size) {
-  return value.replaceAll("[\\W]|-", "-").take(size).replaceAll('-$', 'a')
+  return value.replaceAll("[\\W]|-", "-").take(size).replaceAll('-$', 'a').replaceAll('^-', 'a')
 }

--- a/vars/randomString.groovy
+++ b/vars/randomString.groovy
@@ -38,7 +38,7 @@ def call(Map args = [:]) {
 }
 
 /**
-  Alphanumeric and dash are allowed but not ending with dash
+  Alphanumeric and dash are allowed but not ending nor starting with dash
 */
 def manipulateString(String value, int size) {
   return value.replaceAll("[\\W]|-", "-").take(size).replaceAll('-$', 'a').replaceAll('^-', 'a')


### PR DESCRIPTION
## What does this PR do?

Avoid a random string that starts with a `-`

## Why is it important?

Azure naming convention does not allow that

```
[2021-08-04T08:59:39.911Z] │ Error: "name" must begin with an alphanumeric character

```
