### PR TITLE
Use tab separator for listGithubReleases

### DIFF
--- a/src/test/groovy/ListGithubReleasesStepTests.groovy
+++ b/src/test/groovy/ListGithubReleasesStepTests.groovy
@@ -67,7 +67,7 @@ class ListGithubReleasesStepTests extends ApmBasePipelineTest {
   @Test
   void test_with_single_row() throws Exception {
     helper.registerAllowedMethod('gh', [Map.class], {
-      return 'v1.1.256  Latest  (v1.1.256)  about 21 hours ago' })
+      return 'Go 1.17.2	Latest	1.17.2	2021-10-12T13:26:25Z' })
     def ret = script.call()
     printCallStack()
     assertTrue(ret.size() == 1)
@@ -76,9 +76,9 @@ class ListGithubReleasesStepTests extends ApmBasePipelineTest {
   @Test
   void test_with_multiple_data() throws Exception {
     helper.registerAllowedMethod('gh', [Map.class], {
-      return '''v1.1.256  Latest  (v1.1.256)  about 21 hours ago
-v1.1.255          (v1.1.255)  about 5 days ago
-v1.1.254          (v1.1.254)  about 6 days ago'''})
+      return '''Go 1.17.2	Latest	1.17.2	2021-10-12T13:26:25Z
+Go 1.17.1		1.17.1	2021-10-05T10:20:08Z
+Go 1.15.12		1.15	2021-05-25T17:10:49Z'''})
     def ret = script.call()
     printCallStack()
     assertTrue(ret.size() == 3)

--- a/vars/listGithubReleases.groovy
+++ b/vars/listGithubReleases.groovy
@@ -30,10 +30,12 @@ def call(Map args = [:]) {
   try {
     // filter all the issues given those labels.
     releases = gh(command: 'release list', flags: [limit: limit])
+    log(level: 'DEBUG', text: "listGithubReleases: output ${releases}")
     if (releases?.trim()) {
       releases.split('\n').each { line ->
-        def data = line.split(' ')
-        output.put("${data[0]}", [ value: line ])
+        log(level: 'DEBUG', text: "listGithubReleases: parsing line ${line}")
+        def data = line.split('\t')
+        output.put(data[2], [ value: line ])
       }
     }
   } catch (err) {


### PR DESCRIPTION
## What does this PR do?

Use the tab separator

## Why is it important?

Otherwise the list of github releases is always 1!

## Related issues
Until https://github.com/cli/cli/issues/4572 is supported


## Test

Using tabs in the UTs

Verified locally in a local jenkins instance

![image](https://user-images.githubusercontent.com/2871786/140046438-3698a82c-82ac-4984-b59b-11b1adf68cd9.png)
