### PR TITLE
test: refactor options and properties to avoid modify the jobDSL job on builds

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
@@ -289,8 +289,18 @@ dockerImages.each{ item ->
       artifactNumToKeep(10)
       artifactDaysToKeep(-1)
     }
-    triggers {
-      cron('H H(3-4) * * 1-5')
+    properties {
+      disableResume()
+      durabilityHint{
+        hint('PERFORMANCE_OPTIMIZED')
+      }
+      pipelineTriggers {
+        triggers {
+          cron{
+              spec('H H(3-4) * * 1-5')
+            }
+        }
+      }
     }
     definition {
       cpsScm {


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Refactor properties and pipeline options

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

The jobDSL jobs only keep the history is you don't modify them, there are some sections in pipelines that trigger a modification on the job (options, trigger, ...) this PR try to move as much as possible to jobDSL definitions and wrap the rest in a stage to avoid modify the pipeline job when you trigger it.

<img width="653" alt="Screenshot 2022-02-07 at 18 33 53" src="https://user-images.githubusercontent.com/5400788/152841281-7573a542-bc7b-4986-ae34-04afadf276b3.png">

