### PR TITLE
Find oldest version with or conditions

### DIFF
--- a/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
+++ b/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
@@ -61,28 +61,28 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
   void test_match() throws Exception {
     def ret = script.call(versionCondition: "^7.14.0")
     printCallStack()
-    assertTrue(ret.equals('7.14.0'))
+    assert ret.equals('7.14.0')
   }
 
   @Test
   void test_match_ge() throws Exception {
     def ret = script.call(versionCondition: ">=7.14.0")
     printCallStack()
-    assertTrue(ret.equals('7.14.0'))
+    assert ret.equals('7.14.0')
   }
 
   @Test
   void test_snapshot() throws Exception {
     def ret = script.call(versionCondition: "^7.14.1")
     printCallStack()
-    assertTrue(ret.equals('7.14.1-SNAPSHOT'))
+    assert ret.equals('7.14.1-SNAPSHOT')
   }
 
   @Test
   void test_no_match() throws Exception {
     def ret = script.call(versionCondition: "^7.13.0")
     printCallStack()
-    assertTrue(ret.equals('7.13.0'))
+    assert ret.equals('7.13.0')
   }
 
   @Test
@@ -93,7 +93,7 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
       //NOOP
     }
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'versionCondition supports only'))
+    assert assertMethodCallContainsPattern('error', 'versionCondition supports only')
   }
 
   @Test
@@ -101,34 +101,34 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
     // There are already 7.15.0 artifacts, but this release hasn't happened yet, and there are only snapshots for the docker images.
     def ret = script.call(versionCondition: "^7.15.0")
     printCallStack()
-    assertTrue(ret.equals('7.15.0-SNAPSHOT'))
+    assert ret.equals('7.15.0-SNAPSHOT')
   }
   
   @Test
   void test_without_patch() throws Exception {
     def ret = script.call(versionCondition: "^7.14")
     printCallStack()
-    assertTrue(ret.equals('7.14.0'))
+    assert ret.equals('7.14.0')
   }
 
   @Test
   void test_next_minor() throws Exception {
     def ret = script.call(versionCondition: "^7.16.0")
     printCallStack()
-    assertTrue(ret.equals('7.x-SNAPSHOT'))
+    assert ret.equals('7.x-SNAPSHOT')
   }
 
   @Test
   void test_or_condition() throws Exception {
     def ret = script.call(versionCondition: "^7.14.0 || ^8.0.0")
     printCallStack()
-    assertTrue(ret.equals('7.14.0'))
+    assert ret.equals('7.14.0')
   }
 
   @Test
   void test_or_condition_reversed() throws Exception {
     def ret = script.call(versionCondition: "^8.0.0 || ^7.14.0")
     printCallStack()
-    assertTrue(ret.equals('7.14.0'))
+    assert ret.equals('7.14.0')
   }
 }

--- a/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
+++ b/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
@@ -65,6 +65,13 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_match_ge() throws Exception {
+    def ret = script.call(versionCondition: ">=7.14.0")
+    printCallStack()
+    assertTrue(ret.equals('7.14.0'))
+  }
+
+  @Test
   void test_snapshot() throws Exception {
     def ret = script.call(versionCondition: "^7.14.1")
     printCallStack()
@@ -109,5 +116,19 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
     def ret = script.call(versionCondition: "^7.16.0")
     printCallStack()
     assertTrue(ret.equals('7.x-SNAPSHOT'))
+  }
+
+  @Test
+  void test_or_condition() throws Exception {
+    def ret = script.call(versionCondition: "^7.14.0 || ^8.0.0")
+    printCallStack()
+    assertTrue(ret.equals('7.14.0'))
+  }
+
+  @Test
+  void test_or_condition_reversed() throws Exception {
+    def ret = script.call(versionCondition: "^8.0.0 || ^7.14.0")
+    printCallStack()
+    assertTrue(ret.equals('7.14.0'))
   }
 }

--- a/vars/findOldestSupportedVersion.groovy
+++ b/vars/findOldestSupportedVersion.groovy
@@ -23,10 +23,10 @@ def version = findOldestSupportedVersion(versionCondition: "^7.14.0")
 
 def call(Map args = [:]) {
   def versionCondition = args.containsKey('versionCondition') ? args.versionCondition : error('findOldestStackVersion: versionCondition parameter is required')
-  if (!versionCondition.startsWith('^')) {
-    error('findOldestStackVersion: versionCondition supports only ^[0-9].* format')
+  if (versionCondition.indexOf('||') >= 0) {
+    return handleOr(versionCondition)
   }
-  def version = versionCondition.substring(1)
+  def version = removeOperator(versionCondition)
   def response = httpRequest(url: 'https://artifacts-api.elastic.co/v1/versions?x-elastic-no-kpi=true')
   def availableVersions = readJSON(text: response)
 
@@ -86,4 +86,31 @@ def call(Map args = [:]) {
 
   // Otherwise, return it, whatever this is.
   return version
+}
+
+def removeOperator(String versionCondition) {
+  if (versionCondition.startsWith('^')) {
+    return versionCondition.substring(1)
+  } 
+  if (versionCondition.startsWith('>=')) {
+    return versionCondition.substring(2)
+  }
+  error('findOldestStackVersion: versionCondition supports only ^ and >= operators')
+}
+
+def handleOr(String versionCondition) {
+  def versionConditions = versionCondition.split('\\s*\\|\\|\\s*')
+  if (versionConditions.size() == 0) {
+    error('no conditions found in "'+versionCondition+'"')
+  }
+
+  def result = ""
+  for (condition in versionConditions) {
+    def candidate = call(versionCondition: condition)
+    if (result == "" || candidate < result) {
+      result = candidate
+    }
+  }
+  
+  return result
 }


### PR DESCRIPTION
## What does this PR do?

* Add support for "or" conditions in `findOldestSupportedVersion`.
* Add support for ">=" operator.
* Tests use `assert` instead of `assertTrue` so they display the checked values in case of failure.

## Why is it important?

* We may need packages that support multiple majors, for that we need to support expressions such as `^7.16.0 || ^8.0.0`.

## Related issues

- Issue with these expressions found in https://github.com/elastic/integrations/pull/2122.
