### PR TITLE
Support role and secret vault in dockerLogin

### DIFF
--- a/src/test/groovy/DockerLoginStepTests.groovy
+++ b/src/test/groovy/DockerLoginStepTests.groovy
@@ -61,4 +61,13 @@ class DockerLoginStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('bat', 'docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "other.docker.io"'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_with_role_secret() throws Exception {
+    script.call(secret: VaultSecret.SECRET_NAME.toString(), role_id: "role-id", secret_id: 'secret-id')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('getVaultSecret', 'role_id=role-id, secret_id=secret-id'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}" "docker.io"'))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -393,6 +393,8 @@ dockerLogin(secret: 'secret/team/ci/secret-name', registry: "docker.io")
 
 * secret: Vault secret where the user and password stored.
 * registry: Registry to login into.
+* role_id: vault role ID (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID (Optional). Default 'vault-secret-id'
 
 ## dockerLogs
 Archive all the docker containers in the current context.
@@ -730,6 +732,8 @@ def jsonValue = getVaultSecret(secret: 'secret/team/ci/secret-name')
 ```
 
 * *secret-name*: Name of the secret on the the vault root path.
+* role_id: vault role ID (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID (Optional). Default 'vault-secret-id'
 
 ## gh
 Wrapper to interact with the gh command line. It returns the stdout output.
@@ -2041,7 +2045,7 @@ nexusFindStagingRepository(
   url: "https://oss.sonatype.org",
   stagingProfileId: "comexampleapplication-1010",
   groupId: "co.elastic.apm",
-  secret: secret/release/nexus,
+  secret: 'secret/release/nexus',
   role_id: apm-vault-role-id,
   secret_id: apm-vault-secret-id
   )
@@ -2179,6 +2183,22 @@ opbeansPipeline(downstreamJobs: ['job1', 'folder/job1', 'mbp/PR-1'])
 ```
 
 * downstreamJobs: What downstream pipelines should be triggered once the release has been done. Default: []
+
+## otelHelper
+Helper method to interact with the OpenTelemetry Jenkins plugin
+
+```
+  withOtelEnv() {
+    // block
+  }
+
+  // If you'd like to use a different credentials
+  withOtelEnv(credentialsId: 'foo') {
+    // block
+  }
+```
+
+**NOTE**: It requires the [OpenTelemetry plugin](https://plugins.jenkins.io/opentelemetry")
 
 ## pipelineManager
 This step adds certain validations which might be required to be done per build, for such it does
@@ -3155,12 +3175,12 @@ withNpmrc(path: '/foo', npmrcFile: '.npmrc') {
 Configure the OpenTelemetry Jenkins context to run the body closure with the below
 environment variables:
 
-* `OTEL_EXPORTER_OTLP_ENDPOINT`
-* `OTEL_SERVICE_NAME`
-* `OTEL_EXPORTER_OTLP_HEADERS`
+* `OTEL_EXPORTER_OTLP_ENDPOINT`, opentelemetry 0.19 already provides this environment variable.
+* `OTEL_EXPORTER_OTLP_HEADERS`, opentelemetry 0.19 already provides this environment variable.
 * `ELASTIC_APM_SECRET_TOKEN`
 * `ELASTIC_APM_SERVER_URL`
 * `ELASTIC_APM_SERVICE_NAME`
+* `TRACEPARENT`, opentelemetry 0.19 already provides this environment variable.
 
 ```
   withOtelEnv() {

--- a/vars/README.md
+++ b/vars/README.md
@@ -393,8 +393,8 @@ dockerLogin(secret: 'secret/team/ci/secret-name', registry: "docker.io")
 
 * secret: Vault secret where the user and password stored.
 * registry: Registry to login into.
-* role_id: vault role ID (Optional). Default 'vault-role-id'
-* secret_id: vault secret ID (Optional). Default 'vault-secret-id'
+* role_id: vault role ID (Optional).
+* secret_id: vault secret ID (Optional).
 
 ## dockerLogs
 Archive all the docker containers in the current context.

--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -25,8 +25,10 @@
 def call(Map args = [:]){
   def secret = args.containsKey('secret') ? args.secret : error("dockerLogin: No valid secret to looking for.")
   def registry = args.containsKey('registry') ? args.registry : "docker.io"
+  def role_id = args.containsKey('role_id') ? args.role_id : 'vault-role-id'
+  def secret_id = args.containsKey('secret_id') ? args.secret_id : 'vault-secret-id'
 
-  def jsonValue = getVaultSecret(secret: secret)
+  def jsonValue = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
   def data = jsonValue.containsKey('data') ? jsonValue.data : error("dockerLogin: No valid data in secret.")
   def dockerUser = data.containsKey('user') ? data.user : error("dockerLogin: No valid user in secret.")
   def dockerPassword = data.containsKey('password') ? data.password : error("dockerLogin: No valid password in secret.")
@@ -47,10 +49,10 @@ def call(Map args = [:]){
           sh(label: "Docker login", script: """
             set +x
             if command -v host 2>&1 > /dev/null; then
-              host ${registry} 2>&1 > /dev/null 
+              host ${registry} 2>&1 > /dev/null
             fi
             if command -v dig 2>&1 > /dev/null; then
-              dig ${registry} 2>&1 > /dev/null 
+              dig ${registry} 2>&1 > /dev/null
             fi
             docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
             """)

--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -33,37 +33,31 @@ def call(Map args = [:]){
   def dockerUser = data.containsKey('user') ? data.user : error("dockerLogin: No valid user in secret.")
   def dockerPassword = data.containsKey('password') ? data.password : error("dockerLogin: No valid password in secret.")
 
-  wrap([$class: 'MaskPasswordsBuildWrapper',
-    varPasswordPairs: [
-      [var: 'DOCKER_USER', password: dockerUser],
-      [var: 'DOCKER_PASSWORD', password: dockerPassword],
-  ]]) {
-    withEnv([
-      "DOCKER_USER=${dockerUser}",
-      "DOCKER_PASSWORD=${dockerPassword}"
-    ]) {
-      // When running in the CI with multiple parallel stages
-      // the access could be considered as a DDOS attack.
-      retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-        if (isUnix()) {
-          sh(label: "Docker login", script: """
-            set +x
-            if command -v host 2>&1 > /dev/null; then
-              host ${registry} 2>&1 > /dev/null
-            fi
-            if command -v dig 2>&1 > /dev/null; then
-              dig ${registry} 2>&1 > /dev/null
-            fi
-            docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
-            """)
-        } else {
-          bat(label: 'is registry service up?', script: """@ECHO OFF
-            nslookup ${registry} > NUL 2>&1
+  withEnvMask(vars: [
+    [var: "DOCKER_USER", password: dockerUser],
+    [var: "DOCKER_PASSWORD", password: dockerPassword]
+  ]){
+    // When running in the CI with multiple parallel stages
+    // the access could be considered as a DDOS attack.
+    retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+      if (isUnix()) {
+        sh(label: "Docker login", script: """
+          set +x
+          if command -v host 2>&1 > /dev/null; then
+            host ${registry} 2>&1 > /dev/null
+          fi
+          if command -v dig 2>&1 > /dev/null; then
+            dig ${registry} 2>&1 > /dev/null
+          fi
+          docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
           """)
-          bat(label: 'Docker Login', script: """@ECHO OFF
-            docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "${registry}" 2> NUL
-          """)
-        }
+      } else {
+        bat(label: 'is registry service up?', script: """@ECHO OFF
+          nslookup ${registry} > NUL 2>&1
+        """)
+        bat(label: 'Docker Login', script: """@ECHO OFF
+          docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "${registry}" 2> NUL
+        """)
       }
     }
   }

--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -25,10 +25,8 @@
 def call(Map args = [:]){
   def secret = args.containsKey('secret') ? args.secret : error("dockerLogin: No valid secret to looking for.")
   def registry = args.containsKey('registry') ? args.registry : "docker.io"
-  def role_id = args.containsKey('role_id') ? args.role_id : 'vault-role-id'
-  def secret_id = args.containsKey('secret_id') ? args.secret_id : 'vault-secret-id'
 
-  def jsonValue = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
+  def jsonValue = getVaultSecret(args)
   def data = jsonValue.containsKey('data') ? jsonValue.data : error("dockerLogin: No valid data in secret.")
   def dockerUser = data.containsKey('user') ? data.user : error("dockerLogin: No valid user in secret.")
   def dockerPassword = data.containsKey('password') ? data.password : error("dockerLogin: No valid password in secret.")

--- a/vars/dockerLogin.txt
+++ b/vars/dockerLogin.txt
@@ -11,5 +11,5 @@ dockerLogin(secret: 'secret/team/ci/secret-name', registry: "docker.io")
 
 * secret: Vault secret where the user and password stored.
 * registry: Registry to login into.
-* role_id: vault role ID (Optional). Default 'vault-role-id'
-* secret_id: vault secret ID (Optional). Default 'vault-secret-id'
+* role_id: vault role ID (Optional).
+* secret_id: vault secret ID (Optional).

--- a/vars/dockerLogin.txt
+++ b/vars/dockerLogin.txt
@@ -11,3 +11,5 @@ dockerLogin(secret: 'secret/team/ci/secret-name', registry: "docker.io")
 
 * secret: Vault secret where the user and password stored.
 * registry: Registry to login into.
+* role_id: vault role ID (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID (Optional). Default 'vault-secret-id'

--- a/vars/getVaultSecret.txt
+++ b/vars/getVaultSecret.txt
@@ -13,3 +13,5 @@ def jsonValue = getVaultSecret(secret: 'secret/team/ci/secret-name')
 ```
 
 * *secret-name*: Name of the secret on the the vault root path.
+* role_id: vault role ID (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID (Optional). Default 'vault-secret-id'


### PR DESCRIPTION
## What does this PR do?

Add new parameters to the dockerLogin to configure the vault with different default values.

## Why is it important?

Allow to use different role/secret-id in Vault in a different CI

`dockerLogin` steps consumes [getVaultSecret](https://github.com/elastic/apm-pipeline-library/blob/master/vars/getVaultSecret.groovy) which already provides those parameters to be configured. Therefore, there is no need to set those parameters with any default values but pass through the `args` data structure from `dockerLogin` to `getVaultSecret`.
