### PR TITLE
fix: teach withGoEnv about Go executable package installation for Go 1.16 and up

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -481,6 +481,10 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return script.call()
     })
     helper.registerAllowedMethod('isCommentTrigger', { return false })
+    helper.registerAllowedMethod('isBeforeGo1_16', [Map.class], { m ->
+      def script = loadScript('vars/isBeforeGo1_16.groovy')
+      return script.call(m)
+    })
     helper.registerAllowedMethod('isInstalled', [Map.class], { m ->
       def script = loadScript('vars/isInstalled.groovy')
       return script.call(m)

--- a/src/test/groovy/IsBeforeGo1_16StepTests.groovy
+++ b/src/test/groovy/IsBeforeGo1_16StepTests.groovy
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsBeforeGo1_16Tests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isBeforeGo1_16.groovy')
+  }
+
+  @Test
+  void test_go_1_15() throws Exception {
+    def ret = script.call(version: '1.15')
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_go_1_16() throws Exception {
+    def ret = script.call(version: '1.16')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_default() throws Exception {
+    def ret = script.call()
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+}

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -136,7 +136,7 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void testPkgs() throws Exception {
+  void testPkgs_go_1_12() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "linux" })
     def isOK = false
     script.call(version: "1.12.2", pkgs: [ "P1", "P2" ]){
@@ -148,8 +148,26 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P1'))
-    assertTrue(assertMethodCallContainsPattern('sh', 'Installing P2'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'go get -u P1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'go get -u P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testPkgs_go_1_16() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def isOK = false
+    script.call(version: "1.16.1", pkgs: [ "P1", "P2" ]){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.16.1.linux.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.16.1.linux.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'go install P1@latest'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'go install P2@latest'))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -118,22 +118,22 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
     assertJobStatusSuccess()
   }
 
-@Test
-void testOSArg() throws Exception {
-  env.GO_VERSION = "1.12.2"
-  def isOK = false
-  script.call(os: 'custom-os'){
-    if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.custom-os.amd64/bin:/foo/bin"
-      && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.custom-os.amd64"
-      && binding.getVariable("GOPATH") == "WS" ){
-        isOK = true
-      }
+  @Test
+  void testOSArg() throws Exception {
+    env.GO_VERSION = "1.12.2"
+    def isOK = false
+    script.call(os: 'custom-os'){
+      if(binding.getVariable("PATH") == "WS/bin:WS/.gvm/versions/go1.12.2.custom-os.amd64/bin:/foo/bin"
+        && binding.getVariable("GOROOT") == "WS/.gvm/versions/go1.12.2.custom-os.amd64"
+        && binding.getVariable("GOPATH") == "WS" ){
+          isOK = true
+        }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
+    assertJobStatusSuccess()
   }
-  printCallStack()
-  assertTrue(isOK)
-  assertTrue(assertMethodCallContainsPattern('sh', 'Installing go 1.12.2'))
-  assertJobStatusSuccess()
-}
 
   @Test
   void testPkgs() throws Exception {

--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -93,15 +93,28 @@ void testOSArg() throws Exception {
 }
 
   @Test
-  void testPkgs() throws Exception {
+  void testPkgs_go_1_12() throws Exception {
     def isOK = false
     script.call(version: '1.12.2', pkgs: [ "P1", "P2" ]){
       isOK = definedVariables('1.12.2', 'windows')
     }
     printCallStack()
     assertTrue(isOK)
-    assertTrue(assertMethodCallContainsPattern('bat', 'Installing P1'))
-    assertTrue(assertMethodCallContainsPattern('bat', 'Installing P2'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'go get -u P1'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'go get -u P2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testPkgs_go_1_16() throws Exception {
+    def isOK = false
+    script.call(version: "1.16.1", pkgs: [ "P1", "P2" ]){
+      isOK = definedVariables('1.16.1', 'windows')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'go install P1@latest'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'go install P2@latest'))
     assertJobStatusSuccess()
   }
 

--- a/vars/README.md
+++ b/vars/README.md
@@ -1529,6 +1529,17 @@ Whether the architecture is an arm based using the `nodeArch` step
     }
 ```
 
+## isBeforeGo1_16
+if the given Golang version is pre 1.16.
+
+```
+  whenTrue(isBeforeGo1_16(version: '1.17')) {
+    ...
+  }
+```
+
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)
+
 ## isBranch
 Whether the build is based on a Branch or no
 

--- a/vars/isBeforeGo1_16.groovy
+++ b/vars/isBeforeGo1_16.groovy
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  If the given Golang version is pre 1.16.
+
+  whenTrue(isBeforeGo1_16(version: '1.17')) {
+    ...
+  }
+*/
+def call(Map args = [:]){
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
+  version = version.startsWith('go') ? version.minus('go') : version
+  def ref = "1.16"
+  def vVer = version.tokenize(".")
+  def vRef = ref.tokenize(".")
+  def n = Math.min(vVer.size(), vRef.size())
+  for (int i = 0; i < n; i++) {
+    def q = vVer[i].toInteger()
+    def r = vRef[i].toInteger()
+    if (q != r) {
+      return q < r
+    }
+  }
+  return vVer.size() < vRef.size()
+}

--- a/vars/isBeforeGo1_16.txt
+++ b/vars/isBeforeGo1_16.txt
@@ -1,0 +1,9 @@
+if the given Golang version is pre 1.16.
+
+```
+  whenTrue(isBeforeGo1_16(version: '1.17')) {
+    ...
+  }
+```
+
+* version: Go version to install, if it is not set, it'll use GO_VERSION env var or [default version](#goDefaultVersion)

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -80,23 +80,6 @@ def installPackages(Map args = [:]) {
   }
 }
 
-def isBeforeGo1_16(Map args = [:]) {
-  def ref = "1.16"
-  def version = args.containsKey('version') ? args.version : goDefaultVersion()
-  version = version.startsWith('go') ? version.minus('go') : version
-  def vVer = version.tokenize(".")
-  def vRef = ref.tokenize(".")
-  def n = Math.min(vVer.size(), vRef.size())
-  for (int i = 0; i < n; i++) {
-    def q = vVer[i].toInteger()
-    def r = vRef[i].toInteger()
-    if (q != r) {
-      return q < r
-    }
-  }
-  return vVer.size() < vRef.size()
-}
-
 def goArch() {
   // Unsupported architectures:
   //    darwin for arm64 in case isArm() needs a tweak

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -52,7 +52,7 @@ def call(Map args = [:], Closure body) {
     "GOARCH=${arch}"
   ]){
     installGo(version: version)
-    installPackages(pkgs: pkgs)
+    installPackages(version: version, pkgs: pkgs)
     debugGoEnv()
     body()
   }
@@ -68,13 +68,33 @@ def installPackages(Map args = [:]) {
   // GOARCH is required to be able to install the given packages for the specific arch
   def arch = (env.GOARCH?.trim()) ?: goArch()
   log(level: 'DEBUG', text: "installPackages: GOARCH=${arch}")
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
+  def method = isBeforeGo1_16(version: version) ? "get -u" : "install"
+  def atVersion = isBeforeGo1_16(version: version) ?: "@latest"
   withEnv(["GOARCH=${arch}"]){
     args.pkgs?.each{ p ->
       retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        sh(label: "Installing ${p}", script: "go get -u ${p}")
+        sh(label: "Installing ${p}", script: "go ${method} ${p}${atVersion}")
       }
     }
   }
+}
+
+def isBeforeGo1_16(Map args = [:]) {
+  def ref = "1.16"
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
+  version = version.startsWith('go') ? version.minus('go') : version
+  def vVer = version.tokenize(".")
+  def vRef = ref.tokenize(".")
+  def n = Math.min(vVer.size(), vRef.size())
+  for (int i = 0; i < n; i++) {
+    def q = vVer[i].toInteger()
+    def r = vRef[i].toInteger()
+    if (q != r) {
+      return q < r
+    }
+  }
+  return vVer.size() < vRef.size()
 }
 
 def goArch() {

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -70,7 +70,7 @@ def installPackages(Map args = [:]) {
   log(level: 'DEBUG', text: "installPackages: GOARCH=${arch}")
   def version = args.containsKey('version') ? args.version : goDefaultVersion()
   def method = isBeforeGo1_16(version: version) ? "get -u" : "install"
-  def atVersion = isBeforeGo1_16(version: version) ?: "@latest"
+  def atVersion = isBeforeGo1_16(version: version) ? '' : "@latest"
   withEnv(["GOARCH=${arch}"]){
     args.pkgs?.each{ p ->
       retryWithSleep(retries: 3, seconds: 5, backoff: true){

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -47,7 +47,7 @@ def call(Map args = [:], Closure body) {
   def goRoot = "${userProfile}\\${goDir}"
   def path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};C:\\tools\\mingw${mingwArch}\\bin;${env.PATH}"
   def method = isBeforeGo1_16(version: version) ? "get -u" : "install"
-  def atVersion = isBeforeGo1_16(version: version) ?: "@latest"
+  def atVersion = isBeforeGo1_16(version: version) ? '' : "@latest"
 
   withEnv([
     "HOME=${env.WORKSPACE}",

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -46,6 +46,8 @@ def call(Map args = [:], Closure body) {
   def goDir = ".gvm\\versions\\go${lastCoordinate != ".0" ? version : version[0..-3]}.${os}.${goArch}"
   def goRoot = "${userProfile}\\${goDir}"
   def path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};C:\\tools\\mingw${mingwArch}\\bin;${env.PATH}"
+  def method = isBeforeGo1_16(version: version) ? "get -u" : "install"
+  def atVersion = isBeforeGo1_16(version: version) ?: "@latest"
 
   withEnv([
     "HOME=${env.WORKSPACE}",
@@ -61,9 +63,26 @@ def call(Map args = [:], Closure body) {
     }
     pkgs?.each{ p ->
       retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        bat(label: "Installing ${p}", script: "go get -u ${p}")
+        bat(label: "Installing ${p}", script: "go ${method} ${p}${atVersion}")
       }
     }
     body()
   }
+}
+
+def isBeforeGo1_16(Map args = [:]) {
+  def ref = "1.16"
+  def version = args.containsKey('version') ? args.version : goDefaultVersion()
+  version = version.startsWith('go') ? version.minus('go') : version
+  def vVer = version.tokenize(".")
+  def vRef = ref.tokenize(".")
+  def n = Math.min(vVer.size(), vRef.size())
+  for (int i = 0; i < n; i++) {
+    def q = vVer[i].toInteger()
+    def r = vRef[i].toInteger()
+    if (q != r) {
+      return q < r
+    }
+  }
+  return vVer.size() < vRef.size()
 }

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -69,20 +69,3 @@ def call(Map args = [:], Closure body) {
     body()
   }
 }
-
-def isBeforeGo1_16(Map args = [:]) {
-  def ref = "1.16"
-  def version = args.containsKey('version') ? args.version : goDefaultVersion()
-  version = version.startsWith('go') ? version.minus('go') : version
-  def vVer = version.tokenize(".")
-  def vRef = ref.tokenize(".")
-  def n = Math.min(vVer.size(), vRef.size())
-  for (int i = 0; i < n; i++) {
-    def q = vVer[i].toInteger()
-    def r = vRef[i].toInteger()
-    if (q != r) {
-      return q < r
-    }
-  }
-  return vVer.size() < vRef.size()
-}


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

This change fixes Go executable package installation for Go versions at and above Go version 1.16.


## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

Currently, the installation method used by `withGoEnv` is `go get -u` which modifies go.mod and go.sum, causing subsequent tests to fail if building with a go1.16+ toolchain. The preferred method for installation of executable packages since Go 1.16 is `go install host.dom/path/to/pkg@version` with `@version` being `@latest` for the equivalent to the `-u` currently used with `go get` (see [here](https://go.dev/blog/go116-module-changes) under "Installing an executable at a specific version").


## Related issues
Fixes #1299
