### PR TITLE
Metrics: cannot be search within the build context

### DIFF
--- a/resources/ci-builds-mapping.json
+++ b/resources/ci-builds-mapping.json
@@ -9,9 +9,6 @@
           "interruptedException" : {
             "type" : "long"
           },
-          "liveNode" : {
-            "type" : "long"
-          },
           "missingContextVariableException" : {
             "type" : "long"
           },

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -414,8 +414,6 @@ function prepareErrorMetrics() {
       interruptedException=$(grep -i 'cannot contact .*InterruptedException' --count ${PIPELINE_LOG})
       ## Required context class hudson.Launcher.
       missingContextVariableException=$(grep -i 'org.jenkinsci.plugins.workflow.steps.MissingContextVariableException' --count ${PIPELINE_LOG})
-      ## Computer does not correspond to a live node
-      liveNode=$(grep -i 'computer does not correspond to a live node' --count ${PIPELINE_LOG})
       ## beats-ci-immutable-ubuntu-1804-1634816467154904530 was marked offline: Connection was broken: java.nio.channels.ClosedChannelException
       closedChannelException=$(grep -i 'java.nio.channels.ClosedChannelException' --count ${PIPELINE_LOG})
       ## search for reused workers within the same build
@@ -425,7 +423,6 @@ function prepareErrorMetrics() {
     else
       interruptedException=0
       missingContextVariableException=0
-      liveNode=0
       closedChannelException=0
       reusedWorkers=0
       notSerializableException=0
@@ -435,7 +432,6 @@ function prepareErrorMetrics() {
       echo "{"
       echo "  \"closedChannelException\": ${closedChannelException},"
       echo "  \"interruptedException\": ${interruptedException},"
-      echo "  \"liveNode\": ${liveNode},"
       echo "  \"missingContextVariableException\": ${missingContextVariableException},"
       echo "  \"notSerializableException\": ${notSerializableException},"
       echo "  \"reusedWorkers\": ${reusedWorkers}"


### PR DESCRIPTION
## What does this PR do?

Remove metric for liveness issues with nodes in the CI

## Why is it important?

This can be only searched outside of the build context.


```

[2021-11-11T16:14:25.545Z] [Pipeline] End of Pipeline
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] Also:   java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] java.lang.Exception: computer does not correspond to a live node
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.support.steps.WorkspaceStepExecution.start(WorkspaceStepExecution.java:42)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:319)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:193)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
[2021-11-11T16:14:27.032Z] 	at groovy.lang.MetaClassImpl.invokeMethodOnGroovyObject(MetaClassImpl.java:1278)
[2021-11-11T16:14:27.032Z] 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1172)
[2021-11-11T16:14:27.032Z] 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022)
[2021-11-11T16:14:27.032Z] 	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)
[2021-11-11T16:14:27.032Z] 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
[2021-11-11T16:14:27.032Z] 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
[2021-11-11T16:14:27.032Z] 	at withNode.call(withNode.groovy:66)
[2021-11-11T16:14:27.032Z] 	at ___cps.transform___(Native Method)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:86)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:113)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:83)
[2021-11-11T16:14:27.032Z] 	at sun.reflect.GeneratedMethodAccessor591.invoke(Unknown Source)
[2021-11-11T16:14:27.032Z] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-11-11T16:14:27.032Z] 	at java.lang.reflect.Method.invoke(Method.java:498)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.impl.ClosureBlock.eval(ClosureBlock.java:46)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
[2021-11-11T16:14:27.032Z] 	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129)
[2021-11-11T16:14:27.032Z] 	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268)
[2021-11-11T16:14:27.032Z] 	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:185)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:402)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:96)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:314)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:278)
[2021-11-11T16:14:27.032Z] 	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67)
[2021-11-11T16:14:27.032Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-11-11T16:14:27.032Z] 	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
[2021-11-11T16:14:27.032Z] 	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
[2021-11-11T16:14:27.032Z] 	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
[2021-11-11T16:14:27.032Z] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2021-11-11T16:14:27.032Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-11-11T16:14:27.032Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-11-11T16:14:27.032Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-11-11T16:14:27.032Z] 	at java.lang.Thread.run(Thread.java:748)
[2021-11-11T16:14:28.053Z] 
[2021-11-11T16:14:28.053Z] GitHub has been notified of this commit’s build result
[2021-11-11T16:14:28.053Z] 
[2021-11-11T16:14:28.058Z] Finished: FAILURE
```