### PR TITLE
Add GitHub commands with the description

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^/run infra tests)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run infra tests)")
   }
   parameters {
     string(name: 'MAVEN_CONFIG', defaultValue: '', description: 'Additional maven options.')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   triggers {
-    issueCommentTrigger("${obltGitHubComments()}")
+    issueCommentTrigger("(${obltGitHubComments()}|^/run infra tests)")
   }
   parameters {
     string(name: 'MAVEN_CONFIG', defaultValue: '', description: 'Additional maven options.')
@@ -197,6 +197,7 @@ pipeline {
         anyOf {
           expression { return env.TEST_INFRA == "true" }
           branch 'master'
+          expression { return env.GITHUB_COMMENT?.contains('infra tests') }
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@master') _
+@Library('apm@feature/add-more-context-github-commands') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-@Library('apm@feature/add-more-context-github-commands') _
+@Library('apm@master') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/resources/commands-github-comment-markdown.template
+++ b/resources/commands-github-comment-markdown.template
@@ -3,8 +3,8 @@
 
 To re-run your PR in the CI, just comment with:
 
-<% githubCommands?.each { githubCommand -> %>
-- `${githubCommand}`
+<% githubCommands?.each { githubCommand, description -> %>
+- `${githubCommand}` : ${description}
 <%}%>
 
 <%}%>

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -478,7 +478,7 @@ def getSupportedGithubCommands() {
 
   // Support for the nodejs APM agent
   if (issueCommentTrigger.getCommentPattern().contains('^run (module|benchmark) tests')) {
-    comments['run module tests for <module>'] = 'un TAV tests for one or more modules, where <modules> can be either a comma separated list of modules (e.g. memcached,redis) or the string literal ALL to test all modules'
+    comments['run module tests for <module>'] = 'Run TAV tests for one or more modules, where <modules> can be either a comma separated list of modules (e.g. memcached,redis) or the string literal ALL to test all modules'
     comments['run benchmark tests'] = 'Run the benchmark test only.'
   }
 

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -449,10 +449,10 @@ def getSupportedGithubCommands() {
 
   if (issueCommentTrigger == null) {
     log(level: 'WARN', text: "No IssueCommentTrigger has been triggered")
-    return []
+    return [:]
   }
 
-  def comments = []
+  def comments = [:]
 
   // In order to avoid re-triggering a build when commenting the
   // build status as a PR comment, it's required to filter here
@@ -462,19 +462,36 @@ def getSupportedGithubCommands() {
   // PR comment includes the section for the support trigger comments
   //
   if (issueCommentTrigger.getCommentPattern().contains('^/test')) {
-    comments << '/test'
-  }
-
-  // Support obltGitHubComments interpolation
-  if (issueCommentTrigger.getCommentPattern().contains('^(?:jenkins')) {
-    comments << 'jenkins run the tests'
+    comments['/test'] = 'Retrigger the build.'
   }
 
   // Support for APM server
-  if (issueCommentTrigger.getCommentPattern().contains('hey-apm|package|arm')) {
-    comments << 'run the arm tests'
-    comments << '/hey-apm'
-    comments << '/package'
+  if (issueCommentTrigger.getCommentPattern().contains('hey-apm|package')) {
+    comments['/hey-apm'] = 'Run the hey-apm benchmark.'
+    comments['/package'] = 'Generate and publish the docker images.'
+  }
+
+  // Support for benchmark tests
+  if (issueCommentTrigger.getCommentPattern().contains('^run benchmark tests')) {
+    comments['run benchmark tests'] = 'Run the benchmark test.'
+  }
+
+  // Support for the nodejs APM agent
+  if (issueCommentTrigger.getCommentPattern().contains('^run (module|benchmark) tests')) {
+    comments['run module tests for <module>'] = 'un TAV tests for one or more modules, where <modules> can be either a comma separated list of modules (e.g. memcached,redis) or the string literal ALL to test all modules'
+    comments['run benchmark tests'] = 'Run the benchmark test only.'
+  }
+
+  // Support for the java APM agent
+  if (issueCommentTrigger.getCommentPattern().contains('^run (compatibility|benchmark|integration)')) {
+    comments['run benchmark tests'] = 'Run the benchmark test.'
+    comments['run compatibility tests'] = 'Run the JDK Compatibility test.'
+    comments['run integration tests'] = 'Run the APM-ITs.'
+  }
+
+  // Support for the APM pipeline library
+  if (issueCommentTrigger.getCommentPattern().contains('^run infra tests')) {
+    comments['run infra tests'] = 'Run the test-infra test.'
   }
 
   return comments

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -462,7 +462,7 @@ def getSupportedGithubCommands() {
   // PR comment includes the section for the support trigger comments
   //
   if (issueCommentTrigger.getCommentPattern().contains('^/test')) {
-    comments['/test'] = 'Retrigger the build.'
+    comments['/test'] = 'Re-trigger the build.'
   }
 
   // Support for APM server


### PR DESCRIPTION
## What does this PR do?

* Improve the development experience with some description about what those GitHub commands do.
* In addition, I remove the support for `Jenkins run the ....` from the list of supported GitHub commands, still people can use it, but we want to deprecate it.
* Added support for `run infra tests`

## Why is it important?

`getSupportedGithubCommands` contains the list of supported GitHub commands and what they do.

