### PR TITLE
Support for JENKINS_OTEL_SERVICE_NAME with the OTEL_SERVICE_NAME

### DIFF
--- a/src/test/groovy/co/elastic/mock/OtelHelperMock.groovy
+++ b/src/test/groovy/co/elastic/mock/OtelHelperMock.groovy
@@ -38,4 +38,5 @@ class OtelHelperMock implements Serializable {
   public getOtelPlugin() { return 'otel-plugin' }
   public getAuthentication() { return 'otel-authentication' }
   public getEndpoint() { return 'otel-endpoint' }
+  public getServiceName() { return 'otel-service' }
 }

--- a/vars/otelHelper.groovy
+++ b/vars/otelHelper.groovy
@@ -52,3 +52,8 @@ def getEndpoint() {
   def value = getOtelPlugin().getEndpoint()
   return value
 }
+
+def getServiceName() {
+  def value = getOtelPlugin().getServiceName()
+  return value
+}

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import com.cloudbees.groovy.cps.NonCPS
+
 /**
   Configure the OpenTelemetry Jenkins context to run the body closure.
 

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -54,9 +54,11 @@ def runBodyWithCredentials(credentialsId, Closure body) {
   // Then, mask and provide the environment variables.
   withCredentials([string(credentialsId: credentialsId, variable: 'OTEL_TOKEN_ID')]) {
     def otel_headers = env.OTEL_EXPORTER_OTLP_HEADERS ? "${env.OTEL_EXPORTER_OTLP_HEADERS} " : ''
+    def serviceName = getServiceName()
     withEnvMask(vars: [
       [var: 'ELASTIC_APM_SECRET_TOKEN', password: env.OTEL_TOKEN_ID],
-      [var: 'OTEL_EXPORTER_OTLP_HEADERS', password: "${otel_headers}authorization=Bearer ${env.OTEL_TOKEN_ID}"]
+      [var: 'OTEL_EXPORTER_OTLP_HEADERS', password: "${otel_headers}authorization=Bearer ${env.OTEL_TOKEN_ID}"],
+      [var: 'OTEL_SERVICE_NAME', password: serviceName]
     ]) {
       runBodyWithEndpoint(){
         body()
@@ -82,4 +84,10 @@ def runBodyWithEndpoint(Closure body) {
       body()
     }
   }
+}
+
+@NonCPS
+def getServiceName() {
+  def value = getOtelPlugin().getServiceName()
+  return value
 }

--- a/vars/withOtelEnv.groovy
+++ b/vars/withOtelEnv.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import com.cloudbees.groovy.cps.NonCPS
-
 /**
   Configure the OpenTelemetry Jenkins context to run the body closure.
 
@@ -77,9 +75,9 @@ def runBodyWithEndpoint(Closure body) {
     otelEnvs = ["TRACEPARENT=00-${env.TRACE_ID}-${env.SPAN_ID}-01"]
   }
 
-  def serviceName = getServiceName()
+  def serviceName = otelHelper.getServiceName()
   if (serviceName?.trim()) {
-    otelEnvs << ["JENKINS_OTEL_SERVICE_NAME=${serviceName}"]
+    otelEnvs << "JENKINS_OTEL_SERVICE_NAME=${serviceName}"
   }
 
   withEnvMask(vars: [
@@ -90,10 +88,4 @@ def runBodyWithEndpoint(Closure body) {
       body()
     }
   }
-}
-
-@NonCPS
-def getServiceName() {
-  def value = getOtelPlugin().getServiceName()
-  return value
 }

--- a/vars/withOtelEnv.txt
+++ b/vars/withOtelEnv.txt
@@ -2,6 +2,7 @@ Configure the OpenTelemetry Jenkins context to run the body closure with the bel
 environment variables:
 
 * `OTEL_EXPORTER_OTLP_ENDPOINT`, opentelemetry 0.19 already provides this environment variable.
+* `OTEL_SERVICE_NAME`, opentelemetry 0.19 already provides this environment variable.
 * `OTEL_EXPORTER_OTLP_HEADERS`, opentelemetry 0.19 already provides this environment variable.
 * `ELASTIC_APM_SECRET_TOKEN`
 * `ELASTIC_APM_SERVER_URL`

--- a/vars/withOtelEnv.txt
+++ b/vars/withOtelEnv.txt
@@ -1,8 +1,8 @@
 Configure the OpenTelemetry Jenkins context to run the body closure with the below
 environment variables:
 
+* `JENKINS_OTEL_SERVICE_NAME`
 * `OTEL_EXPORTER_OTLP_ENDPOINT`, opentelemetry 0.19 already provides this environment variable.
-* `OTEL_SERVICE_NAME`, opentelemetry 0.19 already provides this environment variable.
 * `OTEL_EXPORTER_OTLP_HEADERS`, opentelemetry 0.19 already provides this environment variable.
 * `ELASTIC_APM_SECRET_TOKEN`
 * `ELASTIC_APM_SERVER_URL`


### PR DESCRIPTION
## What does this PR do?

Support JENKINS_OTEL_SERVICE_NAME rather than OTEL_SERVICE_NAME

## Why is it important?

Read the servicename provided by the Jenkins opentelemetry plugin then context propagation can use it if needed.

## Related issues
Closes #ISSUE
