### PR TITLE
withGCPEnv: support for value default field in the vault secret

### DIFF
--- a/src/test/groovy/WithGCPEnvStepTests.groovy
+++ b/src/test/groovy/WithGCPEnvStepTests.groovy
@@ -156,4 +156,49 @@ class WithGCPEnvStepTests extends ApmBasePipelineTest {
     assertTrue(ret.contains("linux-x86.tar.gz"))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_readCredentialsContent_with_empty_values() throws Exception {
+    def ret
+    try {
+      ret = script.readCredentialsContent([credentials: '', value: ''])
+    } catch(err) {
+      // NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'Unable to read the credentials'))
+  }
+
+  @Test
+  void test_readCredentialsContent_without_values() throws Exception {
+    def ret
+    try {
+      ret = script.readCredentialsContent([:])
+    } catch(err) {
+      // NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'Unable to read the credentials'))
+  }
+
+  @Test
+  void test_readCredentialsContent_with_credentials() throws Exception {
+    def ret = script.readCredentialsContent([credentials: 'foo'])
+    printCallStack()
+    assertTrue(ret.contains('foo'))
+  }
+
+  @Test
+  void test_readCredentialsContent_with_fallback() throws Exception {
+    def ret = script.readCredentialsContent([credentials: '', value: 'bar1'])
+    printCallStack()
+    assertTrue(ret.contains('bar1'))
+  }
+
+  @Test
+  void test_readCredentialsContent_with_fallback_while_missing_credentials() throws Exception {
+    def ret = script.readCredentialsContent([value: 'bar'])
+    printCallStack()
+    assertTrue(ret.contains('bar'))
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -3183,7 +3183,7 @@ withGCPEnv(secret: 'secret/team/ci/service-account/gcp-provisioner') {
 ```
 
 * credentialsId: The credentials to login to GCP. (Optional).
-* secret: Name of the secret on the the vault root path. (Optional).
+* secret: Name of the secret on the the vault root path (supported fields: credentials and value). (Optional).
 * role_id: vault role ID if using the secret argument (Optional). Default 'vault-role-id'
 * secret_id: vault secret ID if using the secret argument (Optional). Default 'vault-secret-id'
 

--- a/vars/withGCPEnv.groovy
+++ b/vars/withGCPEnv.groovy
@@ -46,10 +46,7 @@ def call(Map args = [:], Closure body) {
         error "withGCPEnv: Unable to get credentials from the vault: ${props.errors.toString()}"
       }
       def value = props?.data
-      def credentialsContent = value?.credentials
-      if (!credentialsContent?.trim()) {
-        error "withGCPEnv: Unable to read the credentials value"
-      }
+      def credentialsContent = readCredentialsContent(value)
       writeFile(file: secretFileLocation, text: credentialsContent)
       gcloudAuth(secretFileLocation)
     } else {
@@ -79,6 +76,23 @@ def call(Map args = [:], Closure body) {
       }
     }
   }
+}
+
+/**
+* Read the vault secret and look for the required fields.
+* * credentials field is the one initially supported and kept for backward compatibility reasons.
+* * value field is the fallback field, this is the case used
+*/
+def readCredentialsContent(Map vaultSecretContent) {
+  def credentialsContent = vaultSecretContent?.credentials
+  if (credentialsContent?.trim()) {
+    return credentialsContent
+  }
+  credentialsContent = vaultSecretContent?.value
+  if (credentialsContent?.trim()) {
+    return credentialsContent
+  }
+  error "withGCPEnv: Unable to read the credentials and value fields"
 }
 
 def gcloudAuth(keyFile) {

--- a/vars/withGCPEnv.groovy
+++ b/vars/withGCPEnv.groovy
@@ -86,10 +86,12 @@ def call(Map args = [:], Closure body) {
 def readCredentialsContent(Map vaultSecretContent) {
   def credentialsContent = vaultSecretContent?.credentials
   if (credentialsContent?.trim()) {
+    log(level: 'INFO', text: "readCredentialsContent: reading the 'credentials' field.")
     return credentialsContent
   }
   credentialsContent = vaultSecretContent?.value
   if (credentialsContent?.trim()) {
+    log(level: 'INFO', text: "readCredentialsContent: reading the 'value' field.")
     return credentialsContent
   }
   error "withGCPEnv: Unable to read the credentials and value fields"

--- a/vars/withGCPEnv.txt
+++ b/vars/withGCPEnv.txt
@@ -11,6 +11,6 @@ withGCPEnv(secret: 'secret/team/ci/service-account/gcp-provisioner') {
 ```
 
 * credentialsId: The credentials to login to GCP. (Optional).
-* secret: Name of the secret on the the vault root path. (Optional).
+* secret: Name of the secret on the the vault root path (supported fields: credentials and value). (Optional).
 * role_id: vault role ID if using the secret argument (Optional). Default 'vault-role-id'
 * secret_id: vault secret ID if using the secret argument (Optional). Default 'vault-secret-id'


### PR DESCRIPTION
## What does this PR do?

Support the `value` field in addition to the existing support for the `credentials` one.

## Why is it important?

Some secrets are managed with terraform and therefore the field is not matching the default one.

Let's keep backward compatibility with the existing credentials one.

For context, `credentials` was aimed to be the mandatory field in order to early detect wrong vault secrets, since `value` is the default field then a secret could be used wrongly and the failure will not be detected earlier but when running the `gcloudAuth` method.

