### PR TITLE
feat: add OS information for each build

### DIFF
--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -163,7 +163,6 @@ function fetchAndPrepareBuildReport() {
 function fetchAndPrepareOSReport() {
     file=$1
     key=$2
-    default=$3
 
     name=$(grep -E '^(NAME)=' /etc/os-release | awk -F\" '{print $(NF-1)}')
     version=$(grep -E '^(VERSION)=' /etc/os-release | awk -F\" '{print $(NF-1)}')
@@ -483,7 +482,7 @@ fi
 
 ### Prepare build report file
 echo '{' > "${BUILD_REPORT}"
-fetchAndPrepareOSReport "${OS_INFO}" "os" "${DEFAULT_HASH}"
+fetchAndPrepareOSReport "${OS_INFO}" "os"
 fetchAndPrepareBuildReport "${JOB_INFO}" "${BO_JOB_URL}/" "job" "${DEFAULT_HASH}"
 fetchAndPrepareBuildReport "${CHANGESET_INFO}" "${BO_BUILD_URL}/changeSet/" "changeSet" "${DEFAULT_LIST}"
 fetchAndPrepareArtifactsInfo "${ARTIFACTS_INFO}" "${BO_BUILD_URL}/artifacts/" "artifacts" "${DEFAULT_LIST}"


### PR DESCRIPTION
## What does this PR do?
This PR adds a new build data file, `os-info.json`, containing the following information:

- OS name, obtained from Linux's `/etc/os-release`
- OS version, obtained from Linux's `/etc/os-release`
- Machine Architecture, obtained from Linux `uname -i`

The data will be added to a new JSON object, with `os` key, that will be appended to the already existing `build-report.json` file, so the new data will be as discoverable as the existing one.


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
This will provide information about where the build has been executed, important for test execution and OS/ARCH support. If/when stored in Elasticsearch, we could search for tests running on Linux > Ubuntu > x86_64.

## Other concerns
Because the `notifyBuildResult` step only works on Linux, these changes are only valid for Unix workers, not Windows.


<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE