### PR TITLE
Support traceparent with otel

### DIFF
--- a/src/test/groovy/WithOtelEnvStepTests.groovy
+++ b/src/test/groovy/WithOtelEnvStepTests.groovy
@@ -43,19 +43,4 @@ class WithOtelEnvStepTests extends ApmBasePipelineTest {
     assertJobStatusFailure()
   }
 
-  @Test
-  void test_env_variable_defined() throws Exception {
-    addEnvVar('OTEL_EXPORTER_OTLP_HEADERS', 'foo')
-    try {
-      script.call(){
-        //NOOP
-      }
-    } catch(e){
-      //NOOP
-    }
-    printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'withOtelEnv: OTEL_EXPORTER_OTLP_HEADERS env variable is already defined'))
-    assertJobStatusFailure()
-  }
-
 }

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -33,9 +33,7 @@ def call(Map args = [:], Closure body) {
     error('withOtelEnv: opentelemetry plugin is not available')
   }
 
-  if (env.OTEL_EXPORTER_OTLP_HEADERS?.trim()) {
-    error('withOtelEnv: OTEL_EXPORTER_OTLP_HEADERS env variable is already defined.')
-  }
+  def otel_headers = env.OTEL_EXPORTER_OTLP_HEADERS ?: ''
 
   // In case the credentialsId argument was not passed, then let's use the
   // OpenTelemetry configuration to dynamically provide those details.
@@ -60,7 +58,7 @@ def call(Map args = [:], Closure body) {
       [var: 'ELASTIC_APM_SERVICE_NAME', password: serviceName],
       [var: 'OTEL_EXPORTER_OTLP_ENDPOINT', password: entrypoint],
       [var: 'OTEL_SERVICE_NAME', password: serviceName],
-      [var: 'OTEL_EXPORTER_OTLP_HEADERS', password: "authorization=Bearer ${env.OTEL_TOKEN_ID}"]
+      [var: 'OTEL_EXPORTER_OTLP_HEADERS', password: "${otel_headers} authorization=Bearer ${env.OTEL_TOKEN_ID}"]
     ]) {
       withEnv(otelEnvs){
         body()

--- a/vars/withOtelEnv.txt
+++ b/vars/withOtelEnv.txt
@@ -1,9 +1,9 @@
 Configure the OpenTelemetry Jenkins context to run the body closure with the below
 environment variables:
 
-* `OTEL_EXPORTER_OTLP_ENDPOINT`
-* `OTEL_SERVICE_NAME`
-* `OTEL_EXPORTER_OTLP_HEADERS`
+* `OTEL_EXPORTER_OTLP_ENDPOINT`, opentelemetry 0.19 already provides this environment variable.
+* `OTEL_SERVICE_NAME`, opentelemetry 0.19 already provides this environment variable.
+* `OTEL_EXPORTER_OTLP_HEADERS`, opentelemetry 0.19 already provides this environment variable.
 * `ELASTIC_APM_SECRET_TOKEN`
 * `ELASTIC_APM_SERVER_URL`
 * `ELASTIC_APM_SERVICE_NAME`

--- a/vars/withOtelEnv.txt
+++ b/vars/withOtelEnv.txt
@@ -7,6 +7,7 @@ environment variables:
 * `ELASTIC_APM_SECRET_TOKEN`
 * `ELASTIC_APM_SERVER_URL`
 * `ELASTIC_APM_SERVICE_NAME`
+* `TRACEPARENT`, opentelemetry 0.19 already provides this environment variable.
 
 ```
   withOtelEnv() {


### PR DESCRIPTION
## What does this PR do?

Opentelemetry 0.19 already supports this feature, but let's support previous versions

## Why is it important?

Simplify the consumers of the withOtelEnv and other integrations to consume `TRACEPARENT` directly rather than generating it.
