### PR TITLE
Main leftovers

### DIFF
--- a/.ci/buildBeatsDockerImages.groovy
+++ b/.ci/buildBeatsDockerImages.groovy
@@ -52,7 +52,9 @@ pipeline {
     stage('Checkout') {
       steps {
         dir("${BASE_DIR}"){
-          git("https://github.com/elastic/${REPO}.git")
+          // TODO: when renaming Beats@main then replace the branch here.
+          git(url: "https://github.com/elastic/${REPO}.git",
+              branch: 'master')
         }
         script {
           dir("${BASE_DIR}"){

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -42,7 +42,9 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+            url: "https://github.com/${ORG_NAME}/${REPO}.git",
+            branch: 'main')
       }
     }
     stage('Fetch latest go release version') {

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -42,7 +42,9 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+            url: "https://github.com/${ORG_NAME}/${REPO}.git",
+            branch: 'main')
       }
     }
     stage('Send Pull Request'){

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -47,7 +47,9 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken', url: "https://github.com/${ORG_NAME}/${REPO}.git")
+        git(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken',
+            url: "https://github.com/${ORG_NAME}/${REPO}.git",
+            branch: 'main')
       }
     }
     stage('Fetch latest versions') {

--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -47,7 +47,8 @@ pipeline {
       steps {
         deleteDir()
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-        gitCheckout(basedir: "${BASE_DIR}", branch: 'main',
+        gitCheckout(basedir: "${BASE_DIR}",
+          branch: 'main',
           repo: "git@github.com:elastic/${env.REPO}.git",
           credentialsId: "${JOB_GIT_CREDENTIALS}",
           githubNotifyFirstTimeContributor: false,

--- a/resources/scripts/artifacts-api-latest-versions.sh
+++ b/resources/scripts/artifacts-api-latest-versions.sh
@@ -54,4 +54,8 @@ for version in ${QUERY_OUTPUT}; do
 done
 echo "}" >> "${TEMP_FILE}"
 
-jq . "${TEMP_FILE}" | tee ${OUTPUT}
+## As long as we need to support main, then let's
+## artificially duplicate the master document
+jq 'with_entries(select(.value.branch=="master")) | with_entries(.key = "main")' "${TEMP_FILE}" > "${TEMP_FILE}.main"
+
+jq -s '.[0] * .[1]' "${TEMP_FILE}" "${TEMP_FILE}.main"| tee ${OUTPUT}

--- a/vars/README.md
+++ b/vars/README.md
@@ -192,11 +192,11 @@ See https://jenkins.io/doc/pipeline/steps/pipeline-build-step/#build-build-a-job
 Builds the Docker image for Kibana, from a branch or a pull Request.
 
 ```
-buildKibanaDockerImage(refspec: 'master')
+buildKibanaDockerImage(refspec: 'main')
 buildKibanaDockerImage(refspec: 'PR/12345')
 ```
 
-* refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
+* refspec: A branch (i.e. main), or a pull request identified by the "pr/" prefix and the pull request ID.
 * packageJSON: Full name of the package.json file. Defaults to 'package.json'
 * baseDir: Directory where to clone the Kibana repository. Defaults to "${env.BASE_DIR}/build"
 * credentialsId: Credentials used access Github repositories.
@@ -2554,7 +2554,7 @@ Trigger the end 2 end testing job. https://beats-ci.elastic.co/job/e2e-tests/job
 
 **NOTE**: It works only in the `beats-ci` controller.
 
-Parameters are defined in https://github.com/elastic/e2e-testing/blob/master/.ci/Jenkinsfile
+Parameters are defined in https://github.com/elastic/e2e-testing/blob/main/.ci/Jenkinsfile
 
 ## runWatcher
 Run the given watcher and send an email if configured for such an action.

--- a/vars/buildKibanaDockerImage.groovy
+++ b/vars/buildKibanaDockerImage.groovy
@@ -19,7 +19,7 @@
 
   Builds the Docker image for Kibana, from a branch or a pull Request.
 
-  buildKibanaDockerImage(refspec: 'master')
+  buildKibanaDockerImage(refspec: 'main')
   buildKibanaDockerImage(refspec: 'PR/12345')
   buildKibanaDockerImage(refspec: 'PR/12345', dockerRegistry: hub.docker.com)
 */

--- a/vars/buildKibanaDockerImage.txt
+++ b/vars/buildKibanaDockerImage.txt
@@ -1,11 +1,11 @@
 Builds the Docker image for Kibana, from a branch or a pull Request.
 
 ```
-buildKibanaDockerImage(refspec: 'master')
+buildKibanaDockerImage(refspec: 'main')
 buildKibanaDockerImage(refspec: 'PR/12345')
 ```
 
-* refspec: A branch (i.e. master), or a pull request identified by the "pr/" prefix and the pull request ID.
+* refspec: A branch (i.e. main), or a pull request identified by the "pr/" prefix and the pull request ID.
 * packageJSON: Full name of the package.json file. Defaults to 'package.json'
 * baseDir: Directory where to clone the Kibana repository. Defaults to "${env.BASE_DIR}/build"
 * credentialsId: Credentials used access Github repositories.

--- a/vars/runE2E.txt
+++ b/vars/runE2E.txt
@@ -29,4 +29,4 @@ Trigger the end 2 end testing job. https://beats-ci.elastic.co/job/e2e-tests/job
 
 **NOTE**: It works only in the `beats-ci` controller.
 
-Parameters are defined in https://github.com/elastic/e2e-testing/blob/master/.ci/Jenkinsfile
+Parameters are defined in https://github.com/elastic/e2e-testing/blob/main/.ci/Jenkinsfile


### PR DESCRIPTION
## What does this PR do?

Some leftovers for the `git` step in Jenkins that requires to checkout the `main` branch instead the default `master` branch.
Support for the artifacts-api to return the list of snapshots and support artificially for the `main` branch. This is required since some consumers don't have anymore the `master` branch and their branch strategy is aligned with the artifacts-api.
Update docs

## Why is it important?

Keep the automation working as expected.

Fixes

![image](https://user-images.githubusercontent.com/2871786/146890948-d0813e45-3c59-4195-9ed5-e2859229fc7b.png)
[build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fbump-stack-version-pipeline/detail/bump-stack-version-pipeline/188/pipeline/637/)

##  Test

```
resources/scripts/artifacts-api-latest-versions.sh                                  
{
  "6.8": {
    "start_time": "Mon, 20 Dec 2021 20:34:48 GMT",
    "release_branch": "6.8",
    "prefix": "",
    "end_time": "Tue, 21 Dec 2021 01:03:59 GMT",
    "manifest_version": "2.0.0",
    "version": "6.8.23-SNAPSHOT",
    "branch": "6.8",
    "build_id": "6.8.23-27e40404",
    "build_duration_seconds": 16151
  },
  "7.15": {
    "start_time": "Wed, 8 Dec 2021 17:14:42 GMT",
    "release_branch": "7.15",
    "prefix": "",
    "end_time": "Wed, 8 Dec 2021 23:35:19 GMT",
    "manifest_version": "2.0.0",
    "version": "7.15.3-SNAPSHOT",
    "branch": "7.15",
    "build_id": "7.15.3-67d7b6ce",
    "build_duration_seconds": 22837
  },
  "7.16": {
    "start_time": "Sat, 18 Dec 2021 05:13:23 GMT",
    "release_branch": "7.16",
    "prefix": "",
    "end_time": "Sat, 18 Dec 2021 10:55:27 GMT",
    "manifest_version": "2.0.0",
    "version": "7.16.2-SNAPSHOT",
    "branch": "7.16",
    "build_id": "7.16.2-02e7fd8e",
    "build_duration_seconds": 20524
  },
  "7.17": {
    "start_time": "Tue, 21 Dec 2021 00:13:09 GMT",
    "release_branch": "7.17",
    "prefix": "",
    "end_time": "Tue, 21 Dec 2021 05:41:05 GMT",
    "manifest_version": "2.0.0",
    "version": "7.17.0-SNAPSHOT",
    "branch": "7.17",
    "build_id": "7.17.0-aa797a6c",
    "build_duration_seconds": 19676
  },
  "8.0": {
    "start_time": "Mon, 20 Dec 2021 00:16:05 GMT",
    "release_branch": "8.0",
    "prefix": "",
    "end_time": "Mon, 20 Dec 2021 06:16:43 GMT",
    "manifest_version": "2.0.0",
    "version": "8.0.0-SNAPSHOT",
    "branch": "8.0",
    "build_id": "8.0.0-7b79b556",
    "build_duration_seconds": 21638
  },
  "master": {
    "start_time": "Fri, 17 Dec 2021 00:14:40 GMT",
    "release_branch": "master",
    "prefix": "",
    "end_time": "Fri, 17 Dec 2021 06:44:14 GMT",
    "manifest_version": "2.0.0",
    "version": "8.1.0-SNAPSHOT",
    "branch": "master",
    "build_id": "8.1.0-befff95a",
    "build_duration_seconds": 23374
  },
  "main": {
    "start_time": "Fri, 17 Dec 2021 00:14:40 GMT",
    "release_branch": "master",
    "prefix": "",
    "end_time": "Fri, 17 Dec 2021 06:44:14 GMT",
    "manifest_version": "2.0.0",
    "version": "8.1.0-SNAPSHOT",
    "branch": "master",
    "build_id": "8.1.0-befff95a",
    "build_duration_seconds": 23374
  }
}
```
