### PR TITLE
Support major.minor ElasticStack versions for the current/next releases

### DIFF
--- a/src/test/groovy/BumpUtilsStepTests.groovy
+++ b/src/test/groovy/BumpUtilsStepTests.groovy
@@ -19,6 +19,7 @@ import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertEquals
 
 class BumpUtilsStepTests extends ApmBasePipelineTest {
 
@@ -140,4 +141,35 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(result.containsKey('assign'))
   }
+
+  @Test
+  void test_getMajorMinorFor7() throws Exception {
+    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15.0' ] })
+    def result = script.getMajorMinor('current_7')
+    printCallStack()
+    println result
+    assertEquals(result, "7.15")
+  }
+
+  @Test
+  void test_getMajorFor7() throws Exception {
+    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15.0' ] })
+    def result = script.getMajor('current_7')
+    printCallStack()
+    assertEquals(result, "7")
+  }
+
+  @Test
+  void test_getMajorMinorFor7_with_wrong_format() throws Exception {
+    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15' ] })
+    try {
+      result = script.getMajorMinor('current_7')
+    } catch(e) {
+      // NOOP
+      println e
+    }
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('error', 1))
+  }
+
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -237,6 +237,8 @@ Utils class for the bump automation pipelines
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
+* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16.
+* `getMajor` -> retrieve the given version in Major format, f.e: given `7.16.2` it returns `7`.
 
 ## cancelPreviousRunningBuilds
 **DEPRECATED**: use `disableConcurrentBuilds(abortPrevious: isPR())`

--- a/vars/README.md
+++ b/vars/README.md
@@ -237,7 +237,7 @@ Utils class for the bump automation pipelines
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
-* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16.
+* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16`.
 * `getMajor` -> retrieve the given version in Major format, f.e: given `7.16.2` it returns `7`.
 
 ## cancelPreviousRunningBuilds

--- a/vars/bumpUtils.groovy
+++ b/vars/bumpUtils.groovy
@@ -54,6 +54,24 @@ def parseArguments(Map args = [:]) {
   return arguments
 }
 
+def getMajor(String key) {
+  def value = getValueForPropertyKey(key)
+  def parts = value.split('\\.')
+  if (parts.size() == 3) {
+    return parts[0]
+  }
+  error('getMajor: version is not major.minor.patch formatted')
+}
+
+def getMajorMinor(String key) {
+  def value = getValueForPropertyKey(key)
+  def parts = value.split('\\.')
+  if (parts.size() == 3) {
+    return parts[0] + "." + parts[1]
+  }
+  error('getMajorMinor: version is not major.minor.patch formatted')
+}
+
 def getCurrentMinorReleaseFor8() {
   return getValueForPropertyKey(current8Key())
 }

--- a/vars/bumpUtils.txt
+++ b/vars/bumpUtils.txt
@@ -9,3 +9,5 @@ Utils class for the bump automation pipelines
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
+* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16.
+* `getMajor` -> retrieve the given version in Major format, f.e: given `7.16.2` it returns `7`.

--- a/vars/bumpUtils.txt
+++ b/vars/bumpUtils.txt
@@ -9,5 +9,5 @@ Utils class for the bump automation pipelines
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
-* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16.
+* `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16`.
 * `getMajor` -> retrieve the given version in Major format, f.e: given `7.16.2` it returns `7`.


### PR DESCRIPTION
## What does this PR do?

Support a way to know the current active branches by consuming `bump.getNextMinorRelease` and similar steps

## Why is it important?

Then we won't need elastic/beats#29602 since we can use bump.branch(bump.getNextMinorReleaseFor7) that returns 7.17 rather than 7.17.0
