### PR TITLE
Enable Otel maven plugin

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -94,19 +94,28 @@ pipeline {
         }
       }
     }
-    /**
-     Checkout the code and stash it, to use it on other stages.
-    */
-    stage('Test') {
+    stage('Build') {
       steps {
-        withGithubNotify(context: 'Test', description: 'UTs', tab: 'tests') {
+        withGithubNotify(context: 'Build', description: 'Build') {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
             retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-              sh './mvnw clean install -V --batch-mode -DskipTests'
+              withOtelEnv() {
+                sh './mvnw clean install -V --batch-mode -DskipTests'
+              }
             }
-            sh './mvnw clean test -V --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+          }
+        }
+      }
+    }
+    stage('Test') {
+      steps {
+        withGithubNotify(context: 'Test', description: 'UTs', tab: 'tests') {
+          dir("${BASE_DIR}"){
+            withOtelEnv() {
+              sh './mvnw clean test -V --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+            }
           }
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,13 @@
         </dependencies>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>co.elastic.opentelemetry.contrib</groupId>
+        <artifactId>opentelemetry-maven-extension</artifactId>
+        <version>0.1.0-beta-5</version>
+      </extension>
+    </extensions>
   </build>
   <profiles>
     <profile>


### PR DESCRIPTION
## What does this PR do?

Added the extension to instrument this maven builds. Added the build stage

## Why is it important?

Use https://github.com/elastic/opentelemetry-maven-extension 

## Test


![image](https://user-images.githubusercontent.com/2871786/132548512-e6b1ed0f-d6cd-47fa-94b9-56c39463571b.png)
