### PR TITLE
[test-infra][beats-ci] validate windows-2019 with docker

### DIFF
--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -63,6 +63,7 @@ pipeline {
             name 'PLATFORM'
             values (
               'arm',  // ephemeral workers
+              'immutable && windows-2019 && docker',
               'immutable && windows-2019',
               'immutable && windows-2016',
               'immutable && windows-2012-r2',


### PR DESCRIPTION
## What does this PR do?

Add a new worker type for being validated.

## Why is it important?

This could be used by the integrations team in the near future