### PR TITLE
Add GH command for rebuilding the docs builds

### DIFF
--- a/resources/commands-github-comment-markdown.template
+++ b/resources/commands-github-comment-markdown.template
@@ -4,7 +4,7 @@
 To re-run your PR in the CI, just comment with:
 
 <% githubCommands?.each { githubCommand, description -> %>
-<% githubFormattedCommand = githubCommand.contains('`') ? "${githubCommand} : "`${githubCommand}`" %>
+<% githubFormattedCommand = githubCommand.contains('`') ? "${githubCommand}" : "`${githubCommand}`" %>
 - ${githubFormattedCommand} : ${description}
 <%}%>
 

--- a/resources/commands-github-comment-markdown.template
+++ b/resources/commands-github-comment-markdown.template
@@ -4,7 +4,8 @@
 To re-run your PR in the CI, just comment with:
 
 <% githubCommands?.each { githubCommand, description -> %>
-- `${githubCommand}` : ${description}
+<% githubFormattedCommand = githubCommand.contains('`') ? "${githubCommand} : "`${githubCommand}`" %>
+- ${githubFormattedCommand} : ${description}
 <%}%>
 
 <%}%>

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -508,7 +508,7 @@ def getSupportedGithubCommands() {
   }
 
   // Support for the elasticsearch-ci/docs GitHub command in all the repositories they use it
-  if (env.REPO?.startsWith('apm') || env.REPO_NAME?.endsWith('server') || env.REPO_NAME?.equals('beats')) {
+  if (env.REPO?.startsWith('apm') || env.REPO_NAME?.startsWith('ecs') || env.REPO_NAME?.equals('beats') || env.REPO_NAME?.equals('observability-docs')) {
     comments['@elasticmachine, run elasticsearch-ci/docs'] = 'Re-trigger the docs validation.'
   }
 

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -509,7 +509,8 @@ def getSupportedGithubCommands() {
 
   // Support for the elasticsearch-ci/docs GitHub command in all the repositories they use it
   if (env.REPO?.startsWith('apm') || env.REPO_NAME?.startsWith('ecs') || env.REPO_NAME?.equals('beats') || env.REPO_NAME?.equals('observability-docs')) {
-    comments['@elasticmachine, run elasticsearch-ci/docs'] = 'Re-trigger the docs validation.'
+    // `run` is needed to avoid the comment to trigger a build itself!
+    comments['@elasticmachine, `run` elasticsearch-ci/docs'] = 'Re-trigger the docs validation. (use unformatted text in the comment!)'
   }
 
   return comments

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -495,25 +495,40 @@ def getSupportedGithubCommands() {
   }
 
   // Support for the Beats specific GitHub commands
-  if (env.REPO?.equals('beats') || env.REPO_NAME?.equals('beats')) {
+  if (isProjectSupported('beats')) {
     comments['/package'] = 'Generate the packages and run the E2E tests.'
     comments['/beats-tester'] = 'Run the installation tests with beats-tester.'
   }
 
   // Support for the Obs11 test environments specific GitHub commands
-  if (env.REPO?.equals('observability-test-environments') || env.REPO_NAME?.equals('observability-test-environments')) {
+  if (isProjectSupported('observability-test-environments')) {
     comments['/test ansible'] = 'Run the ansible tests.'
     comments['/test cypress'] = 'Run the cypress tests.'
     comments['/test tools'] = 'Build and test the CLI tools.'
   }
 
   // Support for the elasticsearch-ci/docs GitHub command in all the repositories they use it
-  if (env.REPO?.startsWith('apm') || env.REPO_NAME?.startsWith('ecs') || env.REPO_NAME?.equals('beats') || env.REPO_NAME?.equals('observability-docs')) {
+  if (isElasticsearchDocsSupported()) {
     // `run` is needed to avoid the comment to trigger a build itself!
     comments['`run` `elasticsearch-ci/docs`'] = 'Re-trigger the docs validation. (use unformatted text in the comment!)'
   }
 
   return comments
+}
+
+private isProjectSupported(String value) {
+  return env.REPO?.equals(value) || env.REPO_NAME?.equals(value)
+}
+
+private isElasticsearchDocsSupported() {
+  return isElasticsearchDocsSupported(env.REPO) || isElasticsearchDocsSupported(env.REPO_NAME)
+}
+
+private isElasticsearchDocsSupported(String value) {
+  return value?.startsWith('apm') ||
+         value?.startsWith('ecs') ||
+         value?.equals('beats') ||
+         value?.equals('observability-docs')
 }
 
 @NonCPS

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -510,7 +510,7 @@ def getSupportedGithubCommands() {
   // Support for the elasticsearch-ci/docs GitHub command in all the repositories they use it
   if (env.REPO?.startsWith('apm') || env.REPO_NAME?.startsWith('ecs') || env.REPO_NAME?.equals('beats') || env.REPO_NAME?.equals('observability-docs')) {
     // `run` is needed to avoid the comment to trigger a build itself!
-    comments['@elasticmachine, `run` elasticsearch-ci/docs'] = 'Re-trigger the docs validation. (use unformatted text in the comment!)'
+    comments['`run` `elasticsearch-ci/docs`'] = 'Re-trigger the docs validation. (use unformatted text in the comment!)'
   }
 
   return comments

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -452,7 +452,7 @@ def getSupportedGithubCommands() {
     return [:]
   }
 
-  def comments = ['@elasticmachine, run elasticsearch-ci/docs': 'Re-trigger the docs validation.']
+  def comments = [:]
 
   // In order to avoid re-triggering a build when commenting the
   // build status as a PR comment, it's required to filter here
@@ -505,6 +505,11 @@ def getSupportedGithubCommands() {
     comments['/test ansible'] = 'Run the ansible tests.'
     comments['/test cypress'] = 'Run the cypress tests.'
     comments['/test tools'] = 'Build and test the CLI tools.'
+  }
+
+  // Support for the elasticsearch-ci/docs GitHub command in all the repositories they use it
+  if (env.REPO?.startsWith('apm') || env.REPO_NAME?.endsWith('server') || env.REPO_NAME?.equals('beats')) {
+    comments['@elasticmachine, run elasticsearch-ci/docs'] = 'Re-trigger the docs validation.'
   }
 
   return comments

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -452,7 +452,7 @@ def getSupportedGithubCommands() {
     return [:]
   }
 
-  def comments = [:]
+  def comments = ['@elasticmachine, run elasticsearch-ci/docs': 'Re-trigger the docs validation.']
 
   // In order to avoid re-triggering a build when commenting the
   // build status as a PR comment, it's required to filter here


### PR DESCRIPTION
## What does this PR do?

Add the rebuild docs GitHub command.

## Why is it important?

This is a core feature for some of the GitHub repositories we work with. So let's filer the ones we already know they use it. Such as, all the APM agents, APM Server, Fleet Server, Beats

I could not find what to run so I have to search in another repository to find it.

## Question

- [x] I see `trigger-phrase: '.*run\W+elasticsearch-ci/docs.*'` but I don't know if this GitHub comment might trigger an extra build in the `elastic-docs` pipeline. Any hints?  I just asked to the infra folks. 

Unfortunately, we cannot change this behaviour, so we will use the above format but split with `run` `elasticsearch-ci/docs` (this will ensure there is no a space between run and elasticsearch but `)


## UI

![image](https://user-images.githubusercontent.com/2871786/140941930-5c9578fd-b525-4f5f-ab04-54dcffa73124.png)
