### PR TITLE
Add GitHub commands for the Beats project

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -494,6 +494,12 @@ def getSupportedGithubCommands() {
     comments['run infra tests'] = 'Run the test-infra test.'
   }
 
+  // Support for the Beats specific GitHub commands
+  if (env.REPO?.equals('beats') || env.REPO_NAME?.equals('beats')) {
+    comments['/package'] = 'Generate the packages and run the E2E Tests.'
+    comments['/beats-tester'] = 'Validate the generated packages.'
+  }
+
   return comments
 }
 

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -496,8 +496,8 @@ def getSupportedGithubCommands() {
 
   // Support for the Beats specific GitHub commands
   if (env.REPO?.equals('beats') || env.REPO_NAME?.equals('beats')) {
-    comments['/package'] = 'Generate the packages and run the E2E Tests.'
-    comments['/beats-tester'] = 'Validate the generated packages.'
+    comments['/package'] = 'Generate the packages and run the E2E tests.'
+    comments['/beats-tester'] = 'Run the installation tests with beats-tester.'
   }
 
   return comments


### PR DESCRIPTION
## What does this PR do?

Add explicitly support for the GitHub commands in Beats:
- https://github.com/elastic/beats#pr-comments

## Why is it important?

Those commands are defined in another pipelines therefore they cannot be accessed directly. Such as:
- https://github.com/elastic/beats/blob/master/.ci/packaging.groovy#L37
- https://github.com/elastic/beats/blob/master/.ci/beats-tester.groovy#L22

