### PR TITLE
[mergify] notify to the assignee if PR was not merged yet

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,6 +17,8 @@ pull_request_rules:
       - label=backport-to-7.x
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - 7.x
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
@@ -48,3 +50,13 @@ pull_request_rules:
       assign:
         add_users:
           - "{{author}}"
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - check-success=CLA
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review it @{{assignee}}? 🙏


### PR DESCRIPTION
## What does this PR do?

Notify the backported PRs from mergify if they have not been merged.

## Why

To test https://github.com/elastic/e2e-testing/pull/1792 (this PR is a subset of the e2e-testing one)