### PR TITLE
Support Windows workers for docker builds

### DIFF
--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -189,11 +189,7 @@ def buildDockerImage(args){
           }
         }
         if(push){
-          if(isUnix()){
-            sh(label: "push docker image", script: "docker push ${image}")
-          } else {
-            bat(label: "push docker image", script: "docker push ${image}")
-          }
+          cmd(label: "push docker image", script: "docker push ${image}")
         }
       }
     }

--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -182,11 +182,7 @@ def buildDockerImage(args){
       withEnv(env){
         retry(3) {
           sleep randomNumber(min: 5, max: 10)
-          if(isUnix()){
-            sh(label: "build docker image", script: "docker build ${options} -t ${image} .")
-          } else {
-            bat(label: "build docker image", script: "docker build ${options} -t ${image} .")
-          }
+          cmd(label: "build docker image", script: "docker build ${options} -t ${image} .")
         }
         if(push){
           cmd(label: "push docker image", script: "docker push ${image}")

--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -182,10 +182,18 @@ def buildDockerImage(args){
       withEnv(env){
         retry(3) {
           sleep randomNumber(min: 5, max: 10)
-          sh(label: "build docker image", script: "docker build ${options} -t ${image} .")
+          if(isUnix()){
+            sh(label: "build docker image", script: "docker build ${options} -t ${image} .")
+          } else {
+            bat(label: "build docker image", script: "docker build ${options} -t ${image} .")
+          }
         }
         if(push){
-          sh(label: "push docker image", script: "docker push ${image}")
+          if(isUnix()){
+            sh(label: "push docker image", script: "docker push ${image}")
+          } else {
+            bat(label: "push docker image", script: "docker push ${image}")
+          }
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Catches a condition where sometimes workers labled as `docker` can be Windows.

## Why is it important?
Corrects occasional build failures such as this one: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-docker-opbeans-pipeline/detail/apm-docker-opbeans-pipeline/779/pipeline


