### PR TITLE
[mergify] notify backported PRs without changes in the last 2 days and at least one assigned person

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,8 +56,9 @@ pull_request_rules:
       - -closed
       - author=mergify[bot]
       - check-success=CLA
-      - schedule=Mon-Mon 12:00-13:00[Europe/Paris]
+      - schedule=Mon-Mon 13:00-14:00[Europe/Paris]
       - updated-at<2 days ago
+      - "#assignee>=1"
     actions:
       comment:
         message: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -56,7 +56,8 @@ pull_request_rules:
       - -closed
       - author=mergify[bot]
       - check-success=CLA
-      - schedule=Mon-Mon 14:00-16:00[Europe/Paris]
+      - schedule=Mon-Mon 12:00-13:00[Europe/Paris]
+      - updated-at<2 days ago
     actions:
       comment:
         message: |


### PR DESCRIPTION
## What does this PR do?

Notify if a backported PR has not been updated in the last two days and there is at least one assigned person

## Why is it important?

This could help with the notifications with a certain `schedule` since it will only report if they are at least 2 days without any activity


## Further details

See https://github.com/Mergifyio/mergify-engine/blob/b6b2fc695c75f510e879281ecabd28e1c889ddbc/docs/source/configuration.rst#relative-timestamp

![image](https://user-images.githubusercontent.com/2871786/141964634-63b66d0f-12e5-4e82-910f-339725b4f4da.png)

cc @jsoriano since you asked about this in https://github.com/elastic/beats/pull/28964


