### PR TITLE
Support for no credentials but endpoint

### DIFF
--- a/src/test/groovy/WithOtelEnvStepTests.groovy
+++ b/src/test/groovy/WithOtelEnvStepTests.groovy
@@ -108,6 +108,8 @@ class WithOtelEnvStepTests extends ApmBasePipelineTest {
     }
     assertTrue(isOK)
     assertFalse(assertMethodCallContainsPattern('withCredentials', 'credentialsId'))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', 'ELASTIC_APM_SERVER_URL, password=otel-endpoint'))
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', 'OTEL_EXPORTER_OTLP_ENDPOINT, password=otel-endpoint'))
     printCallStack()
   }
 }

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -41,6 +41,7 @@ def call(Map args = [:], Closure body) {
       body()
     }
   } else {
+    log(level: 'WARNING', text: 'withOtelEnv: opentelemetry plugin has been configured without any authentication method.')
     // In case the credentialsId argument was not passed and no way to gather those
     // details from the OpenTelemetry configuration then run the body without credentials
     runBodyWithEndpoint() {


### PR DESCRIPTION
## What does this PR do?

We can now support the case of running an endpoint in a secured environment without the need of a credentials.

## Why is it important?

Be able to send traces :)