### PR TITLE
Pin the gh version for the listGithubReleases step

### DIFF
--- a/vars/listGithubReleases.groovy
+++ b/vars/listGithubReleases.groovy
@@ -29,7 +29,7 @@ def call(Map args = [:]) {
   def releases
   try {
     // filter all the issues given those labels.
-    releases = gh(command: 'release list', flags: [limit: limit])
+    releases = gh(command: 'release list', flags: [limit: limit], version: '2.2.0', forceInstallation: true)
     log(level: 'DEBUG', text: "listGithubReleases: output ${releases}")
     if (releases?.trim()) {
       releases.split('\n').each { line ->


### PR DESCRIPTION
## What does this PR do?

Pin the gh version for the listGithubReleases step

## Why is it important?

It parses the output, therefore let's ensure any format changes in the output don't affect the step
