### PR TITLE
Send email if no bump updated has been done in the last x days

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -18,7 +18,7 @@
 @Library('apm@master') _
 
 pipeline {
-  agent { label 'master' }
+  agent { label 'ubuntu && immutable' }
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL='INFO'
@@ -64,6 +64,13 @@ pipeline {
           propagate: false,
           wait: false
         )
+      }
+    }
+    stage('Stalled Beats Bumps') {
+      steps {
+        notifyStalledBeatsBumps(branch: 'master', sendEmail: false, to: 'beats-contrib@elastic.co')
+        notifyStalledBeatsBumps(branch: '8.0', sendEmail: false, to: 'beats-contrib@elastic.co')
+        notifyStalledBeatsBumps(branch: '7.16', sendEmail: false, to: 'beats-contrib@elastic.co')
       }
     }
   }

--- a/resources/scripts/generate-email-template-if-no-recent-changes.sh
+++ b/resources/scripts/generate-email-template-if-no-recent-changes.sh
@@ -41,9 +41,11 @@ git clone "$REPO_URL" --branch "$BRANCH" "$BRANCH"
 
 cd "$BRANCH"
 
-if git log --name-only \
+if git --no-pager \
+    log --pretty=format: \
+      --name-only \
       --since="${DAYS} days ago" \
-    | grep -q 'testing/environments/snapshot-oss.yml' ; then
+    | grep 'testing/environments/snapshot-oss.yml' ; then
 
   echo 'nothing to be reported'
 else

--- a/resources/scripts/generate-email-template-if-no-recent-changes.sh
+++ b/resources/scripts/generate-email-template-if-no-recent-changes.sh
@@ -28,7 +28,6 @@
 
 set -euo pipefail
 
-
 REPO_URL=${1:?'Missing the GitHub repo URL'}
 BRANCH=${2:?'Missing the branch'}
 DAYS=${3:?'Missing the days since the file has not changed result'}
@@ -38,7 +37,9 @@ if [ -e ${EMAIL_FILE} ] ; then
   rm ${EMAIL_FILE}
 fi
 
-git clone "$REPO_URL" --branch "$BRANCH" .
+git clone "$REPO_URL" --branch "$BRANCH" "$BRANCH"
+
+cd "$BRANCH"
 
 if git log --name-only \
       --since="${DAYS} days ago" \
@@ -46,7 +47,7 @@ if git log --name-only \
 
   echo 'nothing to be reported'
 else
-cat <<EOT > ${EMAIL_FILE}
+cat <<EOT > ../${EMAIL_FILE}
 Just wanted to share with you that the Elastic Stack version for the ${BRANCH} branch has not been updated for a while ( > ${DAYS} days).
 
 Those bumps are automatically merged if it passes the CI checks. Otherwise, it might be related to some problems with the
@@ -57,9 +58,9 @@ EOT
   gh pr list \
     --search "is:open is:pr author:apmmachine base:$BRANCH" \
     --json url,createdAt \
-    --template '{{range .}}{{tablerow .url (.createdAt | timeago)}}{{end}}' >> ${EMAIL_FILE}
+    --template '{{range .}}{{tablerow .url (.createdAt | timeago)}}{{end}}' >> ../${EMAIL_FILE}
 
-cat <<EOT >> ${EMAIL_FILE}
+cat <<EOT >> ../${EMAIL_FILE}
 
 If any of the existing PRs are obsolete please close them.
 

--- a/resources/scripts/generate-email-template-if-no-recent-changes.sh
+++ b/resources/scripts/generate-email-template-if-no-recent-changes.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# Script that checkout the given repository and
+# search for recent changes in the last x days for the given
+# file. If no then it will create a template email to be sent
+#
+# Requirements:
+#  - git, in order to clone the repository
+#  - gh, in order to send the existing list of open PRs.
+#
+
+set -euo pipefail
+
+
+REPO_URL=${1:?'Missing the GitHub repo URL'}
+BRANCH=${2:?'Missing the branch'}
+DAYS=${3:?'Missing the days since the file has not changed result'}
+
+EMAIL_FILE=email.txt
+if [ -e ${EMAIL_FILE} ] ; then
+  rm ${EMAIL_FILE}
+fi
+
+git clone "$REPO_URL" --branch "$BRANCH" .
+
+if git log --name-only \
+      --since="${DAYS} days ago" \
+    | grep -q 'testing/environments/snapshot-oss.yml' ; then
+
+  echo 'nothing to be reported'
+else
+cat <<EOT > ${EMAIL_FILE}
+Just wanted to share with you that the Elastic Stack version for the ${BRANCH} branch has not been updated for a while ( > ${DAYS} days).
+
+Those bumps are automatically merged if it passes the CI checks. Otherwise, it might be related to some problems with the
+Integrations Tests.
+
+EOT
+
+  gh pr list \
+    --search "is:open is:pr author:apmmachine base:$BRANCH" \
+    --json url,createdAt \
+    --template '{{range .}}{{tablerow .url (.createdAt | timeago)}}{{end}}' >> ${EMAIL_FILE}
+
+cat <<EOT >> ${EMAIL_FILE}
+
+If any of the existing PRs are obsolete please close them.
+
+Thanks
+EOT
+fi

