### PR TITLE
Support build step signature

### DIFF
--- a/src/test/groovy/BuildStepTests.groovy
+++ b/src/test/groovy/BuildStepTests.groovy
@@ -43,6 +43,15 @@ public class BuildStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_success_with_string_signature() throws Exception {
+    def result = script.call('foo')
+    printCallStack()
+    assertTrue(result != null)
+    assertTrue(assertMethodCallContainsPattern('log', "/job/foo/1/display/redirect"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void testNestedJob() throws Exception {
     def result = script.call(job: 'nested/foo')
     printCallStack()

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -28,7 +28,14 @@ import co.elastic.BuildException
   Further details: https://brokenco.de/2017/08/03/overriding-builtin-steps-pipeline.html
 
   build(job: 'foo', parameters: [string(name: "my param", value: some_value)])
+
+  build 'foo'
 */
+
+def call(String jobName){
+  return call(job: jobName)
+}
+
 def call(Map args = [:]){
   def job = args.job
   def parameters = args.parameters
@@ -59,6 +66,7 @@ def call(Map args = [:]){
   }
   return buildInfo
 }
+
 
 def getBuildId(buildInfo) {
   def buildNumber = ''

--- a/vars/build.txt
+++ b/vars/build.txt
@@ -2,6 +2,7 @@ Override the `build` step to highlight in BO the URL to the downstream job.
 
 ```
 build(job: 'foo', parameters: [string(name: "my param", value: some_value)])
+build 'foo'
 ```
 
 See https://jenkins.io/doc/pipeline/steps/pipeline-build-step/#build-build-a-job


### PR DESCRIPTION
## What does this PR do?

Fixes the build signature

## Why is it important?

Otherwise:

```
[Pipeline] End of Pipeline
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: build.call() is applicable for argument types: (java.lang.String) values: [java-job]
Possible solutions: call(), call(java.util.Map), wait(), any(), wait(long), main([Ljava.lang.String;)
```


when using

```

        stage('Java') {
            steps {
                build "java-job"
            }
        }

```
