### PR TITLE
github commands: enable windows support for the java-agent

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -487,6 +487,7 @@ def getSupportedGithubCommands() {
     comments['run jdk compatibility tests'] = 'Run the JDK Compatibility tests.'
     comments['run integration tests'] = 'Run the Agent Integration tests.'
     comments['run end-to-end tests'] = 'Run the APM-ITs.'
+    comments['run windows tests'] = 'Build & tests on windows.'
   }
 
   if (isProjectSupported('apm-pipeline-library')) {


### PR DESCRIPTION
## What does this PR do?

Enable new GitHub command support for the APM Agent Java.

## Why is it important?

Caused by https://github.com/elastic/apm-agent-java/pull/1705