### PR TITLE
[bump][automation] skip backports for the automation

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -33,13 +33,13 @@ projects:
     branches:
       - master
     enabled: true
-    labels: dependency
+    labels: dependency,backport-skip
   - repo: fleet-server
     script: .ci/bump-go-release-version.sh
     branches:
       - master
     enabled: true
-    labels: dependency
+    labels: dependency,backport-skip
   - repo: golang-crossbuild
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Add `backport-skip` label for certain projects that use the automated bump process

## Why is it important?

Avoid missing backport labels in the notifications

## Related issues

Caused by https://github.com/elastic/beats/pull/28022 and https://github.com/elastic/fleet-server/pull/723
