### PR TITLE
Enable goDefaultVersion to read from the root folder or base_dir folder

### DIFF
--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -25,9 +25,9 @@ def call(Map args = [:]) {
   if(isGoVersionEnvVarSet()) {
     goDefaultVersion = "${env.GO_VERSION}"
   } else {
-    def goFileVersion = '.go-version'
-    if (fileExists(goFileVersion)){
-      goDefaultVersion = readFile(file: goFileVersion)?.trim()
+    def found = ['.go-version', "${env.BASE_DIR}/.go-version'"].find { fileExists(it) }
+    if (found) {
+      goDefaultVersion = readFile(file: found)?.trim()
     }
   }
   return goDefaultVersion


### PR DESCRIPTION
## What does this PR do?

Support to read the BASE_DIR location and look for the `.go-version`

## Why is it important?

`withMageEnv` and `withGoEnv` use `goDefaultVersion` and it relies in three different ways to configure the go-version:

- `version` argument is passed explicitly when using the above steps
- `GO_VERSION` env variable is set
- `.go-version` file exists
- Otherwise it uses the default version expclicitly set in `goDefaultVersion` 

Unfortunately, the consumers of `withMageEnv` and `withGoEnv` use the below format:

```
    withMageEnv(...) {
      dir(....)
```

And the `.go-version` file is not accessible while if they move to:

```
    dir(...) {
       withMageEnv(...
```

Then it will be accessible

### Questions

- [ ] Are there any side effects if using dir ... withMageEnv? I could not see anything in https://github.com/elastic/elastic-package/pull/538
