### PR TITLE
[mergify] transform assignee list in GitHub users

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -59,4 +59,4 @@ pull_request_rules:
     actions:
       comment:
         message: |
-          This pull request has not been merged yet. Could you please review it @{{assignee}}? 🙏
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏


### PR DESCRIPTION
## What does this PR do?

Fixes
![image](https://user-images.githubusercontent.com/2871786/141301264-77a5a6f5-52f5-4f55-b9b7-a7f255b907f6.png)

It uses the same approach as explained in https://github.com/Mergifyio/mergify-engine/blob/b6b2fc695c75f510e879281ecabd28e1c889ddbc/docs/source/configuration.rst#template


## Why is it important?

Notify correctly

