### PR TITLE
Use string versions for the getMajor* helper functions

### DIFF
--- a/src/test/groovy/BumpUtilsStepTests.groovy
+++ b/src/test/groovy/BumpUtilsStepTests.groovy
@@ -144,8 +144,7 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_getMajorMinorFor7() throws Exception {
-    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15.0' ] })
-    def result = script.getMajorMinor('current_7')
+    def result = script.getMajorMinor('7.15.0')
     printCallStack()
     println result
     assertEquals(result, "7.15")
@@ -153,17 +152,27 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_getMajorFor7() throws Exception {
-    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15.0' ] })
-    def result = script.getMajor('current_7')
+    def result = script.getMajor('7.15.0')
     printCallStack()
     assertEquals(result, "7")
   }
 
   @Test
   void test_getMajorMinorFor7_with_wrong_format() throws Exception {
-    helper.registerAllowedMethod('readProperties', [Map.class], { [ current_7 : '7.15' ] })
     try {
-      result = script.getMajorMinor('current_7')
+      result = script.getMajorMinor('7.15')
+    } catch(e) {
+      // NOOP
+      println e
+    }
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('error', 1))
+  }
+
+  @Test
+  void test_getMajorMinor_with_empty_value() throws Exception {
+    try {
+      result = script.getMajorMinor('')
     } catch(e) {
       // NOOP
       println e

--- a/vars/bumpUtils.groovy
+++ b/vars/bumpUtils.groovy
@@ -54,18 +54,22 @@ def parseArguments(Map args = [:]) {
   return arguments
 }
 
-def getMajor(String key) {
-  def value = getValueForPropertyKey(key)
-  def parts = value.split('\\.')
+def getMajor(String version) {
+  if (!version?.trim()) {
+    error('getMajor: version cannot be empty, please use the format major.minor.patch')
+  }
+  def parts = version?.split('\\.')
   if (parts.size() == 3) {
     return parts[0]
   }
   error('getMajor: version is not major.minor.patch formatted')
 }
 
-def getMajorMinor(String key) {
-  def value = getValueForPropertyKey(key)
-  def parts = value.split('\\.')
+def getMajorMinor(String version) {
+  if (!version?.trim()) {
+    error('getMajorMinor: version cannot be empty, please use the format major.minor.patch')
+  }
+  def parts = version?.split('\\.')
   if (parts.size() == 3) {
     return parts[0] + "." + parts[1]
   }


### PR DESCRIPTION
## What does this PR do?

Use a version rather than the alias.

## Why is it important?

To be agnostic to the aliases and allow other use cases.