### PR TITLE
fix: trailing-whitespace

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -8,7 +8,7 @@ module.exports = {
     "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
       "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
       "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows",
-      "team:automation", "ready-to-merge", "backport-to-7.x", "Team:Automation", 
+      "team:automation", "ready-to-merge", "backport-to-7.x",
       "backport-skip","dependencies", "java", "bump"],
     "groupBy": {
         "Enhancements": ["enhancement", "internal", "feature", "feat"],


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
There is a trailing-whitespace in `.grenrc.js`
