### PR TITLE
withAWSEnv: add support for ARM

### DIFF
--- a/src/test/groovy/WithAWSEnvStepTests.groovy
+++ b/src/test/groovy/WithAWSEnvStepTests.groovy
@@ -133,6 +133,14 @@ class WithAWSEnvStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_awsURL_in_arm() throws Exception {
+    helper.registerAllowedMethod('isArm', [], { false })
+    def ret = script.awsURL('2.2.2')
+    printCallStack()
+    assertTrue(ret.contains("linux-aarch64-2.2.2.zip"))
+  }
+
+  @Test
   void test_awsURL_in_windows() throws Exception {
     helper.registerAllowedMethod('isUnix', [], { false })
     try {

--- a/src/test/groovy/WithAWSEnvStepTests.groovy
+++ b/src/test/groovy/WithAWSEnvStepTests.groovy
@@ -134,7 +134,7 @@ class WithAWSEnvStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_awsURL_in_arm() throws Exception {
-    helper.registerAllowedMethod('isArm', [], { false })
+    helper.registerAllowedMethod('isArm', [], { true })
     def ret = script.awsURL('2.2.2')
     printCallStack()
     assertTrue(ret.contains("linux-aarch64-2.2.2.zip"))

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -90,6 +90,9 @@ def downloadAndInstall(where, version) {
 def awsURL(version) {
   def url = 'https://awscli.amazonaws.com/awscli-exe'
   def arch = is64() ? 'x86_64' : 'x86'
+  if (isArm()) {
+    arch = 'aarch64'
+  }
   if (isUnix()) {
     return "${url}-linux-${arch}-${version}.zip"
   }


### PR DESCRIPTION

## What does this PR do?

Add support for ARM 
See https://aws.amazon.com/blogs/developer/aws-cli-v2-now-available-for-linux-arm/

## Why is it important?

Required to use ARM

## Related issues
Caused by https://github.com/elastic/apm-aws-lambda/pull/101
