### PR TITLE
feat: override junit step supporting calling a callback

### DIFF
--- a/src/test/groovy/JunitStepTests.groovy
+++ b/src/test/groovy/JunitStepTests.groovy
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class JunitStepTests extends ApmBasePipelineTest {
+
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/junit.groovy')
+  }
+
+  @Test
+  void test_no_testResults() throws Exception {
+    try {
+      script.call()
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'junit: testResults parameter is required'))
+    assertJobStatusFailure()
+  }
+
+  @Test
+  void test_with_callback_parameter() throws Exception {
+    def initialCount = 0
+
+    try {
+      def callback = { initialCount++ }
+
+      script.call(testResults: 'build/TEST-*.xml', callback: callback)
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('junit', 'testResults=build/TEST-*.xml'))
+    assertTrue(assertMethodCallContainsPattern('log', 'junit: Running callback operations after junit'))
+    assertEquals(initialCount, 1)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_without_callback_parameter() throws Exception {
+    def initialCount = 0
+    try {
+      script.call(testResults: 'build/TEST-*.xml')
+    } catch(err) {
+      //
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('junit', 'testResults=build/TEST-*.xml'))
+    assertFalse(assertMethodCallContainsPattern('log', 'junit: Running callback operations after junit'))
+    assertEquals(initialCount, 0)
+    assertJobStatusSuccess()
+  }
+}

--- a/src/test/groovy/JunitStepTests.groovy
+++ b/src/test/groovy/JunitStepTests.groovy
@@ -43,26 +43,7 @@ class JunitStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_with_callback_parameter() throws Exception {
-    def initialCount = 0
-
-    try {
-      def callback = { initialCount++ }
-
-      script.call(testResults: 'build/TEST-*.xml', callback: callback)
-    } catch(err) {
-      //
-    }
-    printCallStack()
-    assertTrue(assertMethodCallContainsPattern('junit', 'testResults=build/TEST-*.xml'))
-    assertTrue(assertMethodCallContainsPattern('log', 'junit: Running callback operations after junit'))
-    assertEquals(initialCount, 1)
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void test_without_callback_parameter() throws Exception {
-    def initialCount = 0
+  void test_with_extra_logic() throws Exception {
     try {
       script.call(testResults: 'build/TEST-*.xml')
     } catch(err) {
@@ -70,8 +51,7 @@ class JunitStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('junit', 'testResults=build/TEST-*.xml'))
-    assertFalse(assertMethodCallContainsPattern('log', 'junit: Running callback operations after junit'))
-    assertEquals(initialCount, 0)
+    assertTrue(assertMethodCallContainsPattern('log', 'junit: Running extra operations after junit'))
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/JunitStepTests.groovy
+++ b/src/test/groovy/JunitStepTests.groovy
@@ -39,8 +39,7 @@ class JunitStepTests extends ApmBasePipelineTest {
       //
     }
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('error', 'junit: testResults parameter is required'))
-    assertJobStatusFailure()
+    assertJobStatusSuccess()
   }
 
   @Test

--- a/vars/README.md
+++ b/vars/README.md
@@ -1766,6 +1766,34 @@ Whether the architecture is a x86 based using the `nodeArch` step
     }
 ```
 
+## junit
+Wrap the junit built-in step to perform extra operations with the test reports.
+
+```
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit on steroids
+                        junit(callback: closure(), ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+```
+
+* *testResults*: from the `junit` step. Mandatory
+* *allowEmptyResults*: from the `junit` step. Optional
+* *keepLongStdio*: from the `junit` step. Optional
+* *callback*: A closure to run after the built-in `junit` step if set.Optional, default empty.
+
+
+**NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments
+
 ## junitAndStore
 Wrap the junit built-in step to archive the test reports that are going to be
 populated later on with the runbld post build step.

--- a/vars/README.md
+++ b/vars/README.md
@@ -1631,7 +1631,7 @@ evaluates the change list with the pattern list:
 NOTE: This particular implementation requires to checkout with the step gitCheckout
 
 ## isInstalled
-Whether the given tool is installed and available. It also supports specifying a version.
+Whether the given tool is installed and available. It does also supports specifying the version.
 validation.
 
 ```

--- a/vars/README.md
+++ b/vars/README.md
@@ -1777,7 +1777,7 @@ Wrap the junit built-in step to perform extra operations with the test reports.
                 post {
                     always {
                         // JUnit on steroids
-                        junit(callback: closure(), ...)
+                        junit(...)
                     }
                 }
             }
@@ -1789,8 +1789,6 @@ Wrap the junit built-in step to perform extra operations with the test reports.
 * *testResults*: from the `junit` step. Mandatory
 * *allowEmptyResults*: from the `junit` step. Optional
 * *keepLongStdio*: from the `junit` step. Optional
-* *callback*: A closure to run after the built-in `junit` step if set.Optional, default empty.
-
 
 **NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments
 

