### PR TITLE
Docs: add link to the development doc

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Once your changes are ready to submit for review:
 
 2. Code your changes
 
-   See [development guidelines of this project][apm-pipeline-library-guidelines] for details.
+   See [development guidelines of this project][apm-pipeline-library-development] for details.
 
 3. Test your changes
 


### PR DESCRIPTION
## What does this PR do?

Fix the reference to the development section since the code guidelines is pointed out later on in a different section