### PR TITLE
Support for macos, arm and windows in the gh step

### DIFF
--- a/src/test/groovy/GhStepTests.groovy
+++ b/src/test/groovy/GhStepTests.groovy
@@ -32,17 +32,22 @@ class GhStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_windows() throws Exception {
-    testWindows() {
+  void test_without_args() throws Exception {
+    testMissingArgument('command') {
       script.call()
     }
   }
 
   @Test
-  void test_without_args() throws Exception {
-    testMissingArgument('command') {
-      script.call()
-    }
+  void test_windows() throws Exception {
+    helper.registerAllowedMethod('isUnix', [], { false })
+    script.call(command: 'issue list', flags: [ label: 'foo'])
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=2a9602aa-ab9f-4e52-baf3-b71ca88469c7, variable=GITHUB_TOKEN'))
+    assertTrue(assertMethodCallContainsPattern('cmd', "gh issue list --label='foo'"))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PATH+GH'))
+    assertFalse(assertMethodCallContainsPattern('sh', "wget -q -O"))
+    assertJobStatusSuccess()
   }
 
   @Test

--- a/src/test/groovy/GhStepTests.groovy
+++ b/src/test/groovy/GhStepTests.groovy
@@ -87,7 +87,7 @@ class GhStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withEnv', 'PATH+GH'))
     assertTrue(assertMethodCallContainsPattern('sh', 'wget -q -O'))
-    assertTrue(assertMethodCallContainsPattern('sh', '1.9.2'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'linux_amd64.tar.gz'))
     assertJobStatusSuccess()
   }
 
@@ -205,6 +205,27 @@ class GhStepTests extends ApmBasePipelineTest {
     script.call(command: 'issue list', version: "2.0.0", forceInstallation: true)
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', '2.0.0'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_in_darwin() throws Exception {
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m -> return m.tool.equals('wget') })
+    helper.registerAllowedMethod('nodeOS', [], { return 'darwin' })
+    script.call(command: 'issue list')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'macOS_amd64.tar.gz'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_in_arm() throws Exception {
+    helper.registerAllowedMethod('isArm', [], { return true })
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m -> return m.tool.equals('wget') })
+    helper.registerAllowedMethod('nodeOS', [], { return 'linux' })
+    script.call(command: 'issue list')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'linux_arm64.tar.gz'))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/GithubIssuesStepTests.groovy
+++ b/src/test/groovy/GithubIssuesStepTests.groovy
@@ -30,13 +30,6 @@ class GithubIssuesStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_windows() throws Exception {
-    testWindows() {
-      script.call()
-    }
-  }
-
-  @Test
   void test_with_no_data() throws Exception {
     helper.registerAllowedMethod('gh', [Map.class], { return '' })
     def ret = script.call()

--- a/src/test/groovy/GithubPullRequestsStepTests.groovy
+++ b/src/test/groovy/GithubPullRequestsStepTests.groovy
@@ -30,13 +30,6 @@ class GithubPullRequestsStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_windows() throws Exception {
-    testWindows() {
-      script.call()
-    }
-  }
-
-  @Test
   void test_with_no_data() throws Exception {
     helper.registerAllowedMethod('gh', [Map.class], { return '' })
     def ret = script.call()

--- a/src/test/groovy/ListGithubReleasesStepTests.groovy
+++ b/src/test/groovy/ListGithubReleasesStepTests.groovy
@@ -29,13 +29,6 @@ class ListGithubReleasesStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_windows() throws Exception {
-    testWindows() {
-      script.call()
-    }
-  }
-
-  @Test
   void test_with_no_data() throws Exception {
     helper.registerAllowedMethod('gh', [Map.class], { return '' })
     def ret = script.call()

--- a/vars/README.md
+++ b/vars/README.md
@@ -759,8 +759,6 @@ It requires to be executed within the git workspace, otherwise it will use
 * version: The gh CLI version to be installed. Optional (1.9.2)
 * forceInstallation: Whether to install gh regardless. Optional (false)
 
-_NOTE_: Windows is not supported yet.
-
 ## git
 Override the `git` step to retry the checkout up to 3 times.
 

--- a/vars/gh.groovy
+++ b/vars/gh.groovy
@@ -31,9 +31,6 @@ import groovy.transform.Field
 @Field def ghLocation = ''
 
 def call(Map args = [:]) {
-  if(!isUnix()) {
-    error 'gh: windows is not supported yet.'
-  }
   def command = args.containsKey('command') ? args.command : error('gh: command parameter is required.')
   def credentialsId = args.get('credentialsId', '2a9602aa-ab9f-4e52-baf3-b71ca88469c7')
   def flags = args.get('flags', [:])
@@ -61,7 +58,11 @@ def call(Map args = [:]) {
 
   withEnv(["PATH+GH=${ghLocation}"]) {
     if (forceInstallation || !isInstalled(tool: 'gh', flag: '--version')) {
-      downloadInstaller(ghLocation, version)
+      if(isUnix()) {
+        downloadInstaller(ghLocation, version)
+      } else {
+        installTools([[ tool: 'gh', version: version, provider: 'choco']])
+      }
     }
     withCredentials([string(credentialsId: "${credentialsId}", variable: 'GITHUB_TOKEN')]) {
       def flagsCommand = ''
@@ -85,7 +86,7 @@ def call(Map args = [:]) {
 }
 
 def runCommand(command, flagsCommand) {
-  def output = sh(label: "gh ${command}", script: "gh ${command} ${flagsCommand}", returnStdout: true)
+  def output = cmd(label: "gh ${command}", script: "gh ${command} ${flagsCommand}", returnStdout: true)
   return output
 }
 

--- a/vars/gh.groovy
+++ b/vars/gh.groovy
@@ -90,7 +90,12 @@ def runCommand(command, flagsCommand) {
 }
 
 def downloadInstaller(where, version) {
-  def url = "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+  def os = nodeOS()
+  if (os.equals('darwin')) {
+    os = 'macOS'
+  }
+  def arch = (isArm()) ? 'arm64' : 'amd64'
+  def url = "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_${os}_${arch}.tar.gz"
   def tarball = 'gh.tar.gz'
   if(isInstalled(tool: 'wget', flag: '--version')) {
     dir(where) {

--- a/vars/gh.txt
+++ b/vars/gh.txt
@@ -15,5 +15,3 @@ It requires to be executed within the git workspace, otherwise it will use
 * credentialsId: The credentials to access the repo (repo permissions). Optional. Default: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
 * version: The gh CLI version to be installed. Optional (1.9.2)
 * forceInstallation: Whether to install gh regardless. Optional (false)
-
-_NOTE_: Windows is not supported yet.


### PR DESCRIPTION
## What does this PR do?

Support for `Windows`, `Darwin` and `Arm`

## Why is it important?

`isUnix()` returns true for `Darwin` and `Arm`, therefore there was a chance that the consumers run the gh step in one of those OS/Arch, this should avoid that issue

Support for Windows in case it's needed...