### PR TITLE
getBranchesFromAliases step to avoid duplicated code

### DIFF
--- a/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
+++ b/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
+
+  class BumpUtilsMock {
+    String getCurrentMinorReleaseFor8(){ "8.0.0" }
+    String getMajorMinor(String value){ "8.0" }
+  }
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/getBranchesFromAliases.groovy')
+    binding.setProperty('bumpUtils', new BumpUtilsMock())
+  }
+
+  @Test
+  void test_missing_argument() throws Exception {
+    testMissingArgument('aliases') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_alias_without_macro() throws Exception {
+    def ret = script.call(aliases:[ 'foo' ])
+    printCallStack()
+    assert ret.equals(['foo'])
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_alias_with_macro() throws Exception {
+    def ret = script.call(aliases:[ 'foo', '8.<minor>' ])
+    printCallStack()
+    assert ret.equals(['foo', '8.0'])
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -658,6 +658,22 @@ The more common use case is when there are two minor versions in development at 
 
 * branch: the branch name or supported pattern. Mandatory
 
+## getBranchesFromAliases
+This step parses the given list of branch aliases and return
+the branch name.
+
+This is handy to support a dynamic branch generation without the need to
+update the name of the branch when a new minor release branch is created.
+
+```
+// Return the branch name for the main, 8.minor and 8.next-minor branches
+def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<minor-minor>'])
+
+```
+
+
+* aliases: the branch aliases (supported format major.<minor>, major.<next-patch>, major.<next-minor>). Mandatory
+
 ## getBuildInfoJsonFiles
 Grab build related info from the Blueocean REST API and store it on JSON files.
 Then put all togeder in a simple JSON file.

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ This step parses the given list of branch aliases and return
+ the branch name.
+
+ This is handy to support a dynamic branch generation without the need to
+ update the name of the branch when a new minor release branch is created.
+
+ getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<minor-minor>'])
+*/
+
+def call(Map args = [:]) {
+  def aliases = args.containsKey('aliases') ? args.aliases : error('getBranchesFromAliases: aliases parameter is required')
+
+  def branches = []
+  // Expand macros and filter duplicated matches.
+  aliases.each { alias ->
+    def branchName = getBranchNameFromAlias(alias)
+    if (!branches.contains(branchName)) {
+      branches << branchName
+    }
+  }
+
+  return branches
+}
+
+def getBranchNameFromAlias(alias) {
+  // special macro to look for the latest minor version
+  if (alias.contains('8.<minor>')) {
+   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+  }
+  if (alias.contains('8.<next-minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
+  }
+  // special macro to look for the latest minor version
+  if (alias.contains('8.<next-patch>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextPatchReleaseFor8())
+  }
+  if (alias.contains('7.<minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+  }
+  if (alias.contains('7.<next-minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
+  }
+  return alias
+}

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -22,7 +22,7 @@
  This is handy to support a dynamic branch generation without the need to
  update the name of the branch when a new minor release branch is created.
 
- getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<minor-minor>'])
+ getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-minor>'])
 */
 
 def call(Map args = [:]) {

--- a/vars/getBranchesFromAliases.txt
+++ b/vars/getBranchesFromAliases.txt
@@ -6,7 +6,7 @@ update the name of the branch when a new minor release branch is created.
 
 ```
 // Return the branch name for the main, 8.minor and 8.next-minor branches
-def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<minor-minor>'])
+def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-minor>'])
 
 ```
 

--- a/vars/getBranchesFromAliases.txt
+++ b/vars/getBranchesFromAliases.txt
@@ -1,0 +1,14 @@
+This step parses the given list of branch aliases and return
+the branch name.
+
+This is handy to support a dynamic branch generation without the need to
+update the name of the branch when a new minor release branch is created.
+
+```
+// Return the branch name for the main, 8.minor and 8.next-minor branches
+def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<minor-minor>'])
+
+```
+
+
+* aliases: the branch aliases (supported format major.<minor>, major.<next-patch>, major.<next-minor>). Mandatory


### PR DESCRIPTION
## What does this PR do?

getBranchesFromAliases step to replace the code in some pipelines:
- https://github.com/elastic/apm-server/blob/main/.ci/schedule-daily.groovy#L34-L63
- https://github.com/elastic/beats/blob/9d26aea48d4dcf14f146b8a328f5b463c5cfa12d/.ci/schedule-daily.groovy#L34-L67

## Why is it important?

DRY

