### PR TITLE
[local] bump docker version to 2.303.3

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/infra/jenkins:202109131610.ef2e7a6a5a14
+FROM docker.elastic.co/infra/jenkins:202111081526.13f733a5d475
 
 
 COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/local/Makefile
+++ b/local/Makefile
@@ -39,7 +39,7 @@ master:
 		docker-compose \
 			--log-level ${LOG_LEVEL} \
 			--file docker-compose.yml \
-			up --detach --no-recreate jenkins
+			up --detach jenkins
 
 .PHONY: pull
 pull:  ## Pull required images for all Jenkins-related processes


### PR DESCRIPTION
## What does this PR do?

Update the local docker image to the latest release


```
 make build start
WARNING: The VAULT_TOKEN variable is not set. Defaulting to a blank string.
[+] Building 15.7s (8/8) FINISHED                                                                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                                                              0.0s
 => => transferring dockerfile: 230B                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.elastic.co/infra/jenkins:202111081526.13f733a5d475                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                                                                 0.0s
 => => transferring context: 68B                                                                                                                                                                                                  0.0s
 => [1/3] FROM docker.elastic.co/infra/jenkins:202111081526.13f733a5d475                                                                                                                                                          0.3s
 => [2/3] COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt                                                                                                                                                             0.0s
 => [3/3] RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt                                                                                                                                                           15.0s
 => exporting to image                                                                                                                                                                                                            0.3s 
 => => exporting layers                                                                                                                                                                                                           0.2s
 => => writing image sha256:412fcb998387cd2696e8a97c6c42fb18ffca792a0056acd43189c81d6f6915c3                                                                                                                                      0.0s
 => => naming to docker.io/library/local_jenkins                                                                                                                                                                                  0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Docker Compose is now in the Docker CLI, try `docker compose up`

Creating jenkins-lint ... done

Jenkins master now running at http://localhost:18080

```


