### PR TITLE
notify PRs for bumping stack release in azure-vm-extension

### DIFF
--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -44,6 +44,7 @@ projects:
       - master
     enabled: true
     labels: dependency
+    reviewer: narph
   - repo: apm-agent-rum-js
     script: .ci/bump-stack-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Add the reviewer in any of the PRs that are automatically opened in azure-vm-extension

## Why is it important?

Ensure they are reviewed
