### PR TITLE
report: enable a new index for reporting tests in the integrations

### DIFF
--- a/resources/custom-build-report-mapping.json
+++ b/resources/custom-build-report-mapping.json
@@ -1,0 +1,497 @@
+{
+  "mappings" : {
+    "properties" : {
+      "errorMetrics" : {
+        "properties" : {
+          "closedChannelException" : {
+            "type" : "long"
+          },
+          "interruptedException" : {
+            "type" : "long"
+          },
+          "missingContextVariableException" : {
+            "type" : "long"
+          },
+          "notSerializableException" : {
+            "type" : "long"
+          },
+          "reusedWorkers" : {
+            "type" : "long"
+          }
+        }
+      },
+      "artifacts" : {
+        "properties" : {
+          "name" : {
+            "type" : "keyword"
+          },
+          "path" : {
+            "type" : "keyword"
+          },
+          "size" : {
+            "type" : "long"
+          }
+        }
+      },
+      "build" : {
+        "properties" : {
+          "artifactsZipFile" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "causeOfBlockage" : {
+            "type" : "keyword"
+          },
+          "causes" : {
+            "properties" : {
+              "shortDescription" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              },
+              "upstreamBuild" : {
+                "type" : "long"
+              },
+              "upstreamProject" : {
+                "type" : "keyword"
+              },
+              "upstreamUrl" : {
+                "type" : "keyword"
+              },
+              "userId" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              },
+              "userName" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              }
+            }
+          },
+          "commitId" : {
+            "type" : "keyword"
+          },
+          "commitUrl" : {
+            "type" : "keyword"
+          },
+          "description" : {
+            "type" : "keyword"
+          },
+          "durationInMillis" : {
+            "type" : "long"
+          },
+          "enQueueTime" : {
+            "type" : "date"
+          },
+          "endTime" : {
+            "type" : "date"
+          },
+          "estimatedDurationInMillis" : {
+            "type" : "long"
+          },
+          "id" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "name" : {
+            "type" : "keyword"
+          },
+          "organization" : {
+            "type" : "keyword"
+          },
+          "pipeline" : {
+            "type" : "keyword"
+          },
+          "result" : {
+            "type" : "keyword"
+          },
+          "runSummary" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "startTime" : {
+            "type" : "date"
+          },
+          "state" : {
+            "type" : "keyword"
+          },
+          "type" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "changeSet" : {
+        "properties" : {
+          "affectedPaths" : {
+            "type" : "keyword"
+          },
+          "author" : {
+            "properties" : {
+              "fullName" : {
+                "type" : "keyword"
+              },
+              "id" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "checkoutCount" : {
+            "type" : "long"
+          },
+          "commitId" : {
+            "type" : "keyword"
+          },
+          "issues" : {
+            "properties" : {
+              "_class" : {
+                "type" : "keyword"
+              },
+              "id" : {
+                "type" : "keyword"
+              },
+              "url" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "msg" : {
+            "type" : "keyword"
+          },
+          "timestamp" : {
+            "type" : "date"
+          }
+        }
+      },
+      "env" : {
+        "properties" : {
+          "BRANCH_NAME" : {
+            "type" : "keyword"
+          },
+          "BUILD_DISPLAY_NAME" : {
+            "type" : "keyword"
+          },
+          "BUILD_ID" : {
+            "type" : "keyword"
+          },
+          "BUILD_NUMBER" : {
+            "type" : "keyword"
+          },
+          "BUILD_TAG" : {
+            "type" : "keyword"
+          },
+          "BUILD_URL" : {
+            "type" : "keyword"
+          },
+          "CHANGE_AUTHOR" : {
+            "type" : "keyword"
+          },
+          "CHANGE_BRANCH" : {
+            "type" : "keyword"
+          },
+          "CHANGE_FORK" : {
+            "type" : "keyword"
+          },
+          "CHANGE_ID" : {
+            "type" : "keyword"
+          },
+          "CHANGE_TARGET" : {
+            "type" : "keyword"
+          },
+          "CHANGE_URL" : {
+            "type" : "keyword"
+          },
+          "GIT_BASE_COMMIT" : {
+            "type" : "keyword"
+          },
+          "GIT_COMMIT" : {
+            "type" : "keyword"
+          },
+          "GIT_PREVIOUS_COMMIT" : {
+            "type" : "keyword"
+          },
+          "GIT_PREVIOUS_SUCCESSFUL_COMMIT" : {
+            "type" : "keyword"
+          },
+          "JOB_BASE_NAME" : {
+            "type" : "keyword"
+          },
+          "JOB_DISPLAY_URL" : {
+            "type" : "keyword"
+          },
+          "JOB_NAME" : {
+            "type" : "keyword"
+          },
+          "JOB_URL" : {
+            "type" : "keyword"
+          },
+          "ORG_NAME" : {
+            "type" : "keyword"
+          },
+          "OTEL_ELASTIC_URL" : {
+            "type" : "keyword"
+          },
+          "REPO_NAME" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "job" : {
+        "properties" : {
+          "branch" : {
+            "properties" : {
+              "isPrimary" : {
+                "type" : "boolean"
+              },
+              "url" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              }
+            }
+          },
+          "disabled" : {
+            "type" : "boolean"
+          },
+          "displayName" : {
+            "type" : "keyword"
+          },
+          "estimatedDurationInMillis" : {
+            "type" : "long"
+          },
+          "fullDisplayName" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "fullName" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "name" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "organization" : {
+            "type" : "keyword"
+          },
+          "pullRequest" : {
+            "properties" : {
+              "author" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              },
+              "id" : {
+                "type" : "keyword"
+              },
+              "title" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              },
+              "url" : {
+                "type" : "keyword",
+                "fields" : {
+                  "analyzed" : {
+                    "type" : "text"
+                  }
+                }
+              }
+            }
+          },
+          "weatherScore" : {
+            "type" : "long"
+          }
+        }
+      },
+      "test_coverage" : {
+        "properties" : {
+          "Classes" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "Conditionals" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "Files" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "Lines" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "Methods" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "Packages" : {
+            "properties" : {
+              "denominator" : {
+                "type" : "float"
+              },
+              "numerator" : {
+                "type" : "float"
+              },
+              "ratio" : {
+                "type" : "float"
+              }
+            }
+          }
+        }
+      },
+      "test_summary" : {
+        "properties" : {
+          "existingFailed" : {
+            "type" : "long"
+          },
+          "failed" : {
+            "type" : "long"
+          },
+          "fixed" : {
+            "type" : "long"
+          },
+          "passed" : {
+            "type" : "long"
+          },
+          "regressions" : {
+            "type" : "long"
+          },
+          "skipped" : {
+            "type" : "long"
+          },
+          "total" : {
+            "type" : "long"
+          }
+        }
+      },
+      "test": {
+        "type": "nested",
+        "properties" : {
+          "age" : {
+            "type" : "long"
+          },
+          "duration" : {
+            "type" : "long"
+          },
+          "id" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "errorDetails" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "name" : {
+            "type" : "keyword",
+            "fields" : {
+              "analyzed" : {
+                "type" : "text"
+              }
+            }
+          },
+          "status" : {
+            "type" : "keyword"
+          }
+        }
+      }
+    }
+  }
+}

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -40,6 +40,7 @@ PIPELINE_LOG="pipeline-log.txt"
 STEPS_ERRORS="steps-errors.json"
 STEPS_INFO="steps-info.json"
 TESTS_ERRORS="tests-errors.json"
+TESTS_INFO="tests-info.json"
 TESTS_SUMMARY="tests-summary.json"
 TESTS_COVERAGE="tests-coverage.json"
 CUSTOM_BUILD_REPORT="custom-build-report.json"
@@ -505,6 +506,7 @@ echo '}' >> "${BUILD_REPORT}"
 ### See https://github.com/elastic/apm-pipeline-library/pull/1514 as a potential
 ### replacement
 if [ -n "${REPO_NAME}" ] && [ "${REPO_NAME}" == "integrations" ] ; then
+  echo 'INFO: prepare data with the test results'
   {
     echo "{"
     echo "\"build\": $(cat "${BUILD_INFO}"),"

--- a/resources/scripts/generate-build-data.sh
+++ b/resources/scripts/generate-build-data.sh
@@ -42,6 +42,7 @@ STEPS_INFO="steps-info.json"
 TESTS_ERRORS="tests-errors.json"
 TESTS_SUMMARY="tests-summary.json"
 TESTS_COVERAGE="tests-coverage.json"
+CUSTOM_BUILD_REPORT="custom-build-report.json"
 UTILS_LIB='/usr/local/bin/bash_standard_lib.sh'
 
 DEFAULT_HASH="{ }"
@@ -148,6 +149,7 @@ function fetchAndPrepareTestsInfo() {
     url=$2
     key=$3
     default=$4
+    report_file=$5
 
     echo "INFO: fetchAndPrepareTestsInfo (see ${file})"
     fetchAndDefault "${file}" "${url}" "${default}"
@@ -161,7 +163,7 @@ function fetchAndPrepareTestsInfo() {
         normaliseTestsWithoutStacktrace "${file}"
     fi
 
-    echo "\"${key}\": $(cat "${file}")," >> "${BUILD_REPORT}"
+    echo "\"${key}\": $(cat "${file}")," >> "${report_file}"
 }
 
 function fetchAndPrepareTestCoverageReport() {
@@ -491,7 +493,6 @@ fetchAndPrepareBuildReport "${JOB_INFO}" "${BO_JOB_URL}/" "job" "${DEFAULT_HASH}
 fetchAndPrepareBuildReport "${CHANGESET_INFO}" "${BO_BUILD_URL}/changeSet/" "changeSet" "${DEFAULT_LIST}"
 fetchAndPrepareArtifactsInfo "${ARTIFACTS_INFO}" "${BO_BUILD_URL}/artifacts/" "artifacts" "${DEFAULT_LIST}"
 echo "\"test\": $(cat "${TESTS_ERRORS}")," >> "${BUILD_REPORT}"
-### fetchAndPrepareTestSummaryReport should run after fetchAndPrepareTestsInfo
 fetchAndPrepareTestSummaryReport "${TESTS_SUMMARY}" "${BO_BUILD_URL}/blueTestSummary/" "test_summary" "${DEFAULT_LIST}" "${TESTS_ERRORS}"
 fetchAndPrepareTestCoverageReport "${TESTS_COVERAGE}" "${BUILD_URL}" "test_coverage" "${DEFAULT_HASH}"
 fetchAndPrepareBuildInfo "${BUILD_INFO}" "${BO_BUILD_URL}/" "build" "${DEFAULT_HASH}"
@@ -499,6 +500,24 @@ prepareErrorMetrics "errorMetrics"
 ### prepareEnvInfo should run the last one since it's the last field to be added
 prepareEnvInfo "${ENV_INFO}" "env"
 echo '}' >> "${BUILD_REPORT}"
+
+### Support temporarily the email notifications with the test summary
+### See https://github.com/elastic/apm-pipeline-library/pull/1514 as a potential
+### replacement
+if [ -n "${REPO_NAME}" ] && [ "${REPO_NAME}" == "integrations" ] ; then
+  {
+    echo "{"
+    echo "\"build\": $(cat "${BUILD_INFO}"),"
+    echo "\"job\": $(cat "${JOB_INFO}"),"
+    echo "\"test_summary\": $(cat "${TESTS_SUMMARY}"),"
+    echo "\"test_coverage\": $(cat "${TESTS_COVERAGE}"),"
+  } > "${CUSTOM_BUILD_REPORT}"
+  fetchAndPrepareTestsInfo "${TESTS_INFO}" "${BO_BUILD_URL}/tests/?limit=10000000" "test" "${DEFAULT_LIST}" "${CUSTOM_BUILD_REPORT}"
+  {
+    echo "\"env\": $(cat "${ENV_INFO}")"
+    echo '}'
+  } >> "${CUSTOM_BUILD_REPORT}"
+fi
 
 ## Create specific files to store the failed tests in individual
 ## docs and overal build data. Excluded passed and skipped tests

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -119,6 +119,13 @@ def call(Map args = [:]) {
           if (fileExists(datafile)) {
             sendDataToElasticsearch(es: es, secret: secret, restCall: '/ci-builds/_doc/', data: readFile(file: datafile))
           }
+
+          // NOTE: Support temporarily the email notifications with the test summary
+          //       See https://github.com/elastic/apm-pipeline-library/pull/1514 as a potential replacement
+          if (env.REPO_NAME == 'integrations') {
+            datafile = readFile(file: 'custom-build-report.json')
+            sendDataToElasticsearch(es: es, secret: secret, data: datafile, restCall: '/ci-integrations-builds/_doc/')
+          }
         }
       }
       // Ensure we don't leave any leftovers if running in the jenkins controller.


### PR DESCRIPTION
## What does this PR do?

Enable a new index for the https://github.com/elastic/integrations project as it relies in the test data structure to report when tests are not executed or skipped

## Why is it important?

Enable the contract we had with the `jenkins-build` index while we will spend time in a long term proposal to migrate the existing implementation to something else.

## Related issues

Enable partially https://github.com/elastic/apm-pipeline-library/pull/1417 for the https://github.com/elastic/integrations

## Actions

- [x] Create the Kibana index with the right mapping
- [x] Create a branch in the upstream
- [x] Create alias `ci-integrations-builds`
- [x] Create PR in the integrations to use this change
- [x] Verify whether any documents are sent correctly.
- [x] Then we can merge and confirm no documents are digested for the apm-pipeline-library repo

![image](https://user-images.githubusercontent.com/2871786/151199672-81f2aba4-4452-476f-a98c-b8e289daa7c9.png)

![image](https://user-images.githubusercontent.com/2871786/151199937-7aed469c-e39b-4eac-87a2-8cf798d64c0a.png)



```
PUT /ci-integrations-builds-000001

PUT /ci-integrations-builds-000001/_mapping
{
}
  

POST /_aliases
{
  "actions": [
    {
      "add": {
        "index": "ci-integrations-builds-000001",
        "alias": "ci-integrations-builds",
        "is_write_index": true
      }
    }
  ]
}

```