### PR TITLE
bump: releases

### DIFF
--- a/resources/versions/releases.properties
+++ b/resources/versions/releases.properties
@@ -1,7 +1,7 @@
 current_6=6.8.20
-current_7=7.15.1
+current_7=7.15.2
 next_minor_7=7.16.0
-next_patch_7=7.15.2
+next_patch_7=7.16.0
 current_8=8.0.0
 next_minor_8=8.1.0
 next_patch_8=8.0.1

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -45,7 +45,7 @@ def version(value, args = [:]){
 
 def edge(Map args = [:]){
   // TODO: this should not use a hardcoded string but bmptUtils.getNextMinorReleaseFor8()
-  return version("8.0.0", args)
+  return version("8.1.0", args)
 }
 
 def dev(Map args = [:]){
@@ -58,7 +58,7 @@ def dev(Map args = [:]){
 def release(Map args = [:]){
   // IMPORTANT: this variable is needed to automate the elastic stack bump
   // TODO: this should not use a hardcoded string but bmptUtils.getCurrentMinorReleaseFor7()
-  def releaseVersion = "7.15.1"
+  def releaseVersion = "7.15.2"
   return version(releaseVersion, args)
 }
 


### PR DESCRIPTION
## What does this PR do?

`current_7` is now 7.15.2, aka latest release

`edge` is now `8.1.0`

