### PR TITLE
Allow to customise the vault token in withGCPEnv

### DIFF
--- a/src/test/groovy/WithGCPEnvStepTests.groovy
+++ b/src/test/groovy/WithGCPEnvStepTests.groovy
@@ -76,6 +76,22 @@ class WithGCPEnvStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_with_vault_arguments() throws Exception {
+    def ret = false
+    try {
+    script.call(secret: VaultSecret.SECRET_GCP_PROVISIONER.toString(), role_id: 'my-role', secret_id: 'my-secret') {
+      ret = true
+    }
+    } catch (e) {
+      println e
+    }
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('getVaultSecret', "secret=${VaultSecret.SECRET_GCP_PROVISIONER.toString()}, role_id=my-role, secret_id=my-secret"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_with_failed() throws Exception {
     helper.registerAllowedMethod('cmd', [Map.class], { m -> throw new Exception('force a failure') })
     def result = false

--- a/vars/README.md
+++ b/vars/README.md
@@ -3184,6 +3184,8 @@ withGCPEnv(secret: 'secret/team/ci/service-account/gcp-provisioner') {
 
 * credentialsId: The credentials to login to GCP. (Optional).
 * secret: Name of the secret on the the vault root path. (Optional).
+* role_id: vault role ID if using the secret argument (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID if using the secret argument (Optional). Default 'vault-secret-id'
 
 ## withGitRelease
 Configure the git release context to run the body closure.

--- a/vars/withGCPEnv.groovy
+++ b/vars/withGCPEnv.groovy
@@ -41,7 +41,7 @@ def call(Map args = [:], Closure body) {
     }
 
     if (secret) {
-      def props = getVaultSecret(secret: secret)
+      def props = getVaultSecret(args)
       if (props?.errors) {
         error "withGCPEnv: Unable to get credentials from the vault: ${props.errors.toString()}"
       }

--- a/vars/withGCPEnv.txt
+++ b/vars/withGCPEnv.txt
@@ -12,3 +12,5 @@ withGCPEnv(secret: 'secret/team/ci/service-account/gcp-provisioner') {
 
 * credentialsId: The credentials to login to GCP. (Optional).
 * secret: Name of the secret on the the vault root path. (Optional).
+* role_id: vault role ID if using the secret argument (Optional). Default 'vault-role-id'
+* secret_id: vault secret ID if using the secret argument (Optional). Default 'vault-secret-id'


### PR DESCRIPTION
## What does this PR do?

Enable vault customisation for the withGCPEnv

## Why is it important?

Similar to https://github.com/elastic/apm-pipeline-library/pull/1435