### PR TITLE
Support internal controller with different permissions

### DIFF
--- a/vars/githubPrComment.groovy
+++ b/vars/githubPrComment.groovy
@@ -108,7 +108,12 @@ def editComment(id, details) {
 
 def getCommentFromFile(Map args = [:]) {
   def commentFile = args.commentFile
-  copyArtifacts(filter: commentFile, flatten: true, optional: true, projectName: env.JOB_NAME, selector: lastWithArtifacts())
+  try {
+    copyArtifacts(filter: commentFile, flatten: true, optional: true, projectName: env.JOB_NAME, selector: lastWithArtifacts())
+  } catch(e) {
+    // Some CI controllers don't grant access to copy artifacts between jobs.
+    return ''
+  }
   if (fileExists(commentFile)) {
     return readFile(commentFile)?.trim()
   } else {


### PR DESCRIPTION
## What does this PR do?

Add support for the internal controller

## Why is it important?

Copy Artifacts between jobs is not supported in some particular cases

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1449
