### PR TITLE
feat: add a new step for adding Docker context to closures

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -573,6 +573,10 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return script.call(m)
     })
     helper.registerAllowedMethod('withCredentials', [List.class, Closure.class], TestUtils.withCredentialsInterceptor)
+    helper.registerAllowedMethod('withDockerEnv', [Map.class, Closure.class], { m, c ->
+      def script = loadScript('vars/withDockerEnv.groovy')
+      return script.call(m, c)
+    })
     helper.registerAllowedMethod('withEnvMask', [Map.class, Closure.class], TestUtils.withEnvMaskInterceptor)
     helper.registerAllowedMethod('withEnvWrapper', [Closure.class], { closure -> closure.call() })
     helper.registerAllowedMethod('withGithubNotify', [Map.class, Closure.class], null)

--- a/src/test/groovy/WithDockerEnvStepTests.groovy
+++ b/src/test/groovy/WithDockerEnvStepTests.groovy
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class WithDockerEnvStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/withDockerEnv.groovy')
+  }
+
+  @Test
+  void test() throws Exception {
+    script.call(secret: VaultSecret.SECRET_NAME.toString()){}
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}" "docker.io"'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testDockerContext() throws Exception {
+    def isOK = false
+    script.call(secret: VaultSecret.SECRET_NAME.toString()){
+      if(binding.getVariable("DOCKER_USER") == "username"
+      && binding.getVariable("DOCKER_PASSWORD") == "user_password"){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testRegistry() throws Exception {
+    script.call(secret: VaultSecret.SECRET_NAME.toString(), registry: "other.docker.io"){}
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}" "other.docker.io"'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testWindows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { false })
+    script.call(secret: VaultSecret.SECRET_NAME.toString()){}
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('bat', 'docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "docker.io"'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testRegistryInWindows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { false })
+    script.call(secret: VaultSecret.SECRET_NAME.toString(), registry: 'other.docker.io'){}
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('bat', 'docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "other.docker.io"'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_role_secret() throws Exception {
+    script.call(secret: VaultSecret.SECRET_NAME.toString(), role_id: "role-id", secret_id: 'secret-id'){}
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('getVaultSecret', 'role_id=role-id, secret_id=secret-id'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}" "docker.io"'))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -2879,6 +2879,26 @@ Wrap the cluster credentials and entrypoints as environment variables that are m
 NOTE: secrets for the test clusters are defined in the 'secret/observability-team/ci/test-clusters'
       vault location
 
+## withDockerEnv
+Configure the Docker context to run the body closure, logining to hub.docker.com with an
+authentication credentials from a Vault secret. The vault secret contains `user` and `password`
+fields with the authentication details. with the below environment variables:
+
+* `DOCKER_USER`
+* `DOCKER_PASSWORD`
+
+```
+  withDockerEnv() {
+    // block
+  }
+  withDockerEnv(secret: 'secret/team/ci/secret-name') {
+    // block
+  }
+  withDockerEnv(secret: 'secret/team/ci/secret-name', registry: "docker.io") {
+    // block
+  }
+```
+
 ## withEnvMask
 This step will define some environment variables and mask their content in the
 console output, it simplifies Declarative syntax

--- a/vars/dockerLogin.groovy
+++ b/vars/dockerLogin.groovy
@@ -23,40 +23,7 @@
   dockerLogin(secret: 'secret/team/ci/secret-name', registry: "docker.io")
 */
 def call(Map args = [:]){
-  def secret = args.containsKey('secret') ? args.secret : error("dockerLogin: No valid secret to looking for.")
-  def registry = args.containsKey('registry') ? args.registry : "docker.io"
-
-  def jsonValue = getVaultSecret(args)
-  def data = jsonValue.containsKey('data') ? jsonValue.data : error("dockerLogin: No valid data in secret.")
-  def dockerUser = data.containsKey('user') ? data.user : error("dockerLogin: No valid user in secret.")
-  def dockerPassword = data.containsKey('password') ? data.password : error("dockerLogin: No valid password in secret.")
-
-  withEnvMask(vars: [
-    [var: "DOCKER_USER", password: dockerUser],
-    [var: "DOCKER_PASSWORD", password: dockerPassword]
-  ]){
-    // When running in the CI with multiple parallel stages
-    // the access could be considered as a DDOS attack.
-    retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-      if (isUnix()) {
-        sh(label: "Docker login", script: """
-          set +x
-          if command -v host 2>&1 > /dev/null; then
-            host ${registry} 2>&1 > /dev/null
-          fi
-          if command -v dig 2>&1 > /dev/null; then
-            dig ${registry} 2>&1 > /dev/null
-          fi
-          docker login -u "\${DOCKER_USER}" -p "\${DOCKER_PASSWORD}" "${registry}" 2>/dev/null
-          """)
-      } else {
-        bat(label: 'is registry service up?', script: """@ECHO OFF
-          nslookup ${registry} > NUL 2>&1
-        """)
-        bat(label: 'Docker Login', script: """@ECHO OFF
-          docker login -u "%DOCKER_USER%" -p "%DOCKER_PASSWORD%" "${registry}" 2> NUL
-        """)
-      }
-    }
+  withDockerEnv(args) {
+    // NOOP
   }
 }

--- a/vars/withDockerEnv.txt
+++ b/vars/withDockerEnv.txt
@@ -1,0 +1,18 @@
+Configure the Docker context to run the body closure, logining to hub.docker.com with an
+authentication credentials from a Vault secret. The vault secret contains `user` and `password`
+fields with the authentication details. with the below environment variables:
+
+* `DOCKER_USER`
+* `DOCKER_PASSWORD`
+
+```
+  withDockerEnv() {
+    // block
+  }
+  withDockerEnv(secret: 'secret/team/ci/secret-name') {
+    // block
+  }
+  withDockerEnv(secret: 'secret/team/ci/secret-name', registry: "docker.io") {
+    // block
+  }
+```


### PR DESCRIPTION
## What does this PR do?
It adds `withDockerEnv` as a new step, so that it will run a closure adding the DOCKER_USER and DOCKER_PASSWORD environment variables to the closure.

It's copying the very same logic that the existing `dockerLogin` step, which I'd like to deprecate in favour of this one:

```groovy
def call(Map args = [:]){
  withDockerEnv(args) {
    // NOOP
  }
}
```


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
In the e2e-testing framework we are seeing that pulling from observability-ci private registry is not possible with the current Go code, which uses the Docker client library to Pull images. This code needs Auth credentials to be set, never mind if we already performed a docker-login in the machine.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #1305