### PR TITLE
Bump release stack version: support for the dev version

### DIFF
--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -99,14 +99,15 @@ def prepareArguments(Map args = [:]){
   def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
   // TODO: to be adapted to the 8 releases, so maybe the branch should be the one driving this dynamically.
-  def stackVersion = bumpUtils.getCurrentMinorReleaseFor7()
-  def message = """### What \n Bump stack version with the latest release. \n ### Further details \n ${stackVersion}"""
+  def stackCurrentVersion = bumpUtils.getCurrentMinorReleaseFor7()
+  def stackCurrentMinorVersion = bumpUtils.getNextMinorReleaseFor7()
+  def message = """### What \n Bump stack version with the latest release. \n ### Further details \n ${stackCurrentVersion}"""
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"
   }
-  return [repo: repo, branchName: branch, title: "${title} ${stackVersion}", labels: labels, scriptFile: scriptFile, stackVersion: stackVersion,
-          message: message, assign: assign, reviewer: reviewer]
+  return [repo: repo, branchName: branch, title: "${title} ${stackCurrentVersion} ${stackCurrentMinorVersion}", labels: labels, scriptFile: scriptFile,
+          stackCurrentVersion: stackCurrentVersion, stackCurrentMinorVersion: stackCurrentMinorVersion, message: message, assign: assign, reviewer: reviewer]
 }
 
 def createPullRequest(Map args = [:]) {
@@ -114,10 +115,10 @@ def createPullRequest(Map args = [:]) {
 
   bumpUtils.createBranch(prefix: 'update-stack-version', suffix: args.branchName)
 
-  sh(script: "${args.scriptFile} '${args.stackVersion}' ''", label: "Prepare changes for ${args.repo}")
+  sh(script: "${args.scriptFile} '${args.stackCurrentVersion}' '${args.stackCurrentMinorVersion}'", label: "Prepare changes for ${args.repo}")
 
   if (params.DRY_RUN_MODE) {
-    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.stackVersion}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
+    log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
     return
   }
 
@@ -129,8 +130,8 @@ def createPullRequest(Map args = [:]) {
   }
 
   // In case the docker image is not available yet, let's skip the PR automation.
-  if (!bumpUtils.isVersionAvailable(args.stackVersion)) {
-    log(level: 'INFO', text: "Version '${args.stackVersion}' is not available yet.")
+  if (!bumpUtils.isVersionAvailable(args.stackCurrentVersion) || !bumpUtils.isVersionAvailable(args.stackCurrentMinorVersion)) {
+    log(level: 'INFO', text: "Versions '${args.stackCurrentVersion}'/'${args.stackCurrentMinorVersion}' are not available yet.")
     return
   }
 

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -100,14 +100,14 @@ def prepareArguments(Map args = [:]){
   def reviewer = args.get('reviewer', '')
   // TODO: to be adapted to the 8 releases, so maybe the branch should be the one driving this dynamically.
   def stackCurrentVersion = bumpUtils.getCurrentMinorReleaseFor7()
-  def stackCurrentMinorVersion = bumpUtils.getNextMinorReleaseFor7()
-  def message = """### What \n Bump stack version with the latest release. \n ### Further details \n ${stackCurrentVersion}"""
+  def stackNextMinorVersion = bumpUtils.getNextMinorReleaseFor7()
+  def message = """### What \n Bump stack version with the latest release. \n ### Further details \n ${stackCurrentVersion} ${stackNextMinorVersion}"""
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"
   }
-  return [repo: repo, branchName: branch, title: "${title} ${stackCurrentVersion} ${stackCurrentMinorVersion}", labels: labels, scriptFile: scriptFile,
-          stackCurrentVersion: stackCurrentVersion, stackCurrentMinorVersion: stackCurrentMinorVersion, message: message, assign: assign, reviewer: reviewer]
+  return [repo: repo, branchName: branch, title: "${title} ${stackCurrentVersion} ${stackNextMinorVersion}", labels: labels, scriptFile: scriptFile,
+          stackCurrentVersion: stackCurrentVersion, stackNextMinorVersion: stackNextMinorVersion, message: message, assign: assign, reviewer: reviewer]
 }
 
 def createPullRequest(Map args = [:]) {
@@ -115,7 +115,7 @@ def createPullRequest(Map args = [:]) {
 
   bumpUtils.createBranch(prefix: 'update-stack-version', suffix: args.branchName)
 
-  sh(script: "${args.scriptFile} '${args.stackCurrentVersion}' '${args.stackCurrentMinorVersion}'", label: "Prepare changes for ${args.repo}")
+  sh(script: "${args.scriptFile} '${args.stackCurrentVersion}' '${args.stackNextMinorVersion}'", label: "Prepare changes for ${args.repo}")
 
   if (params.DRY_RUN_MODE) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")
@@ -130,8 +130,8 @@ def createPullRequest(Map args = [:]) {
   }
 
   // In case the docker image is not available yet, let's skip the PR automation.
-  if (!bumpUtils.isVersionAvailable(args.stackCurrentVersion) || !bumpUtils.isVersionAvailable(args.stackCurrentMinorVersion)) {
-    log(level: 'INFO', text: "Versions '${args.stackCurrentVersion}'/'${args.stackCurrentMinorVersion}' are not available yet.")
+  if (!bumpUtils.isVersionAvailable(args.stackCurrentVersion) || !bumpUtils.isVersionAvailable(args.stackNextMinorVersion)) {
+    log(level: 'INFO', text: "Versions '${args.stackCurrentVersion}'/'${args.stackNextMinorVersion}' are not available yet.")
     return
   }
 

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -44,17 +44,20 @@ def version(value, args = [:]){
 }
 
 def edge(Map args = [:]){
+  // TODO: this should not use a hardcoded string but bmptUtils.getNextMinorReleaseFor8()
   return version("8.0.0", args)
 }
 
 def dev(Map args = [:]){
   // IMPORTANT: this variable is needed to automate the elastic stack bump
   def devVersion = "7.16.0"
+  // TODO: this should not use a hardcoded string but bmptUtils.getNextMinorReleaseFor7()
   return version(devVersion, args)
 }
 
 def release(Map args = [:]){
   // IMPORTANT: this variable is needed to automate the elastic stack bump
+  // TODO: this should not use a hardcoded string but bmptUtils.getCurrentMinorReleaseFor7()
   def releaseVersion = "7.15.1"
   return version(releaseVersion, args)
 }


### PR DESCRIPTION
## What does this PR do?

Enable `bumpUtils.getNextMinorReleaseFor7()` when running the bump script.

## Why is it important?

The version with the next minor release was removed when refactoring the source of truth with the versions.