### PR TITLE
fix: skip branch parsing when format is not major.minor.patch based

### DIFF
--- a/src/test/groovy/GetBranchNameFromArtifactsAPIStepTests.groovy
+++ b/src/test/groovy/GetBranchNameFromArtifactsAPIStepTests.groovy
@@ -27,12 +27,13 @@ class GetBranchNameFromArtifactsAPIStepTests extends ApmBasePipelineTest {
     script = loadScript('vars/getBranchNameFromArtifactsAPI.groovy')
     helper.registerAllowedMethod('artifactsApi', [Map.class], { f ->
       return [
-        "7.14": ["version": "7.16.3-SNAPSHOT"],
-        "7.15": ["version": "7.16.3-SNAPSHOT"],
+        "7.14": ["version": "7.14.3-SNAPSHOT"],
+        "7.15": ["version": "7.15.3-SNAPSHOT"],
         "7.16": ["version": "7.16.3-SNAPSHOT"],
-        "7.17": ["version": "7.16.3-SNAPSHOT"],
-        "7.18": ["version": "7.16.3-SNAPSHOT"],
-        "8.0": ["version": "7.16.3-SNAPSHOT"]
+        "7.17": ["version": "7.17.3-SNAPSHOT"],
+        "7.18": ["version": "7.18.3-SNAPSHOT"],
+        "8.0": ["version": "8.0.0-SNAPSHOT"],
+        "main": ["version": "8.1.0-SNAPSHOT"]
       ]
     })
   }
@@ -98,5 +99,13 @@ class GetBranchNameFromArtifactsAPIStepTests extends ApmBasePipelineTest {
 
     printCallStack()
     assert ret.equals('7.14')
+  }
+
+  @Test
+  void test_main() throws Exception {
+    def ret = script.call(branch: "main")
+
+    printCallStack()
+    assert ret.equals("main")
   }
 }

--- a/vars/getBranchNameFromArtifactsAPI.groovy
+++ b/vars/getBranchNameFromArtifactsAPI.groovy
@@ -41,14 +41,14 @@ def call(Map args = [:]) {
   def parts = branch.split('\\.')
   def major = parts[0]
   def minor
-  if (parts.size() > 0) {
+  if (parts.size() > 1) {
     minor = parts[1]
     minor = minor.replaceAll("<", "")
     minor = minor.replaceAll(">", "")
   }
 
     // special macro to look for the latest minor version
-  if (minor.contains('-')) {
+  if (minor?.contains('-')) {
     def minorParts = minor.split('-')
     minor = minorParts[0]
 


### PR DESCRIPTION
## What does this PR do?

Fix a bug when parsing the `main`/`master` branch

## Why is it important?

Otherwise the automation for the bump wont' work in the default branches


Fixes

![image](https://user-images.githubusercontent.com/2871786/150782047-5df09e06-7e47-41a8-a55f-73c960b72232.png)
