### PR TITLE
[mergify][codeowners] Auto-assign and add reviewers with Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,6 @@
 
 # Beats
 /resources/approval-list/beats.yml @andresrc
+
+# Auto assign reviews
+* @elastic/observablt-robots @elastic/observablt-robots-contractors

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,15 +39,12 @@ pull_request_rules:
       - base~=^update-.*-version
     actions:
       delete_head_branch:
-  - name: assign PRs and add reviewers
+  - name: assign PRs
     conditions:
       - -merged
       - -closed
+      - "#assignee=0"
     actions:
       assign:
         add_users:
           - "{{author}}"
-      request_reviews:
-        teams:
-          - "@elastic/observablt-robots"
-          - "@elastic/observablt-robots-contractors"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,3 +39,15 @@ pull_request_rules:
       - base~=^update-.*-version
     actions:
       delete_head_branch:
+  - name: assign PRs and add reviewers
+    conditions:
+      - -merged
+      - -closed
+    actions:
+      assign:
+        add_users:
+          - "{{author}}"
+      request_reviews:
+        teams:
+          - "@elastic/observablt-robots"
+          - "@elastic/observablt-robots-contractors"


### PR DESCRIPTION
## What does this PR do?

Use mergify to auto-assign the PRs to the PR creator and assign `Reviewers` with the Codeowners

## Why is it important?

Less manual actions

