### PR TITLE
Add support for minor constraints in findOldestSupportedVersion

### DIFF
--- a/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
+++ b/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
@@ -72,6 +72,13 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_match_minor() throws Exception {
+    def ret = script.call(versionCondition: "~7.14.0")
+    printCallStack()
+    assert ret.equals('7.14.0')
+  }
+
+  @Test
   void test_snapshot() throws Exception {
     def ret = script.call(versionCondition: "^7.14.1")
     printCallStack()
@@ -88,7 +95,7 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
   @Test
   void test_unsupported_versionCondition() throws Exception {
     try {
-      script.call(versionCondition: "~7.13.0")
+      script.call(versionCondition: "<7.13.0")
     } catch(e) {
       //NOOP
     }
@@ -121,6 +128,13 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
   @Test
   void test_or_condition() throws Exception {
     def ret = script.call(versionCondition: "^7.14.0 || ^8.0.0")
+    printCallStack()
+    assert ret.equals('7.14.0')
+  }
+
+  @Test
+  void test_or_condition_for_minor() throws Exception {
+    def ret = script.call(versionCondition: "^7.14.0 || ~8.0.0")
     printCallStack()
     assert ret.equals('7.14.0')
   }

--- a/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
+++ b/src/test/groovy/FindOldestSupportedVersionStepTests.groovy
@@ -110,7 +110,7 @@ class FindOldestSupportedVersionStepTests extends ApmBasePipelineTest {
     printCallStack()
     assert ret.equals('7.15.0-SNAPSHOT')
   }
-  
+
   @Test
   void test_without_patch() throws Exception {
     def ret = script.call(versionCondition: "^7.14")

--- a/vars/findOldestSupportedVersion.groovy
+++ b/vars/findOldestSupportedVersion.groovy
@@ -92,10 +92,13 @@ def removeOperator(String versionCondition) {
   if (versionCondition.startsWith('^')) {
     return versionCondition.substring(1)
   } 
+  if (versionCondition.startsWith('~')) {
+    return versionCondition.substring(1)
+  }
   if (versionCondition.startsWith('>=')) {
     return versionCondition.substring(2)
   }
-  error('findOldestStackVersion: versionCondition supports only ^ and >= operators')
+  error('findOldestStackVersion: versionCondition supports only ^, ~ and >= operators')
 }
 
 def handleOr(String versionCondition) {

--- a/vars/findOldestSupportedVersion.groovy
+++ b/vars/findOldestSupportedVersion.groovy
@@ -91,7 +91,7 @@ def call(Map args = [:]) {
 def removeOperator(String versionCondition) {
   if (versionCondition.startsWith('^')) {
     return versionCondition.substring(1)
-  } 
+  }
   if (versionCondition.startsWith('~')) {
     return versionCondition.substring(1)
   }

--- a/vars/findOldestSupportedVersion.groovy
+++ b/vars/findOldestSupportedVersion.groovy
@@ -114,6 +114,6 @@ def handleOr(String versionCondition) {
       result = candidate
     }
   }
-  
+
   return result
 }


### PR DESCRIPTION
## What does this PR do?

Add support for the `~` operator in `findOldestSupportedVersion`.

## Why is it important?

In some packages we may want to play safe by now, see https://github.com/elastic/integrations/pull/2125#discussion_r742613627.