### PR TITLE
fix: use different tests for the demos

### DIFF
--- a/resources/scripts/pytest_otel/Makefile
+++ b/resources/scripts/pytest_otel/Makefile
@@ -136,14 +136,15 @@ publish: package
 
 ## @help:demo-start-DEMO_NAME:Starts the demo from the demo folder, DEMO_NAME is the name of the demo type folder in the docs/demos folder (jaeger, elastic).
 .PHONY: demo-start-%
-demo-start-%:
+demo-start-%: virtualenv install
 	$(MAKE) demo-stop-$*
 	mkdir -p $(DEMO_DIR)/$*/build
 	touch $(DEMO_DIR)/$*/build/tests.json
 	docker-compose -f $(DEMO_DIR)/$*/docker-compose.yml up -d
 	. $(DEMO_DIR)/$*/demo.env;\
 	env | grep OTEL;\
-	$(MAKE) test
+	source $(VENV)/bin/activate;\
+	pytest --capture=no docs/demos/test/test_demo.py || echo "Demo execution finished you can access to http://localhost:5601 to check the traces";
 
 ## @help:demo-stop-DEMO_NAME:Stops the demo from the demo folder, DEMO_NAME is the name of the demo type folder in the docs/demos folder (jaeger, elastic).
 .PHONY: demo-stop-%

--- a/resources/scripts/pytest_otel/docs/demos/test/test_demo.py
+++ b/resources/scripts/pytest_otel/docs/demos/test/test_demo.py
@@ -1,0 +1,35 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+pytest_plugins = ["pytester"]
+
+import time
+import logging
+import pytest
+
+
+def test_basic():
+    time.sleep(5)
+    pass
+
+def test_success():
+    assert True
+
+def test_failure():
+    assert 1 < 0
+
+def test_failure_code():
+    d = 1/0
+    pass
+
+@pytest.mark.skip
+def test_skip():
+    assert True
+
+@pytest.mark.xfail(reason="foo bug")
+def test_xfail():
+    assert False
+
+@pytest.mark.xfail(run=False)
+def test_xfail_no_run():
+    assert False


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* It uses a new set of tests for the demos.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

Before this change we use the pytest-otel tests for the demos, we can no longer use those tests because we use the In-Memory Otel exporter and a file to check the plugin behavior, this causes not all the traces to be reported to the demo. Using a simpler test suit for the demos fixes the issue.
