### PR TITLE
Remove test stats in the Flakyness github comment

### DIFF
--- a/resources/flaky-github-comment-markdown.template
+++ b/resources/flaky-github-comment-markdown.template
@@ -1,6 +1,6 @@
 <% if(flakyTests) {%>
 ## :bug: Flaky test report
-:snowflake: The following tests failed but also have a history of flakiness and may not be related to this change: 
+:snowflake: The following tests failed but also have a history of flakiness and may not be related to this change:
     <% flakyTests?.each{ k,v -> %>
 <% url = (v?.startsWith('https:')) ? "${v}" : "#${v}"%>
 * **Name**: `${k}` ${ (v?.trim()) ? "reported in the issue " + url : 'has not been reported yet.'}<%}%>
@@ -14,25 +14,15 @@ Tests succeeded.
 ## :grey_exclamation: Flaky test report
 No test was executed to be analysed.
 <%}%>
-<% if(testsSummary?.total > 0) {%>
-<!-- BUILD SUMMARY-->
+<% if(!testsErrors?.isEmpty()) {%>
+
 <details><summary>Expand to view the summary</summary>
 <p>
 
-### Test stats :test_tube:
-| Test         | Results                         |
-| ------------ | :-----------------------------: |
-| Failed       | ${(testsSummary?.failed) ?: 0}  |
-| Passed       | ${(testsSummary?.passed) ?: 0}  |
-| Skipped      | ${(testsSummary?.skipped) ?: 0} |
-| Total        | ${(testsSummary?.total) ?: 0}   |
-
-<% if(!testsErrors?.isEmpty()) {%>
 ### Genuine test errors [![${testsErrors?.size()}](https://img.shields.io/badge/${testsErrors?.size()}%20-red)](${jobUrl}/tests)
 :broken_heart: There are test failures but not known flaky tests, most likely a genuine test failure.
 <%testsErrors?.each {%>
 * **Name**: `${it}`<%}%>
-<%}%>
 
 </p>
 </details>


### PR DESCRIPTION
## What does this PR do?

Remove the test summary in the flaky comment.

## Why is it important?

It's already duplicated in the GitHub build comment which it runs always by default. So this could help to reduce the verbosity in the GitHub comments .

![image](https://user-images.githubusercontent.com/2871786/134490999-4118b4cd-3683-4f80-ae14-ceb9ea300657.png)
