### PR TITLE
automation: enable 7.<minor-1> alias for the beats, fleet-server and apm-server projects

### DIFF
--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -21,6 +21,7 @@ projects:
       - master
       - 8.<minor>
       - 7.<minor>
+      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
@@ -30,6 +31,7 @@ projects:
       - master
       - 8.<minor>
       - 7.<minor>
+      - 7.<minor-1>
       - "6.8"
     enabled: true
     reusePullRequest: false
@@ -51,6 +53,7 @@ projects:
       - master
       - 8.<minor>
       - 7.<minor>
+      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip

--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -11,8 +11,9 @@
 ##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
 ##
 ##  NOTE:
-##  <minor> is a special token that refers to the latest minor branch. The automation
-##          will resolve the correct version at runtime, so you don't need to change it.
+##  <minor> is a special token that refers to the latest minor branch.
+##  <minor-1> is a special token that refers to the previous latest minor branch.
+##  The automation will resolve the correct version at runtime, so you don't need to change it.
 ##
 projects:
   - repo: apm-server


### PR DESCRIPTION
## What does this PR do?

Enable `7.minor-1` for the ElasticStack bump automation in the remaining projects.

## Why is it important?

Support the active branches

## Related issues

Uses https://github.com/elastic/apm-pipeline-library/pull/1503
