### PR TITLE
Support the case when OTEL plugin has not been configured

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -96,7 +96,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     binding.setProperty('docker', new DockerMock())
     binding.setProperty('getVaultSecret', new GetVaultSecretMock())
     binding.setProperty('githubEnv', new GithubEnvMock())
-    binding.setProperty('otelHelper', new OtelHelperMock(true))
+    binding.setProperty('otelHelper', new OtelHelperMock(true, true))
     binding.setProperty('pullRequest', new PullRequestMock())
     binding.setProperty('steps', new StepsMock())
   }

--- a/src/test/groovy/WithOtelEnvStepTests.groovy
+++ b/src/test/groovy/WithOtelEnvStepTests.groovy
@@ -106,7 +106,8 @@ class WithOtelEnvStepTests extends ApmBasePipelineTest {
     script.call(){
       isOK = true
     }
+    assertTrue(isOK)
+    assertFalse(assertMethodCallContainsPattern('withCredentials', 'credentialsId'))
     printCallStack()
   }
-
 }

--- a/src/test/groovy/WithOtelEnvStepTests.groovy
+++ b/src/test/groovy/WithOtelEnvStepTests.groovy
@@ -34,7 +34,7 @@ class WithOtelEnvStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_plugin_not_installed() throws Exception {
-    binding.setProperty('otelHelper', new OtelHelperMock(false))
+    binding.setProperty('otelHelper', new OtelHelperMock(false, false))
     try {
       script.call(){
         //NOOP
@@ -97,6 +97,16 @@ class WithOtelEnvStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(isOK)
     assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=my-foo-id, variable=OTEL_TOKEN_ID'))
+  }
+
+  @Test
+  void test_plugin_not_configured() throws Exception {
+    binding.setProperty('otelHelper', new OtelHelperMock(true, false))
+    def isOK = false
+    script.call(){
+      isOK = true
+    }
+    printCallStack()
   }
 
 }

--- a/src/test/groovy/co/elastic/mock/OtelHelperMock.groovy
+++ b/src/test/groovy/co/elastic/mock/OtelHelperMock.groovy
@@ -23,11 +23,18 @@ package co.elastic.mock
 class OtelHelperMock implements Serializable {
 
   private installed = true
-  public OtelHelperMock(boolean installed) {
+  private configured = true
+  public OtelHelperMock(boolean installed, boolean configured) {
     this.installed = installed
+    this.configured = configured
   }
   public boolean isPluginInstalled() { return this.installed }
-  public calculateCrendentialsId() { return 'otel-token' }
+  public calculateCrendentialsId() {
+    if (configured) {
+      return 'otel-token'
+    }
+    return ''
+  }
   public getOtelPlugin() { return 'otel-plugin' }
   public getAuthentication() { return 'otel-authentication' }
   public getEndpoint() { return 'otel-endpoint' }

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -36,6 +36,14 @@ def call(Map args = [:], Closure body) {
     credentialsId = otelHelper.calculateCrendentialsId()
   }
 
+  // In case the credentialsId argument was not passed and no way to gather those
+  // details from the OpenTelemetry configuration then run the body and exit
+  if (!credentialsId?.trim()) {
+    log(level: 'WARNING', text: 'withOtelEnv: opentelemetry plugin has missing credentials.')
+    body()
+    return
+  }
+
   // Then, mask and provide the environment variables.
   withCredentials([string(credentialsId: credentialsId, variable: 'OTEL_TOKEN_ID')]) {
     def entrypoint = otelHelper.getEndpoint()


### PR DESCRIPTION
## What does this PR do?

Support the fallback case to run the body when no otel plugin configuration has been defined

## Why is it important?

Ensure we allow the CI to run correctly when misconfigured