### PR TITLE
Notify pipeline syntax/configuration errors

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -116,9 +116,8 @@ ${description}
 <%} else {%>
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
   <p>
-  This error is likely related to the pipeline itself. Either a wrong syntax or configuration could be the reason.
-  Please go to the traditional console output <a href=\"${env?.BUILD_URL}/console\">here</a>" and you will probably see the stacktrace.
+  This error is likely related to the pipeline itself. Please go to the traditional console output <a href=\"${env?.BUILD_URL}/console\">here</a>"
+  You will see the error (either a wrong syntax or configuration)
   </p>
-  </details>
 <%}%>
 <%}%>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -92,7 +92,8 @@ ${errorStackTrace}
 <% if (!buildStatus?.equals('ABORTED') && errorGithubPrCheckApproved) {%>
   <% stepsErrors = stepsErrors << errorGithubPrCheckApproved %>
 <%}%>
-<% if (stepsErrors?.size() != 0 && !statusSuccess) {%>
+<% if (!statusSuccess) {%>
+<% if (stepsErrors?.size() != 0) {%>
 ### Steps errors [![${stepsErrors?.size()}](https://img.shields.io/badge/${stepsErrors?.size()}%20-red)](${jobUrl}/pipeline)
   <details><summary>Expand to view the steps failures</summary>
   <p>
@@ -112,4 +113,12 @@ ${description}
   <%}%>
   </p>
   </details>
+<%} else {%>
+### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
+  <p>
+  This error is likely related to the pipeline itself. Either a wrong syntax or configuration could be the reason.
+  Please go to the traditional console output <a href=\"${env?.BUILD_URL}/console\">here</a>" and you will probably see the stacktrace.
+  </p>
+  </details>
+<%}%>
 <%}%>

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -255,6 +255,25 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_notify_pr_with_failure_and_no_failed_steps() throws Exception {
+    script.notifyPR(
+      build: readJSON(file: "build-info.json"),
+      buildStatus: "FAILURE",
+      changeSet: readJSON(file: "changeSet-info.json"),
+      statsUrl: "https://ecs.example.com/app/kibana",
+      stepsErrors: [],
+      testsErrors: [],
+      testsSummary: readJSON(file: "tests-summary.json"),
+      statusSuccess: false
+    )
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Pipeline error'))
+    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'go to the traditional console output'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_notify_pr_with_unstable() throws Exception {
     script.notifyPR(
       build: readJSON(file: "build-info.json"),


### PR DESCRIPTION
## What does this PR do?

This is a workaround to notify pipeline failures while there are no failed steps. With a new section in the build comment

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/2871786/154506737-a15c9cc7-cb8e-4951-90a2-3eebe2a69f25.png">


## Why is it important?

Help users to debug easily when there are pipeline syntax errors or even configuration files.


## Related issues
Relates to https://github.com/elastic/apm-pipeline-library/issues/1555

