### PR TITLE
Abort on PR basis if an old running build

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
-    disableConcurrentBuilds(abortPrevious: true)
+    disableConcurrentBuilds(abortPrevious: isPR())
   }
   triggers {
     issueCommentTrigger("(${obltGitHubComments()}|^run infra tests)")

--- a/resources/JenkinsfileTemplate.groovy
+++ b/resources/JenkinsfileTemplate.groovy
@@ -67,7 +67,7 @@ pipeline {
     ansiColor('xterm')
     // Option to disable concurrent builds by aborting previous ones.
     //   Only supported from https://github.com/jenkinsci/workflow-job-plugin/releases/tag/workflow-job-2.42
-    disableConcurrentBuilds(abortPrevious: true)
+    disableConcurrentBuilds(abortPrevious: isPR())
     // As long as we use ephemeral workers we cannot use the resume. The below couple of
     // options will help to speed up the performance.
     disableResume()

--- a/vars/README.md
+++ b/vars/README.md
@@ -239,7 +239,7 @@ Utils class for the bump automation pipelines
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
 
 ## cancelPreviousRunningBuilds
-**DEPRECATED**: use `disableConcurrentBuilds(abortPrevious: true)`
+**DEPRECATED**: use `disableConcurrentBuilds(abortPrevious: isPR())`
 
 Abort any previously running builds as soon as a new build starts
 

--- a/vars/cancelPreviousRunningBuilds.groovy
+++ b/vars/cancelPreviousRunningBuilds.groovy
@@ -25,7 +25,7 @@
 
 def call(Map args = [:]) {
   def maxBuildsToSearch = args.get('maxBuildsToSearch', 10)
-  log(level: 'WARN', text: "cancelPreviousRunningBuilds step is DEPRECATED; use `disableConcurrentBuilds(abortPrevious: true)`")
+  log(level: 'WARN', text: "cancelPreviousRunningBuilds step is DEPRECATED; use `disableConcurrentBuilds(abortPrevious: isPR())`")
   log(level: 'INFO', text: "Number of builds to be searched ${maxBuildsToSearch}")
   b = currentBuild
   for (int i=0; i<maxBuildsToSearch; i++) {

--- a/vars/cancelPreviousRunningBuilds.txt
+++ b/vars/cancelPreviousRunningBuilds.txt
@@ -1,4 +1,4 @@
-**DEPRECATED**: use `disableConcurrentBuilds(abortPrevious: true)`
+**DEPRECATED**: use `disableConcurrentBuilds(abortPrevious: isPR())`
 
 Abort any previously running builds as soon as a new build starts
 


### PR DESCRIPTION
## What does this PR do?

Avoid killing builds for branches/tags but only for PRs

## Why is it important?

Otherwise builds running on branches are killed

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1439