--- a/src/test/groovy/NotifyStalledBeatsBumpsStepTests.groovy
+++ b/src/test/groovy/NotifyStalledBeatsBumpsStepTests.groovy
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+
+class NotifyStalledBeatsBumpsStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/notifyStalledBeatsBump.groovy')
+  }
+
+  @Test
+  void test_without_arguments() throws Exception {
+    testMissingArgument('branch') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_with_defaults() throws Exception {
+    script.call(branch: 'foo')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "'https://github.com/elastic/beats.git' foo 7"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_all_params_and_nothing_to_be_reported() throws Exception {
+    helper.registerAllowedMethod('fileExists', [String.class], { return false })
+    script.call(branch: 'foo', days: 1, sendEmail: true, to: 'me@acme.com')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "'https://github.com/elastic/beats.git' foo 1"))
+    assertTrue(assertMethodCallOccurrences('mail', 0))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_email() throws Exception {
+    helper.registerAllowedMethod('fileExists', [String.class], { return true })
+    script.call(branch: 'foo', sendEmail: true, to: 'me@acme.com')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', "'https://github.com/elastic/beats.git' foo 7"))
+    assertTrue(assertMethodCallContainsPattern('mail', "to=me@acme.com"))
+  }
+
+  @Test
+  void test_with_email_and_no_to() throws Exception {
+    helper.registerAllowedMethod('fileExists', [String.class], { return true })
+    script.call(branch: 'foo', sendEmail: true)
+    printCallStack()
+    assertJobStatusSuccess()
+    assertTrue(assertMethodCallContainsPattern('log', "to' param is empty"))
+    assertTrue(assertMethodCallOccurrences('mail', 0))
+  }
+}

--- a/vars/notifyStalledBeatsBump.groovy
+++ b/vars/notifyStalledBeatsBump.groovy
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Evaluate if the latest bump update was merged a few days ago and if so
+  send an email if configured for such an action.
+
+  // Run the notifyStalledBeatsBumps and send an email
+  notifyStalledBeatsBumps(branch: '8.0', sendEmail: true, to: 'foo@acme.com')
+*/
+
+def call(Map args = [:]) {
+  def branch = args.branch
+  def days = args.get('days', 7)
+  def sendEmail = args.get('sendEmail', 'false')
+  def to = args.get('to', '')
+
+  // Proceed but notify with a warning
+  if (sendEmail && !to?.trim()) {
+    log(level: 'WARN', text: "stalledBeatsBump: email won't be sent since 'to' param is empty.")
+  }
+
+  // Look whether the file has changed recently
+  def didFileChangeRecently = true
+  dir(branch) {
+    // TODO: review is a full checkout or at least n number of days
+    git(branch: branch, url: 'https://github.com/elastic/beats.git')
+    fileDidNotChangeRecently = sh(script: "git log --name-only --since='${days} days ago' | grep 'testing/environments/snapshot-oss.yml'", returnStatus: true) > 0
+  }
+
+  if (fileDidNotChangeRecently) {
+    if (sendEmail && to?.trim()) {
+      mail(to: to,
+        subject: getSubject(branch),
+        body: getBody(branch, openPullRequest(branch), days),
+        mimeType: 'text/html'
+      )
+    }
+  } else {
+    log(level: 'WARN', text: "stalledBeatsBump: there are no changes to be reported")
+  }
+}
+
+private openPullRequest(branch) {
+  def filter = "is:open is:pr author:apmmachine base:${branch}"
+  def template = '{{range .}}{{tablerow .url (.createdAt | timeago)}}{{end}}'
+  return gh(command: 'pr list', flags: [ search: filter, json: "url,createdAt", template: template ])
+}
+
+private getSubject(branch){
+  return "[Bump][${branch}] Elastic Stack version has not been updated."
+}
+
+private getBody(branch, list, days){
+  return """
+  Just wanted to share with you that the Elastic Stack version for the ${branch} branch has not been updated for a while ( > ${days} days).
+
+  Those bumps are automatically merged if it passes the CI checks. Otherwise, it might be related to some problems with the
+  Integrations Tests.
+
+  ${list}
+
+  If any of the existing PRs are obsolete please close them.
+
+  Thanks
+  """
+}