```
docker ps
CONTAINER ID   IMAGE                                                  COMMAND                  CREATED         STATUS                 PORTS                                                                                                                                                                                                                                        NAMES
2db04f175453   local_jenkins                                          "/sbin/tini -- /usr/…"   4 minutes ago   Up 4 minutes           0.0.0.0:50000->50000/tcp, :::50000->50000/tcp, 0.0.0.0:18080->8080/tcp, :::18080->8080/tcp                                                                                                                                                   jenkins-lint

docker logs -f jenkins-lint 
Running from: /usr/share/jenkins/jenkins.war
webroot: EnvVars.masterEnvVars.get("JENKINS_HOME")
2021-11-16 16:16:57.444+0000 [id=1]	INFO	org.eclipse.jetty.util.log.Log#initialized: Logging initialized @531ms to org.eclipse.jetty.util.log.JavaUtilLog
2021-11-16 16:16:57.527+0000 [id=1]	INFO	winstone.Logger#logInternal: Beginning extraction from war file
2021-11-16 16:16:58.358+0000 [id=1]	WARNING	o.e.j.s.handler.ContextHandler#setContextPath: Empty contextPath
2021-11-16 16:16:58.428+0000 [id=1]	INFO	org.eclipse.jetty.server.Server#doStart: jetty-9.4.43.v20210629; built: 2021-06-30T11:07:22.254Z; git: 526006ecfa3af7f1a27ef3a288e2bef7ea9dd7e8; jvm 11.0.13+8
2021-11-16 16:16:58.651+0000 [id=1]	INFO	o.e.j.w.StandardDescriptorProcessor#visitServlet: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
2021-11-16 16:16:58.691+0000 [id=1]	INFO	o.e.j.s.s.DefaultSessionIdManager#doStart: DefaultSessionIdManager workerName=node0
2021-11-16 16:16:58.691+0000 [id=1]	INFO	o.e.j.s.s.DefaultSessionIdManager#doStart: No SessionScavenger set, using defaults
2021-11-16 16:16:58.693+0000 [id=1]	INFO	o.e.j.server.session.HouseKeeper#startScavenging: node0 Scavenging every 660000ms
2021-11-16 16:16:59.141+0000 [id=1]	INFO	hudson.WebAppMain#contextInitialized: Jenkins home directory: /var/jenkins_home found at: EnvVars.masterEnvVars.get("JENKINS_HOME")
2021-11-16 16:16:59.336+0000 [id=1]	INFO	o.e.j.s.handler.ContextHandler#doStart: Started w.@341672e{Jenkins v2.303.3,/,file:///var/jenkins_home/war/,AVAILABLE}{/var/jenkins_home/war}
2021-11-16 16:16:59.369+0000 [id=1]	INFO	o.e.j.server.AbstractConnector#doStart: Started ServerConnector@3fa2213{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2021-11-16 16:16:59.370+0000 [id=1]	INFO	org.eclipse.jetty.server.Server#doStart: Started @2459ms
2021-11-16 16:16:59.372+0000 [id=25]	INFO	winstone.Logger#logInternal: Winstone Servlet Engine running: controlPort=disabled
2021-11-16 16:16:59.643+0000 [id=32]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2021-11-16 16:17:00.149+0000 [id=42]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/jenkins_home/plugins/jaxb.jpi
2021-11-16 16:17:00.451+0000 [id=44]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/jenkins_home/plugins/allure-jenkins-plugin/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
2021-11-16 16:17:01.728+0000 [id=40]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/jenkins_home/plugins/dynamic-axis/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
2021-11-16 16:17:01.736+0000 [id=40]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/jenkins_home/plugins/built-on-column/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
2021-11-16 16:17:05.755+0000 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$2 (file:/var/jenkins_home/war/WEB-INF/lib/guice-4.0.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2021-11-16 16:17:13.650+0000 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2021-11-16 16:17:15.076+0000 [id=30]	INFO	h.p.c.CopyArtifactConfiguration#load: CopyArtifact is set to Production mode.
2021-11-16 16:17:15.285+0000 [id=30]	WARNING	o.j.p.p.c.PrometheusConfiguration#lambda$parseLongFromEnv$1: COLLECTING_METRICS_PERIOD_IN_SECONDS must be a positive integer. The default value: '120' will be used instead of provided.
2021-11-16 16:17:15.732+0000 [id=30]	INFO	i.j.p.o.OpenTelemetrySdkProvider#postConstruct: OpenTelemetry SdkMeterProvider resources: jenkins.url: #undefined#, service.name: jenkins, service.namespace: jenkins, service.version: 2.303.3, telemetry.sdk.language: java, telemetry.sdk.name: opentelemetry, telemetry.sdk.version: 1.6.0
2021-11-16 16:17:15.828+0000 [id=43]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2021-11-16 16:17:15.840+0000 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2021-11-16 16:17:15.956+0000 [id=62]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Re-estimating disk usage
2021-11-16 16:17:16.055+0000 [id=62]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Finished re-estimating disk usage.
2021-11-16 16:17:16.074+0000 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
...
2021-11-16 16:17:48.227+0000 [id=31]	INFO	j.j.plugin.JenkinsJobManagement#createOrUpdateConfig: createOrUpdateConfig for it/writeVaultSecret
2021-11-16 16:17:48.235+0000 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
2021-11-16 16:17:48.235+0000 [id=38]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2021-11-16 16:17:48.237+0000 [id=39]	INFO	i.j.p.o.i.JvmMonitoringInitializer#initialize: Start monitoring the JVM...
2021-11-16 16:17:48.239+0000 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
2021-11-16 16:17:48.239+0000 [id=62]	INFO	c.c.s.QuickDiskUsagePlugin$3#run: Waiting for Jenkins to be up before computing disk usage
2021-11-16 16:17:48.246+0000 [id=114]	INFO	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Started Download metadata
2021-11-16 16:17:48.253+0000 [id=114]	INFO	hudson.util.Retrier#start: Attempt #1 to do the action check updates server
2021-11-16 16:17:48.325+0000 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2021-11-16 16:17:48.349+0000 [id=24]	INFO	hudson.WebAppMain$3#run: Jenkins is fully up and running
```