### PR TITLE
Add reused workers metrics in the apm-ci

### DIFF
--- a/.ci/jobs/gather-ci-metrics-pipeline.yml
+++ b/.ci/jobs/gather-ci-metrics-pipeline.yml
@@ -1,0 +1,24 @@
+---
+- job:
+    name: apm-shared/gather-ci-metrics-pipeline
+    display-name: Gather CI metrics
+    description: Gather CI metrics
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/gather-ci-metrics.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/observability-robots.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/observability-robots.git
+            branches:
+              - $branch_specifier

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -96,6 +96,14 @@ pipeline {
           propagate: false,
           wait: false
         )
+
+        build(job: 'apm-shared/gather-ci-metrics-pipeline',
+          parameters: [
+            string(name: 'MTIME_FILTER', value: '1')
+          ],
+          propagate: false,
+          wait: false
+        )
       }
     }
     stage('Populate GitHub data') {


### PR DESCRIPTION
## What does this PR do?

Collect metrics regarding the reused workers in the CI (apm-ci).


The pipeline is defined in another repository, therefore this is only the JJBB and the job call.

## Why is it important?

We already use a similar approach for the `beats-ci`
