### PR TITLE
fix: add HOME folders to the PATH

### DIFF
--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -25,6 +25,7 @@ pipeline {
     PIPELINE_LOG_LEVEL='INFO'
     DOCKER_SECRET = "secret/observability-team/ci/docker-registry/prod"
     HOME="${env.WORKSPACE}"
+    PATH="${env.PATH}:${env.HOME}/bin:${env.HOME}/go/bin"
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Add `$HOME/bin`, and `$HOME/go/bin` to the PATH

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->
We have cases in which we install tools and they should be in the path.


```
11:34:41  + cat ../../.go-version
11:34:41  + gvm 1.17.2
11:34:48  + eval export GOROOT="/var/lib/jenkins/workspace/apm-shared/docker-images/metricbeat-integrations-images-x-pack/.gvm/versions/go1.17.2.linux.amd64" export PATH="/var/lib/jenkins/workspace/apm-shared/docker-images/metricbeat-integrations-images-x-pack/.gvm/versions/go1.17.2.linux.amd64/bin:$PATH"
11:34:48  + export GOROOT=/var/lib/jenkins/workspace/apm-shared/docker-images/metricbeat-integrations-images-x-pack/.gvm/versions/go1.17.2.linux.amd64 export PATH=/var/lib/jenkins/workspace/apm-shared/docker-images/metricbeat-integrations-images-x-pack/.gvm/versions/go1.17.2.linux.amd64/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
11:34:48  + make mage
11:34:48  Installing mage v1.11.0.
11:34:49  go: downloading github.com/magefile/mage v1.11.0
11:34:49  go get: installing executables with 'go get' in module mode is deprecated.
11:34:49  	To adjust and download dependencies of the current module, use 'go get -d'.
11:34:49  	To install using requirements of the current module, use 'go install'.
11:34:49  	To install ignoring the current module, use 'go install' with a version,
11:34:49  	like 'go install example.com/cmd@latest'.
11:34:49  	For more information, see https://golang.org/doc/go-get-install-deprecation
11:34:49  	or run 'go help get' or 'go help install'.
11:34:50  make: mage: Command not found
11:34:50  make: [../../dev-tools/make/mage-install.mk:11: mage] Error 127 (ignored)
11:34:50  + mage compose:buildSupportedVersions
11:34:50  /var/lib/jenkins/workspace/apm-shared/docker-images/metricbeat-integrations-images-x-pack/metricbeat-integrations-images-x-pack-latest/x-pack/metricbeat@tmp/durable-5073b089/script.sh: 1: mage: not found
```
