### PR TITLE
chore: add arch

### DIFF
--- a/local/configs/jenkins.yaml
+++ b/local/configs/jenkins.yaml
@@ -11,7 +11,7 @@ jenkins:
   scmCheckoutRetryCount: 2
   nodes:
   - permanent:
-      labelString: "linux immutable docker"
+      labelString: "linux immutable docker x86_64"
       launcher:
         jnlp:
           workDirSettings:


### PR DESCRIPTION
## What does this PR do?

Add a default arch in the local worker

## Why is it important?

`isArm` and some other steps read the labels to be able to know the arch

Otherwise, when testing a pipeline locally if any of those steps are called then it will fail.


![image](https://user-images.githubusercontent.com/2871786/140102487-a48fcf10-24b1-4c5f-8150-42140b1ebf3b.png)

