### PR TITLE
docker: no cache flag when building the image

### DIFF
--- a/.ci/buildDockerImages.groovy
+++ b/.ci/buildDockerImages.groovy
@@ -590,7 +590,7 @@ def buildDockerImage(args){
       withEnv(env){
         prepareWith()
         if (buildCommand.equals("")) {
-          sh(label: "build docker image", script: "docker build --force-rm ${options} -t ${image} .")
+          sh(label: "build docker image", script: "docker build --force-rm --no-cache ${options} -t ${image} .")
         } else {
           sh(label: "custom build docker image", script: "${buildCommand}")
         }


### PR DESCRIPTION
## What does this PR do?

Use `--no-cache                Do not use cache when building the image`

## Why is it important?

Node:16 and Node:17 cached docker images point to node:8

## Related issues

Relates to https://github.com/elastic/ecs-logging-nodejs/issues/112
