### PR TITLE
Fix upstream build reasons

### DIFF
--- a/src/test/groovy/IsUpstreamTriggerStepTests.groovy
+++ b/src/test/groovy/IsUpstreamTriggerStepTests.groovy
@@ -164,4 +164,25 @@ class IsUpstreamTriggerStepTests extends ApmBasePipelineTest {
     assertFalse(assertMethodCallContainsPattern('log', "isUpstreamTrigger: apm-integration-tests/PR-695, filter: 'PR-'"))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_with_build_upstream_cause() throws Exception {
+    binding.getVariable('currentBuild').getBuildCauses = {
+      return [
+        [
+          _class: 'org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause',
+          shortDescription: 'Started by upstream project "Beats/beats/PR-28919" build number 2',
+          upstreamBuild: 2,
+          upstreamProject: 'Beats/beats/PR-28919',
+          upstreamUrl: 'job/Beats/job/beats/job/PR-28919/'
+        ]
+      ]
+    }
+
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('log', "isUpstreamTrigger: Beats/beats/PR-28919, filter: 'all'"))
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/isUpstreamTrigger.groovy
+++ b/vars/isUpstreamTrigger.groovy
@@ -24,7 +24,8 @@
 def call(Map args=[:]){
   def filter = args.get('filter', 'all')
 
-  def buildCause = currentBuild.getBuildCauses()?.find{ it._class == 'hudson.model.Cause$UpstreamCause'}
+  def buildCause = currentBuild.getBuildCauses()?.find{ it._class == 'hudson.model.Cause$UpstreamCause' ||
+                                                        it._class == 'org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause' }
   if (buildCause?.upstreamProject?.trim()) {
     log(level: 'DEBUG', text: "isUpstreamTrigger: ${buildCause?.upstreamProject?.toString()}, filter: '${filter}'")
     // evaluate filter


### PR DESCRIPTION
## What does this PR do?

Supports https://javadoc.jenkins-ci.org/hudson/model/Cause.UpstreamCause.html

## Why is it important?

Otherwise in some cases the `isUpstreamTrigger` won't detect those builds.

