### PR TITLE
feat: move stackVersions to use bumpUtils

### DIFF
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -23,8 +23,6 @@ else
 fi
 
 echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
-${SED} -E -e "s#(def releaseVersion) = \"[0-9]+\.[0-9]+\.[0-9]\"#\1 = \"${VERSION_RELEASE}\"#g" vars/stackVersions.groovy
-${SED} -E -e "s#(def devVersion) = \"[0-9]+\.[0-9]+\.[0-9]\"#\1 = \"${VERSION_DEV}\"#g" vars/stackVersions.groovy
 ${SED} -E -e "s#(docker.elastic.co/beats/.*beat:)[0-9]+\.[0-9]+\.[0-9]#\1${VERSION_RELEASE}#g" .ci/packer_cache.sh
 ${SED} -E -e "s#(docker.elastic.co/beats/.*beat:)[0-9]+\.[0-9]+\.[0-9]#\1${VERSION_RELEASE}#g" vars/filebeat.groovy
 ${SED} -E -e "s#(docker.elastic.co/beats/.*beat:)[0-9]+\.[0-9]+\.[0-9]#\1${VERSION_RELEASE}#g" vars/metricbeat.groovy

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -63,7 +63,7 @@ pipeline {
           // TODO: to support the 8.x branches
           releaseVersions[bumpUtils.current8Key()] = '8.0.0'
           releaseVersions[bumpUtils.nextMinor8Key()] = '8.2.0'
-          releaseVersions[bumpUtils.nextPatch8Key()] = '8.0.1'
+          releaseVersions[bumpUtils.nextPatch8Key()] = '8.1.0'
         }
       }
     }

--- a/src/test/groovy/StackVersionsStepTests.groovy
+++ b/src/test/groovy/StackVersionsStepTests.groovy
@@ -21,11 +21,18 @@ import static org.junit.Assert.assertTrue
 
 class StackVersionsStepTests extends ApmBasePipelineTest {
 
+  class BumpUtilsMock {
+    String getNextMinorReleaseFor8(){ "8.2.0" }
+    String getNextPatchReleaseFor8(){ "8.1.0" }
+    String getCurrentMinorReleaseFor7(){ "7.17.1" }
+  }
+
   @Override
   @Before
   void setUp() throws Exception {
     super.setUp()
     script = loadScript('vars/stackVersions.groovy')
+    binding.setProperty('bumpUtils', new BumpUtilsMock())
   }
 
   @Test

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -44,22 +44,15 @@ def version(value, args = [:]){
 }
 
 def edge(Map args = [:]){
-  // TODO: this should not use a hardcoded string but bmptUtils.getNextMinorReleaseFor8()
-  return version("8.1.0", args)
+  return version(bumpUtils.getNextMinorReleaseFor8(), args)
 }
 
-def dev(Map args = [:]){
-  // IMPORTANT: this variable is needed to automate the elastic stack bump
-  def devVersion = "7.17.1"
-  // TODO: this should not use a hardcoded string but bmptUtils.getNextMinorReleaseFor7()
-  return version(devVersion, args)
+def dev(Map args = [:]){)
+  return version(bumpUtils.getNextPatchReleaseFor8(), args)
 }
 
 def release(Map args = [:]){
-  // IMPORTANT: this variable is needed to automate the elastic stack bump
-  // TODO: this should not use a hardcoded string but bmptUtils.getCurrentMinorReleaseFor7()
-  def releaseVersion = "7.17.0"
-  return version(releaseVersion, args)
+  return version(bumpUtils.getCurrentMinorReleaseFor7(), args)
 }
 
 def isSnapshot(args){

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -47,7 +47,7 @@ def edge(Map args = [:]){
   return version(bumpUtils.getNextMinorReleaseFor8(), args)
 }
 
-def dev(Map args = [:]){)
+def dev(Map args = [:]){
   return version(bumpUtils.getNextPatchReleaseFor8(), args)
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* bump patch version to 8.1
* change stackVersions to use 

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

It reduces the manual updates we have to make
