### PR TITLE
notification: fix JSONNull field

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -37,7 +37,7 @@
 <% if(build?.durationInMillis >= 0) {%>
 * Duration: ${Math.round(build.durationInMillis/1000/60)} min ${Math.round(build.durationInMillis/1000)%60} sec
 <%}%>
-<% if(build?.commitId != null && !build?.commitId.equals('null') && build?.commitId.toString().trim()) {%>
+<% if(!build?.commitId instanceof net.sf.json.JSONNull && build?.commitId != null && !build?.commitId.equals('null') && build?.commitId.toString().trim()) {%>
 * Commit: ${build?.commitId.split('\\+')[0]}
 <%}%>
 

--- a/resources/groovy-html-custom.template
+++ b/resources/groovy-html-custom.template
@@ -122,7 +122,7 @@
       <tr>
         <td colspan="5" style="vertical-align: middle; font-family: Helvetica; font-size: 24px; color: #343B49; letter-spacing: 1px; line-height: 30px;overflow: hidden;word-break: break-word;">
           ${jenkinsText}</br>
-          ${build?.description != null && build?.description != 'null' ? build?.description : ''}
+          ${!build?.description instanceof net.sf.json.JSONNull && build?.description != null && build?.description != 'null' ? build?.description : ''}
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## What does this PR do?

Fix JSONNull validation that started to fail after the recent upgrade

![image](https://user-images.githubusercontent.com/2871786/151883842-cdbd8089-ae97-41c6-bfda-2f37fedda28e.png)


## Why is it important?

Otherwise the notifications won't be processed correctly

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1516