### PR TITLE
Add 7.17 branch versions

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -56,7 +56,7 @@ pipeline {
         script {
           releaseVersions[bumpUtils.current6Key()] = '6.8.21'
           releaseVersions[bumpUtils.current7Key()] = '7.16.1'
-          releaseVersions[bumpUtils.nextMinor7Key()] = '7.16.2'
+          releaseVersions[bumpUtils.nextMinor7Key()] = '7.17.0'
           releaseVersions[bumpUtils.nextPatch7Key()] = '7.16.2'
           // TODO: to support the 8.x branches
           releaseVersions[bumpUtils.current8Key()] = '8.0.0'


### PR DESCRIPTION
## What does this PR do?

`7.17` branch is a new one, therefore let's  enable the next minor 7 version.

## Why is it important?

Keep the automation running