### PR TITLE
Enable the opentelemetry

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -79,6 +79,11 @@ credentials:
               id: "apm-ci-gcs-plugin-file-credentials"
               scope: GLOBAL
               secretBytes: "${google_cloud_bucket_secret}" # secretBytes requires base64 encoded content
+          - string:
+              description: APM-Server Token
+              id: apm-server-token
+              scope: GLOBAL
+              secret: ${apmServerToken}
 
 unclassified:
   location:
@@ -108,6 +113,22 @@ unclassified:
   gitscm:
     globalConfigName: username
     globalConfigEmail: username@example.com
+  openTelemetry:
+    authentication:
+      bearerTokenAuthentication:
+        tokenId: "apm-server-token"
+    endpoint: "${apmServerUrl}"
+    exportOtelConfigurationAsEnvironmentVariables: true
+    exporterIntervalMillis: 60000
+    exporterTimeoutMillis: 30000
+    ignoredSteps: "dir,echo,fileExists,isUnix,pwd,properties,readFile,readYaml,writeFile"
+    observabilityBackends:
+      - elastic:
+          kibanaBaseUrl: "${kibanaFriendlyUrl}"
+          name: "Elastic Observability"
+    serviceName: "jenkins-local"
+    serviceNamespace: "jenkins-local"
+
 jobs:
   - file: "/var/pipeline-library/src/test/resources/folders/it.dsl"
   - file: "/var/pipeline-library/src/test/resources/folders/beats.dsl"

--- a/local/configs/plugins.txt
+++ b/local/configs/plugins.txt
@@ -4,5 +4,6 @@ google-compute-engine
 job-dsl
 metrics
 monitoring
+opentelemetry
 plot
 ssh-agent

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       CASC_JENKINS_CONFIG: /var/jenkins_home/casc_configs
       CASC_VAULT_ENGINE_VERSION: "1"
       CASC_VAULT_PATHS: |
-        secret/jcasc/localhost/base,secret/jcasc/localhost/apm-ci,secret/observability-team/ci/service-account/jenkins-google-storage-elastic-observability,secret/observability-team/ci/service-account/jenkins-gce-elastic-observability
+        secret/jcasc/localhost/base,secret/jcasc/localhost/apm-ci,secret/observability-team/ci/service-account/jenkins-google-storage-elastic-observability,secret/observability-team/ci/service-account/jenkins-gce-elastic-observability,secret/observability-team/ci/jenkins-stats
       CASC_VAULT_TOKEN: ${VAULT_TOKEN}
       CASC_VAULT_URL: ${VAULT_ADDR:-https://secrets.elastic.co:8200}
       JAVA_OPTS: >-


### PR DESCRIPTION
## What does this PR do?

Enable the OpenTelemetry plugin that uses the ElasticStack we have in place.

https://github.com/elastic/apm-pipeline-library/pull/1051 was reverted since it created a local ElasticStack environment. So this approach uses our ES that runs in the Cloud.

## Why is it important?

To test this functionality locally and easily

## Related issues

This will help me to debug -> https://github.com/elastic/apm-agent-java/pull/2103 since somehow the `withOtelEnv` is not working as expected or something else is causing some issues.

## Caveats

You need to `make -C local clean` or destroy your local container.

Otherwise you might face issues with the existing opentelemetry version

## Test


![image](https://user-images.githubusercontent.com/2871786/132033031-95ba828e-1742-4877-ab0a-0dedb9592933.png)


