### PR TITLE
[mergify] use merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=apm-ci/pr-merge
+
 pull_request_rules:
   - name: Automatic squash and merge on approval with success checks and ready-to-merge label
     conditions:
@@ -8,9 +13,9 @@ pull_request_rules:
       - label=ready-to-merge
       - base=master
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: backport patches to 7.x branch
     conditions:
       - base=master
@@ -31,9 +36,9 @@ pull_request_rules:
       - check-success=Test
       - base=7.x
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: delete upstream branch after merging changes
     conditions:
       - merged


### PR DESCRIPTION
### What

Migrate from the `merge action` to the `queue action`.

See https://docs.mergify.io/actions/queue/#queue-rules to know more about how the `queue` command works.

### Why

We use the merge action to automerge automated PRs, so we cannot use this approach from January 2022

```
The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.io/strict-mode-deprecation/
```
