### PR TITLE
Gather metrics for the apm-ci with apm-ci agents

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -99,7 +99,8 @@ pipeline {
 
         build(job: 'apm-shared/gather-ci-metrics-pipeline',
           parameters: [
-            string(name: 'MTIME_FILTER', value: '1')
+            string(name: 'MTIME_FILTER', value: '1'),
+            string(name: 'AGENT_PREFIX', value: 'apm-ci')
           ],
           propagate: false,
           wait: false


### PR DESCRIPTION
## What does this PR do?

Add explicit agent name to be searched

## Why is it important?

Otherwise it uses the default value that points to a different CI instance