--- a/vars/junit.groovy
+++ b/vars/junit.groovy
@@ -34,7 +34,7 @@ Wrap the junit built-in step to perform extra operations with the test reports.
     }
 */
 def call(Map args = [:]) {
-  def hasCallback = args.containsKey('callback') ? true : false
+  def hasCallback = args.containsKey('callback')
   def testResults = args.containsKey('testResults') ? args.testResults : error('junit: testResults parameter is required')
   def junitArgs = args.findAll { k,v -> !(k.equals('callback')) }
 

--- a/vars/junit.groovy
+++ b/vars/junit.groovy
@@ -25,7 +25,7 @@ Wrap the junit built-in step to perform extra operations with the test reports.
                 post {
                     always {
                         // JUnit on steroids
-                        junit(callback: closure(), ...)
+                        junit(...)
                     }
                 }
             }
@@ -34,17 +34,7 @@ Wrap the junit built-in step to perform extra operations with the test reports.
     }
 */
 def call(Map args = [:]) {
-  def hasCallback = args.containsKey('callback')
-  def junitArgs = args.findAll { k,v -> !(k.equals('callback')) }
+  junit(args)
 
-  junit(junitArgs)
-
-  if (!hasCallback) {
-      return
-  }
-
-  def callback = args.callback
-
-  log(level: 'DEBUG', text: "junit: Running callback operations after junit")
-  callback()
+  log(level: 'DEBUG', text: "junit: Running extra operations after junit")
 }

--- a/vars/junit.groovy
+++ b/vars/junit.groovy
@@ -35,7 +35,6 @@ Wrap the junit built-in step to perform extra operations with the test reports.
 */
 def call(Map args = [:]) {
   def hasCallback = args.containsKey('callback')
-  def testResults = args.containsKey('testResults') ? args.testResults : error('junit: testResults parameter is required')
   def junitArgs = args.findAll { k,v -> !(k.equals('callback')) }
 
   junit(junitArgs)

--- a/vars/junit.groovy
+++ b/vars/junit.groovy
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Wrap the junit built-in step to perform extra operations with the test reports.
+
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit on steroids
+                        junit(callback: closure(), ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+*/
+def call(Map args = [:]) {
+  def hasCallback = args.containsKey('callback') ? true : false
+  def testResults = args.containsKey('testResults') ? args.testResults : error('junit: testResults parameter is required')
+  def junitArgs = args.findAll { k,v -> !(k.equals('callback')) }
+
+  junit(junitArgs)
+
+  if (!hasCallback) {
+      return
+  }
+
+  def callback = args.callback
+
+  log(level: 'DEBUG', text: "junit: Running callback operations after junit")
+  callback()
+}

--- a/vars/junit.txt
+++ b/vars/junit.txt
@@ -1,0 +1,26 @@
+Wrap the junit built-in step to perform extra operations with the test reports.
+
+```
+    pipeline {
+        ...
+        stages {
+            stage(...) {
+                post {
+                    always {
+                        // JUnit on steroids
+                        junit(callback: closure(), ...)
+                    }
+                }
+            }
+        }
+        ...
+    }
+```
+
+* *testResults*: from the `junit` step. Mandatory
+* *allowEmptyResults*: from the `junit` step. Optional
+* *keepLongStdio*: from the `junit` step. Optional
+* *callback*: A closure to run after the built-in `junit` step if set.Optional, default empty.
+
+
+**NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments

--- a/vars/junit.txt
+++ b/vars/junit.txt
@@ -8,7 +8,7 @@ Wrap the junit built-in step to perform extra operations with the test reports.
                 post {
                     always {
                         // JUnit on steroids
-                        junit(callback: closure(), ...)
+                        junit(...)
                     }
                 }
             }
@@ -20,7 +20,5 @@ Wrap the junit built-in step to perform extra operations with the test reports.
 * *testResults*: from the `junit` step. Mandatory
 * *allowEmptyResults*: from the `junit` step. Optional
 * *keepLongStdio*: from the `junit` step. Optional
-* *callback*: A closure to run after the built-in `junit` step if set.Optional, default empty.
-
 
 **NOTE**: See https://www.jenkins.io/doc/pipeline/steps/junit/#junit-plugin for reference of the arguments


### PR DESCRIPTION
## What does this PR do?
This PR adds a new step overriding the built-in `junit` step, so that it's possible we are able to add extra logic to be executed right after `junit`.

At this moment, there is no custom logic apart from the call to junit, but we could enrich this step to add pre-defined actions adding them right after `junit`. 

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
We'd like to start defining logic that must always be executed when handling junit test results, such as:

- parsing test results files and sending aggregations to a backend (Elasticseach)
- detecting the runtime environment where the tests are run (OS, arch) and send it to a backend (Elasticseach)
- ...

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Follow-ups
We already have a `junitAndStore` step, which could be refactored to reuse this new step.

## Other concerns
Addressed in comments: ~~Are you OK with adding the `callback` extension point, specially security-wise? Maybe it's not a good idea to let consumers to extend the `junit` step with their own functionality and simply keep our defaults. Thoughts?~~
