### PR TITLE
Enable version validation in the isInstalled step

### DIFF
--- a/src/test/groovy/IsInstalledStepTests.groovy
+++ b/src/test/groovy/IsInstalledStepTests.groovy
@@ -67,4 +67,30 @@ class IsInstalledStepTests extends ApmBasePipelineTest {
     assertTrue(ret)
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_tool_with_version_unmatched() throws Exception {
+    helper.registerAllowedMethod('cmd', [Map.class], {
+      return """gh version 2.2.0 (2021-10-25)
+https://github.com/cli/cli/releases/tag/v2.2.0"""
+    })
+    def ret = script.call(tool: 'docker', flag: '--version', version: '1.2.3')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('cmd', 'docker --version'))
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_tool_with_version_matched() throws Exception {
+    helper.registerAllowedMethod('cmd', [Map.class], {
+      return """gh version 2.2.0 (2021-10-25)
+https://github.com/cli/cli/releases/tag/v2.2.0"""
+    })
+    def ret = script.call(tool: 'docker', flag: '--version', version: '2.2.0')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('cmd', 'docker --version'))
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1631,7 +1631,8 @@ evaluates the change list with the pattern list:
 NOTE: This particular implementation requires to checkout with the step gitCheckout
 
 ## isInstalled
-Whether the given tools is installed and available.
+Whether the given tools is installed and available. It does also support version
+validation.
 
 ```
   // if docker is installed, the validation uses docker --version
@@ -1647,6 +1648,7 @@ Whether the given tools is installed and available.
 
 * tool: The name of the tool to check whether it is installed and available. Mandatory.
 * flag: The flag to be added to the validation. For instance `--version`. Optional.
+* version: The version of the tool to check with. Optional.
 
 ## isInternalCI
 Whether the CI instance is the internal-ci one.

--- a/vars/README.md
+++ b/vars/README.md
@@ -1631,7 +1631,7 @@ evaluates the change list with the pattern list:
 NOTE: This particular implementation requires to checkout with the step gitCheckout
 
 ## isInstalled
-Whether the given tools is installed and available. It does also support version
+Whether the given tool is installed and available. It also supports specifying a version.
 validation.
 
 ```

--- a/vars/gh.groovy
+++ b/vars/gh.groovy
@@ -57,7 +57,7 @@ def call(Map args = [:]) {
   }
 
   withEnv(["PATH+GH=${ghLocation}"]) {
-    if (forceInstallation || !isInstalled(tool: 'gh', flag: '--version')) {
+    if (forceInstallation || !isInstalled(tool: 'gh', flag: '--version', version: version)) {
       if(isUnix()) {
         downloadInstaller(ghLocation, version)
       } else {

--- a/vars/isInstalled.groovy
+++ b/vars/isInstalled.groovy
@@ -16,7 +16,8 @@
 // under the License.
 
 /**
-  Check it the given tools is installed and available.
+  Check it the given tools is installed and available. It does also support version
+  validation.
 
   whenTrue(isInstalled(tool: 'docker', flag: '--version')) {
     // ...
@@ -28,9 +29,12 @@
 */
 def call(Map args = [:]) {
   def tool = args.containsKey('tool') ? args.tool : error('isInstalled: tool parameter is required')
+  def version = args.get('version', '')
   def flag = args.get('flag', '')
-
   def redirectStdout = isUnix() ? '>/dev/null' : '>NUL'
 
+  if (version?.trim()) {
+    return cmd(returnStdout: true, script: "${tool} ${flag}").contains(version)
+  }
   return cmd(returnStatus: true, script: "${tool} ${flag} ${redirectStdout}") == 0
 }

--- a/vars/isInstalled.txt
+++ b/vars/isInstalled.txt
@@ -1,4 +1,4 @@
-Whether the given tools is installed and available. It does also support version
+Whether the given tool is installed and available. It does also supports specifying the version.
 validation.
 
 ```

--- a/vars/isInstalled.txt
+++ b/vars/isInstalled.txt
@@ -1,4 +1,5 @@
-Whether the given tools is installed and available.
+Whether the given tools is installed and available. It does also support version
+validation.
 
 ```
   // if docker is installed, the validation uses docker --version
@@ -14,3 +15,4 @@ Whether the given tools is installed and available.
 
 * tool: The name of the tool to check whether it is installed and available. Mandatory.
 * flag: The flag to be added to the validation. For instance `--version`. Optional.
+* version: The version of the tool to check with. Optional.


### PR DESCRIPTION
## What does this PR do?

Add version validation in the `isInstalled` step and enable this validation in the `gh` step

## Why is it important?

Avoid installing if no `forceInstallation` is enabled in the `gh` step in addition enhance the existing step for verifying if the tools are installed.

## Related issues
Notifies https://github.com/elastic/apm-pipeline-library/pull/1358
