### PR TITLE
[dependencies] bump for the local jenkins instance

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/infra/jenkins:202107191510.c5edabb9486d
+FROM docker.elastic.co/infra/jenkins:202109131610.ef2e7a6a5a14
 
 
 COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/local/configs/plugins.txt
+++ b/local/configs/plugins.txt
@@ -7,3 +7,12 @@ monitoring
 opentelemetry
 plot
 ssh-agent
+
+blueocean
+blueocean-jira
+configuration-as-code
+git
+git-client
+github-branch-source
+pipeline-model-definition
+workflow-cps-global-lib


### PR DESCRIPTION
## What does this PR do?

Bump version to consume the latest OpenTelemetry plugin version

## Why is it important?

Otherwise it fails the local jenkins instance
