### PR TITLE
Removed check for repo argument when specified forceRepo: true.

### DIFF
--- a/src/test/groovy/GhStepTests.groovy
+++ b/src/test/groovy/GhStepTests.groovy
@@ -247,4 +247,19 @@ class GhStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('sh', "--repo='acme/bar'"))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_outside_of_a_repo_with_variables_and_force_repo_wothout_repo_flag() throws Exception {
+    env.REPO_NAME = 'foo'
+    env.ORG_NAME = 'org'
+    helper.registerAllowedMethod('sh', [Map.class], { m ->
+      if (m?.returnStatus) { return 1 }})
+    try {
+      script.call(command: 'issue list', forceRepo: true)
+    } catch(err) { println err}
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', "--repo"))
+    assertJobStatusSuccess()
+  }
+
 }

--- a/vars/gh.groovy
+++ b/vars/gh.groovy
@@ -45,7 +45,7 @@ def call(Map args = [:]) {
     log(level: 'DEBUG', text: 'gh: running within a git workspace.')
   } else {
     if (forceRepo) {
-      if (env.REPO_NAME?.trim() && env.ORG_NAME?.trim() && flags.containsKey('repo')) {
+      if (env.REPO_NAME?.trim() && env.ORG_NAME?.trim()) {
         log(level: 'WARN', text: 'gh: repo flag has higher precedence over REPO_NAME and ORG_NAME')
       }
     } else {


### PR DESCRIPTION
## What does this PR do?

Removed check for repo argument when specified forceRepo: true.

## Why is it important?

This will allow to run gh command without --repo flag.
This is important because 'gh api' doesn't accept --repo flag

## Related issues
Related to: Allow repo customisation for the GH #1394 
