### PR TITLE
Exclude errors related to the approval-list and githubPrCheckApproved in the GitHub comment

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -74,7 +74,12 @@ ${errorStackTrace}
 <% errorGitHub = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Notifies GitHub')}%>
 <% errorGithubPrCheckApproved = stepsErrors?.find{it?.result == "FAILURE" && it?.displayDescription?.contains('githubPrCheckApproved')}%>
 <% errorDeleteDir = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
-<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit') && !it?.displayDescription?.contains('githubPrCheckApproved') && !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
+<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" &&
+                                      !it?.displayName?.contains('Notifies GitHub') &&
+                                      !it?.displayName?.contains('Archive JUnit') &&
+                                      !it?.displayDescription?.contains('githubPrCheckApproved') &&
+                                      !it?.displayDescription?.contains('approval-list/elastic') &&
+                                      !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
 <% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>
 <% stepsErrors = stepsErrors?.findAll{ !it?.displayName?.contains('Error signal') } %>
 <% if (errorSignal) { stepsErrors = stepsErrors << errorSignal }%>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -72,14 +72,18 @@ ${errorStackTrace}
 
 <!-- STEPS ERRORS IF ANY -->
 <% errorGitHub = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Notifies GitHub')}%>
+<% errorGithubPrCheckApproved = stepsErrors?.find{it?.result == "FAILURE" && it?.displayDescription?.contains('githubPrCheckApproved')}%>
 <% errorDeleteDir = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
-<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit') && !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
+<% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" && !it?.displayName?.contains('Notifies GitHub') && !it?.displayName?.contains('Archive JUnit') && !it?.displayDescription?.contains('githubPrCheckApproved') && !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
 <% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>
 <% stepsErrors = stepsErrors?.findAll{ !it?.displayName?.contains('Error signal') } %>
 <% if (errorSignal) { stepsErrors = stepsErrors << errorSignal }%>
 <% if (errorDeleteDir) { stepsErrors = stepsErrors << errorDeleteDir }%>
 <% if (stepsErrors?.size() <= 0 && !buildStatus?.equals('SUCCESS') && errorGitHub) {%>
   <% stepsErrors = stepsErrors << errorGitHub %>
+<%}%>
+<% if (!buildStatus?.equals('ABORTED') && errorGithubPrCheckApproved) {%>
+  <% stepsErrors = stepsErrors << errorGithubPrCheckApproved %>
 <%}%>
 <% if (stepsErrors?.size() != 0 && !statusSuccess) {%>
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -228,9 +228,11 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
       testsSummary: readJSON(file: "tests-summary.json")
     )
     printCallStack()
-    // Then the description contains the reason and therefore there is no need to report the Error for the githubPrCheckApproved
+    // Then the description contains the reason, there is no need to report the Error for the githubPrCheckApproved
+    // and load resources for the approval-list should not be reported in the GitHub comment.
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Aborted'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', '> The PR is not allowed to run in the CI yet'))
+    assertFalse(assertMethodCallContainsPattern('githubPrComment', 'approval-list/elastic'))
     assertFalse(assertMethodCallContainsPattern('githubPrComment', 'githubPrCheckApproved'))
     assertJobStatusSuccess()
   }

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -217,6 +217,25 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_aborted_not_allowed_to_run() throws Exception {
+    script.notifyPR(
+      build: readJSON(file: "build-info_aborted_allowed_to_run.json"),
+      buildStatus: "ABORTED",
+      changeSet: readJSON(file: "changeSet-info.json"),
+      statsUrl: "https://ecs.example.com/app/kibana",
+      stepsErrors: readJSON(file: "steps-errors-allowed-to-run.json"),
+      testsErrors: readJSON(file: "tests-errors.json"),
+      testsSummary: readJSON(file: "tests-summary.json")
+    )
+    printCallStack()
+    // Then the description contains the reason and therefore there is no need to report the Error for the githubPrCheckApproved
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Aborted'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', '> The PR is not allowed to run in the CI yet'))
+    assertFalse(assertMethodCallContainsPattern('githubPrComment', 'githubPrCheckApproved'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_pr_with_failure() throws Exception {
     script.notifyPR(
       build: readJSON(file: "build-info.json"),

--- a/src/test/resources/build-info_aborted_allowed_to_run.json
+++ b/src/test/resources/build-info_aborted_allowed_to_run.json
@@ -1,0 +1,23 @@
+{
+  "artifactsZipFile": "https://apm-ci.elastic.co//job/apm-agent-nodejs/job/ecs-logging-nodejs-mbp/job/PR-101/1/artifact/*zip*/archive.zip",
+  "causeOfBlockage": null,
+  "causes": {
+    "shortDescription": "Pull request #101 opened"
+  },
+  "description": "The PR is not allowed to run in the CI yet",
+  "durationInMillis": 189755,
+  "enQueueTime": "2021-09-22T09:29:02.777+0000",
+  "endTime": null,
+  "estimatedDurationInMillis": -1,
+  "id": "1",
+  "name": null,
+  "organization": "jenkins",
+  "pipeline": "PR-101",
+  "result": "ABORTED",
+  "runSummary": "?",
+  "startTime": "2021-09-22T09:29:02.785+0000",
+  "state": "FINISHED",
+  "type": "WorkflowRun",
+  "commitId": "f61cab1e9b150b9fe1216efb8431849fa6224099+ae3cd0763415e131cee39d13539addead2b13665 (91d9f874aa47b1d2b93e7bdc36afe02ff5627221)",
+  "commitUrl": null
+}

--- a/src/test/resources/steps-errors-allowed-to-run.json
+++ b/src/test/resources/steps-errors-allowed-to-run.json
@@ -1,0 +1,26 @@
+[
+  {
+    "displayDescription": "approval-list/elastic/ecs-logging-nodejs.yml",
+    "displayName": "Load a resource file from a shared library",
+    "durationInMillis": 23,
+    "id": "83",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-09-22T09:32:09.701+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://apm-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/apm-agent-nodejs/pipelines/ecs-logging-nodejs-mbp/pipelines/PR-101/runs/1/steps/83/log"
+  },
+  {
+    "displayDescription": "githubPrCheckApproved: The PR is not allowed to run in the CI yet. (Only users with write permissions can do so.)",
+    "displayName": "Error signal",
+    "durationInMillis": 11,
+    "id": "86",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-09-22T09:32:09.751+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://apm-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/apm-agent-nodejs/pipelines/ecs-logging-nodejs-mbp/pipelines/PR-101/runs/1/steps/86/log"
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Exclude certain errors from the GitHub comment.

## Why is it important?

Those errors don't provide any value to the contributor/reviewer. And might cause some misleading.

## Used to be

![image](https://user-images.githubusercontent.com/2871786/134487530-77d7c1f5-b801-437f-a488-20c6fa0765d0.png)

## Now

![image](https://user-images.githubusercontent.com/2871786/134487724-e733d296-951c-44fb-b30b-e175f4e8c158.png)


## Related issues

See https://github.com/elastic/ecs-logging-nodejs/pull/101#issuecomment-925092969
