### PR TITLE
Updated TestUtils.withEnvInterceptor to fix IndexOutOfBoundsException

### DIFF
--- a/src/test/groovy/co/elastic/TestUtils.groovy
+++ b/src/test/groovy/co/elastic/TestUtils.groovy
@@ -20,14 +20,18 @@ package co.elastic
 public class TestUtils {
 
   public static withEnvInterceptor = { list, closure ->
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], fields[1])
+    def savedVars = []
+    // filter invlaid entries - with name empty or containing only spaces
+    list.findAll{ it&&it=~/^\s*[^=\s]+\s*=?/ }.forEach{
+      List fields = it.split("=");
+      def name = fields.remove(0);
+      def value = fields.join("="); // add back = chars deleted by split
+      savedVars.add([name, binding.hasVariable(name) ? binding.getVariable(name) : null])
+      binding.setVariable(name, value.size()> 0 ? value : null)
     }
     def res = closure.call()
-    list.forEach {
-      def fields = it.split("=")
-      binding.setVariable(fields[0], null)
+    savedVars.reverse().forEach {
+      binding.setVariable(it[0], it[1])
     }
     return res
   }

--- a/src/test/groovy/co/elastic/TestUtils.groovy
+++ b/src/test/groovy/co/elastic/TestUtils.groovy
@@ -21,7 +21,7 @@ public class TestUtils {
 
   public static withEnvInterceptor = { list, closure ->
     def savedVars = []
-    // filter invlaid entries - with name empty or containing only spaces
+    // filter invalid entries - with name empty or containing only spaces
     list.findAll{ it&&it=~/^\s*[^=\s]+\s*=?/ }.forEach{
       List fields = it.split("=");
       def name = fields.remove(0);


### PR DESCRIPTION
## What does this PR do?

It fixes 3 problems in TestUtils.withEnvInterceptor

1. IndexOutOfBoundsException when environment variable defined with empty value. Like this:
```
withEnv(["ORG_NAME=", "REPO_NAME="])
```
2. Incorrect value in variables after withEnv exited. Current implementation has different behavior in comparison with how withEnv works in Jenkins. When withEnv  finished variables which was defined in argument string are set to null while in Jenkins they restored to values they had before withEnv  called.

3. If value for specified variable has = character it will have only value before this = character. This will set VAR to SOME instead of SOME=TEXT.
```
withEnv(["VAR=SOME=TEXT"]) 
```
## Why is it important?

It will allow use withEnv with empty variables value in unit tests. And withEnv in tests will work close to how it works in Jenkins.

