### PR TITLE
bump: obs-test-env is not a multibranch repo

### DIFF
--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -31,10 +31,7 @@ projects:
   - repo: observability-test-environments
     script: .ci/bump-stack-release-version.sh
     branches:
-      - dev
-      - edge
       - master
-      - release
     enabled: true
     labels: dependency
     reviewer: elastic/observablt-robots-on-call


### PR DESCRIPTION
## What does this PR do?

Tidying up the branches for the obs-test-env repo

## Why is it important?

Those branches don't exist anymore