### PR TITLE
fix: use Ubuntu workers

### DIFF
--- a/.ci/buildBeatsDockerImages.groovy
+++ b/.ci/buildBeatsDockerImages.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'ubuntu-20' }
   environment {
     REPO = 'beats'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/.ci/dockerImagesOpbeans.groovy
+++ b/.ci/dockerImagesOpbeans.groovy
@@ -56,7 +56,7 @@ pipeline {
       }
       parallel {
         stage('Opbeans-dotnet') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-dotnet.git',
@@ -66,7 +66,7 @@ pipeline {
           }
         }
         stage('Opbeans-node') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-node.git',
@@ -76,7 +76,7 @@ pipeline {
           }
         }
         stage('Opbeans-python') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-python.git',
@@ -86,7 +86,7 @@ pipeline {
           }
         }
         stage('Opbeans-frontend') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-frontend.git',
@@ -96,7 +96,7 @@ pipeline {
           }
         }
         stage('Opbeans-java') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-java.git',
@@ -106,7 +106,7 @@ pipeline {
           }
         }
         stage('Opbeans-go') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-go.git',
@@ -116,7 +116,7 @@ pipeline {
           }
         }
         stage('Opbeans-loadgen') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-loadgen.git',
@@ -126,7 +126,7 @@ pipeline {
           }
         }
         stage('Opbeans-flask') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           /** FIXME disable until it is fully implemented: https://github.com/elastic/opbeans-flask/pull/5 */
           when {
@@ -140,7 +140,7 @@ pipeline {
           }
         }
         stage('Opbeans-ruby') {
-          agent { label 'docker' }
+          agent { label 'ubuntu-20' }
           options { skipDefaultCheckout() }
           steps {
             buildDockerImage(repo: 'https://github.com/elastic/opbeans-ruby.git',


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Explicitly use Ubuntu 20.04 workers.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
The label `docker` can provision Linux and Windows workers so the pipeline fails when hit a Windows worker.
 