### PR TITLE
Beats: notify 7 next minor branch and 7 current branch

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -45,8 +45,9 @@ pipeline {
       steps {
         setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
         runWatcherForBranch(branch: 'master')
-        runWatcherForBranch(branch: '7.<next>')
         runWatcherForBranch(branch: '8.<current>')
+        runWatcherForBranch(branch: '7.<next>')
+        runWatcherForBranch(branch: '7.<current>')
       }
     }
     stage('Sync GitHub labels') {
@@ -76,6 +77,7 @@ pipeline {
         runNotifyStalledBeatsBumps(branch: 'master')
         runNotifyStalledBeatsBumps(branch: '8.<current>')
         runNotifyStalledBeatsBumps(branch: '7.<next>')
+        runNotifyStalledBeatsBumps(branch: '7.<current>')
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Support two 7 minor branches (7.16 and 7.17)

## Why is it important?
`7.17` was not reported while `7.16` is also active.


Thanks @ruflin for pointing out about this

## Follow ups

How to dynamically know if there are two active 7.minor branches

## Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1470