### PR TITLE
Retrive 3x times more steps

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -442,7 +442,7 @@ function prepareEnvInfo() {
 }
 
 ### Fetch some artifacts that won't be attached to the data to be sent to ElasticSearch
-fetchAndDefaultStepsInfo "${STEPS_INFO}" "${BO_BUILD_URL}/steps/?limit=10000" "${DEFAULT_HASH}"
+fetchAndDefaultStepsInfo "${STEPS_INFO}" "${BO_BUILD_URL}/steps/?limit=30000" "${DEFAULT_HASH}"
 fetchAndDefaultTestsErrors "${TESTS_ERRORS}" "${BO_BUILD_URL}/tests/?status=FAILED" "${DEFAULT_LIST}"
 fetchAndDefault "${PIPELINE_LOG}" "${BO_BUILD_URL}/log/" "${DEFAULT_STRING}"
 

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_abort_runs_1_steps-f9074b7b-7552-4ad1-b753-22349b0f4aaf.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_abort_runs_1_steps-f9074b7b-7552-4ad1-b753-22349b0f4aaf.json
@@ -2,7 +2,7 @@
   "id" : "f9074b7b-7552-4ad1-b753-22349b0f4aaf",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_abort_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/abort/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/abort/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_empty_runs_1_steps-d0c9398e-e195-4670-a60c-42f6137c3e6a.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_empty_runs_1_steps-d0c9398e-e195-4670-a60c-42f6137c3e6a.json
@@ -2,7 +2,7 @@
   "id" : "d0c9398e-e195-4670-a60c-42f6137c3e6a",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_empty_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/empty/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/empty/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_error_runs_1_steps-61d5f603-0b12-44f1-a722-b476a42c0cdc.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_error_runs_1_steps-61d5f603-0b12-44f1-a722-b476a42c0cdc.json
@@ -2,7 +2,7 @@
   "id" : "61d5f603-0b12-44f1-a722-b476a42c0cdc",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_error_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/error/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/error/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_multitestfailures_runs_1_steps-d56fb1f2-cfe1-4f48-9b1a-5040f0109bef.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_multitestfailures_runs_1_steps-d56fb1f2-cfe1-4f48-9b1a-5040f0109bef.json
@@ -2,7 +2,7 @@
   "id" : "d56fb1f2-cfe1-4f48-9b1a-5040f0109bef",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_multitestfailures_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/multiTestFailures/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/multiTestFailures/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_success_runs_1_steps-fb5412aa-feea-4ccd-a33f-60d6bc76e741.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_success_runs_1_steps-fb5412aa-feea-4ccd-a33f-60d6bc76e741.json
@@ -2,7 +2,7 @@
   "id" : "fb5412aa-feea-4ccd-a33f-60d6bc76e741",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_success_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/success/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/success/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_unstable_runs_1_steps-0152ed4b-b083-4072-830e-7768364a3597.json
+++ b/src/test/resources/mappings/blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_unstable_runs_1_steps-0152ed4b-b083-4072-830e-7768364a3597.json
@@ -2,7 +2,7 @@
   "id" : "0152ed4b-b083-4072-830e-7768364a3597",
   "name" : "blue_rest_organizations_jenkins_pipelines_it_getbuildinfojsonfiles_unstable_runs_1_steps",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/unstable/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/unstable/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/mappings/mapping-blue-rest-organizations-jenkins-pipelines-it-getBuildInfoJsonFiles-cobertura-runs-1-steps-7nqjX.json
+++ b/src/test/resources/mappings/mapping-blue-rest-organizations-jenkins-pipelines-it-getBuildInfoJsonFiles-cobertura-runs-1-steps-7nqjX.json
@@ -1,7 +1,7 @@
 {
   "id" : "1bee78fa-9ded-30e1-9568-de52fa294a2d",
   "request" : {
-    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/cobertura/runs/1/steps/?limit=10000",
+    "url" : "/blue/rest/organizations/jenkins/pipelines/it/getBuildInfoJsonFiles/cobertura/runs/1/steps/?limit=30000",
     "method" : "GET"
   },
   "response" : {


### PR DESCRIPTION
## What does this PR do?

Retrieve more steps that are consumed to generate the GitHub comment with the build status

## Why is it important?

Some pipeline are that big that their build comment in GitHub does not provide all the errors:

![image](https://user-images.githubusercontent.com/2871786/134518857-2bb12308-720d-415c-91cd-0e5d6a633142.png)

![image](https://user-images.githubusercontent.com/2871786/134518891-2b955bc6-a08c-453b-847a-2f6064fbe512.png)

![image](https://user-images.githubusercontent.com/2871786/134518922-32653efd-2a54-43d9-b7cf-789cdf7d82fa.png)


See https://github.com/elastic/beats/pull/27878