### PR TITLE
Switch observability-dev checkouts from master branch by default to main branch

### DIFF
--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -47,7 +47,7 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git", branch: "main")
       }
     }
     stage('Fetch latest versions') {

--- a/.ci/githubSyncupLabelsObsDev.groovy
+++ b/.ci/githubSyncupLabelsObsDev.groovy
@@ -40,7 +40,7 @@ pipeline {
     stage('Sync GitHub labels') {
       steps {
         deleteDir()
-        git(url: "https://github.com/elastic/${REPO}.git", credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken')
+        git(url: "https://github.com/elastic/${REPO}.git", credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', branch: 'main')
         withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GITHUB_TOKEN')]) {
           sh '''#!/bin/bash -e
             cd .github/labels


### PR DESCRIPTION
## What does this PR do?

Uses the main branch instead of the master branch when checking out `observability-dev`.

## Why is it important?

When using the `master` branch, we end up with an empty checkout. This causes failures such as https://apm-ci.elastic.co/job/apm-shared/job/bump-stack-version-pipeline/112/

