### PR TITLE
Support for DisableConcurrentBuildsJobProperty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.42</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.1.0</version>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -1,5 +1,7 @@
 <%if (statusSuccess) {%>
 ## :green_heart: Build Succeeded
+<%} else if (abortedBuild) {%>
+  > There is a new build on-going so the previous on-going builds have been aborted.
 <%} else if (buildStatus?.equals('ABORTED')) {%>
 ## :grey_exclamation: Build Aborted
   <%if (!build?.description != null && build?.description.toString().toLowerCase().contains('aborted')) {%>
@@ -7,7 +9,7 @@
   <%} else if (!build?.description != null && build?.description.toString().toLowerCase().contains('allowed')) {%>
   > ${build.description}
   <%} else {%>
-  > Either there was a build timeout or someone aborted the build.'}
+  > Either there was a build timeout or someone aborted the build.
   <%}%>
 <%} else {%>
 ## :broken_heart: ${(testsSummary?.failed != 0) ? 'Tests Failed' : 'Build Failed'}

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -202,8 +202,8 @@ def notifyEmail(Map params = [:]) {
       def statusSuccess = true
 
       if(buildStatus != "SUCCESS") {
-          icon = "❌"
-          statusSuccess = false
+        icon = "❌"
+        statusSuccess = false
       }
 
       def boURL = getBlueoceanDisplayURL()
@@ -366,11 +366,13 @@ def generateBuildReport(Map args = [:]) {
     def output = ''
     catchError(buildResult: 'SUCCESS', message: 'generateBuildReport: Error generating build report') {
       def statusSuccess = (buildStatus == "SUCCESS")
+      def abortedBuild = (buildStatus == 'NOT_BUILT' && isCancelledCausedFromADisableConcurrentBuilds())
       def boURL = getBlueoceanDisplayURL()
       output = buildTemplate([
         "template": 'github-comment-markdown.template',
         "build": build,
         "buildStatus": buildStatus,
+        "abortedBuild": abortedBuild,
         "changeSet": changeSet,
         "docsUrl": docsUrl,
         "env": env,
@@ -540,4 +542,9 @@ private isElasticsearchDocsSupported(String value) {
 @NonCPS
 def findIssueCommentTrigger() {
   return currentBuild.rawBuild.getParent().getTriggers().collect { it.value }.find { it instanceof IssueCommentTrigger }
+}
+
+@NonCPS
+def isCancelledCausedFromADisableConcurrentBuilds() {
+  return currentBuild.rawBuild.getAction(org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty.CancelledCause.class)
 }

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -374,6 +374,17 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_not_built() throws Exception {
+    script.notifyPR(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "NOT_BUILT"
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'There is a new build on-going so the previous on-going builds have been aborted'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_pr_without_comment_notifications() throws Exception {
     script.notifyPR(
       build: readJSON(file: "build-info.json"),

--- a/src/test/groovy/co/elastic/mock/RunMock.groovy
+++ b/src/test/groovy/co/elastic/mock/RunMock.groovy
@@ -45,11 +45,19 @@ public class RunMock implements Serializable {
     return new Parent()
   }
 
+  public Action getAction(java.lang.Class clazz) {
+    return new Action()
+  }
+
   private class Parent implements Serializable {
     public Parent() { }
 
     public Map getTriggers() {
       return [:]
     }
+  }
+
+  private class Action implements Serializable {
+    public Action() { }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Support for DisableConcurrentBuildsJobProperty in order to notify the build status in the GitHub comment if the build was aborted when using the new property.


## Why is it important?

Keep the DX similar to what we have already in place with the CancelPreviousBuild.

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1420
