### PR TITLE
Add test coverage for multi field arguments in gh

### DIFF
--- a/src/test/groovy/GhStepTests.groovy
+++ b/src/test/groovy/GhStepTests.groovy
@@ -182,4 +182,11 @@ class GhStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', """--search='"[automation] foo bar" in:title'"""))
   }
+
+  @Test
+  void test_with_same_field_twice() throws Exception {
+    script.call(command: 'workflow run build_and_test.yml', flags: [field: ['id=1', 'runner=ubuntu']])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "gh workflow run build_and_test.yml --field='id=1' --field='runner=ubuntu'"))
+  }
 }

--- a/src/test/groovy/GhStepTests.groovy
+++ b/src/test/groovy/GhStepTests.groovy
@@ -184,7 +184,7 @@ class GhStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_with_same_field_twice() throws Exception {
+  void test_with_multiple_flag_entries() throws Exception {
     script.call(command: 'workflow run build_and_test.yml', flags: [field: ['id=1', 'runner=ubuntu']])
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', "gh workflow run build_and_test.yml --field='id=1' --field='runner=ubuntu'"))


### PR DESCRIPTION
## What does this PR do?

Add test coverage for the `gh` step to validate the same field can be set several times.

## Why is it important?

To illustrate this is possible