### PR TITLE
ci: delete workspace after notifying

### DIFF
--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -125,6 +125,10 @@ def call(Map args = [:]) {
           }
         }
       }
+      // Ensure we don't leave any leftovers if running in the jenkins controller.
+      catchError(message: 'Delete dir if possible', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+        deleteDir()
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Reenable the deleteDir in the notifyBuildResult.


## Why

I saw some weird behaviour with the test reporting in the GitHub comments.

A file timestamp was wrong 

![image](https://user-images.githubusercontent.com/2871786/143463706-9f4a4841-c01a-4e4b-8756-687daa36f6d8.png)

Tests are not present

![image](https://user-images.githubusercontent.com/2871786/143463786-fa3f5493-cc28-439c-b945-01b66701bed3.png)

But the json with the tests files is filled with probably some data from a previous build:

![image](https://user-images.githubusercontent.com/2871786/143463924-2cdc3d39-45b3-4dd7-a4fb-e0cca6a36192.png)

I wonder if something is cached in the Jenkins controller ?


### Issues

Initially enabled in https://github.com/elastic/apm-pipeline-library/pull/511

Removed in https://github.com/elastic/apm-pipeline-library/pull/904