--- a/vars/notifyStalledBeatsBump.txt
+++ b/vars/notifyStalledBeatsBump.txt
@@ -1,0 +1,11 @@
+Evaluate if the latest bump update was merged a few days ago and if so
+send an email if configured for such an action.
+
+```
+  notifyStalledBeatsBumps(branch: '8.0', sendEmail: true, to: 'foo@acme.com')
+```
+
+* *sendEmail*: whether to send an email. Optional. Default false
+* *to*: who should receive the email. Optional.
+* *branch*: what branch to be searched for. Mandatory.
+* *days*: search for any changes before those days. Optional. Default 7


### PR DESCRIPTION
## What does this PR do?

Monitor the Beats project and report on a weekly basis if the Elastic Stack version has not been updated in the active release branches.

## Why is it important?

This is something I've been doing manually, so let's simplify this by some automation.


## Test

Run 

```
sh -x resources/scripts/generate-email-template-if-no-recent-changes.sh \
  https://github.com/elastic/beats.git \
  master \
  7 
```

produces:

```
+ set -euo pipefail
+ REPO_URL=https://github.com/elastic/beats.git
+ BRANCH=master
+ DAYS=7
+ EMAIL_FILE=email.txt
+ '[' -e email.txt ']'
+ git clone https://github.com/elastic/beats.git --branch master master
Cloning into 'master'...
remote: Enumerating objects: 311054, done.
remote: Total 311054 (delta 0), reused 0 (delta 0), pack-reused 311054
Receiving objects: 100% (311054/311054), 361.35 MiB | 12.79 MiB/s, done.
Resolving deltas: 100% (191741/191741), done.
Updating files: 100% (13145/13145), done.
+ cd master
+ git log --name-only '--since=7 days ago'
+ grep -q testing/environments/snapshot-oss.yml
+ cat
+ gh pr list --search 'is:open is:pr author:apmmachine base:master' --json url,createdAt --template '{{range .}}{{tablerow .url (.createdAt | timeago)}}{{end}}'
+ cat
```

And the email contains

```
cat email.txt 
Just wanted to share with you that the Elastic Stack version for the master branch has not been updated for a while ( > 7 days).

Those bumps are automatically merged if it passes the CI checks. Otherwise, it might be related to some problems with the
Integrations Tests.

https://github.com/elastic/beats/pull/29139  4 hours ago
https://github.com/elastic/beats/pull/29114  1 day ago
https://github.com/elastic/beats/pull/29086  2 days ago
https://github.com/elastic/beats/pull/29044  6 days ago
https://github.com/elastic/beats/pull/29021  7 days ago
https://github.com/elastic/beats/pull/29008  8 days ago
https://github.com/elastic/beats/pull/28990  9 days ago
https://github.com/elastic/beats/pull/28956  10 days ago
https://github.com/elastic/beats/pull/28944  13 days ago
https://github.com/elastic/beats/pull/28877  16 days ago
https://github.com/elastic/beats/pull/28860  17 days ago

If any of the existing PRs are obsolete please close them.

Thanks
```

If the given number of days is over 30:

```
sh -x resources/scripts/generate-email-template-if-no-recent-changes.sh https://github.com/elastic/beats.git master 30
+ set -euo pipefail
+ REPO_URL=https://github.com/elastic/beats.git
+ BRANCH=master
+ DAYS=30
+ EMAIL_FILE=email.txt
+ '[' -e email.txt ']'
+ rm email.txt
+ cd master
+ git --no-pager log --pretty=format: --name-only '--since=30 days ago'
+ grep testing/environments/snapshot-oss.yml
testing/environments/snapshot-oss.yml
+ echo 'nothing to be reported'
nothing to be reported
```