### PR TITLE
feat: improve build Kibana Docker images

### DIFF
--- a/.ci/docker/kibana-yarn/Dockerfile
+++ b/.ci/docker/kibana-yarn/Dockerfile
@@ -1,64 +1,59 @@
-ARG NODE_VERSION=16.11.1
-FROM node:${NODE_VERSION} AS src
+ARG NODE_VERSION=16.13.2
+FROM node:${NODE_VERSION}-bullseye AS src
 
-ARG GID=1001
-ARG UID=1001
 # 19846019a2841428b8564d9ad5dfd56334e41277
 # main
 # FIXME for PR the checkout and the fetch are diferents git fetch origin refs/pull/124994/head -> git checkout origin/PR/124994
 ARG BRANCH=main
 
-RUN groupadd -f --gid ${GID} kibana \
-  && useradd --uid ${UID} --gid ${GID} --groups 0 --home-dir /usr/share/kibana --no-create-home kibana
-# Bazel is installed at global level so we need permissions on /usr/local
-RUN chown kibana:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share /usr/share
+RUN chown node:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share
 
-USER kibana
-WORKDIR /usr/share
-RUN git clone --depth 1 --branch main --single-branch --jobs 5 https://github.com/elastic/kibana.git \
-  && git config --global user.email "none@example.com" \
-  && git config --global user.name "None" \
-  && git config --global --add remote.origin.fetch '+refs/pull/*/head:refs/remotes/origin/PR/*' \
-  && git config --global --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+USER node
 
-WORKDIR /usr/share/kibana
-RUN git fetch --depth 1 --jobs 5 origin "${BRANCH}" \
-  && git checkout "${BRANCH}" -b "freeze_branch"
-
-ENV HOME=/usr/share/kibana
+ENV HOME=/home/node
 ENV NVM_DIR=${HOME}/.nvm
 ENV NODE_OPTIONS= --max-old-space-size=4096
 ENV FORCE_COLOR=1
 ENV BABEL_DISABLE_CACHE=false
 ENV BAZEL_CACHE_MODE=read
+ENV DISABLE_BOOTSTRAP_VALIDATION=true
+
+WORKDIR /home/node
+RUN git clone --depth 1 --branch main --single-branch --jobs 5 https://github.com/elastic/kibana.git \
+  && git config --global user.email "none@example.com" \
+  && git config --global user.name "None" && echo "5"
+
+WORKDIR /home/node/kibana
+RUN git --version && echo 1
+RUN git fetch --depth 1 --jobs 5 origin "${BRANCH}" \
+  && cat .git/FETCH_HEAD \
+  && git checkout "${BRANCH}" -b "freeze_branch" \
+  && cat .git/FETCH_HEAD \
+  && git log -1 FETCH_HEAD --pretty=%h \
+  && cat .git/FETCH_HEAD
+
+RUN git log -1 FETCH_HEAD --pretty=%h
+RUN git merge-base HEAD FETCH_HEAD
+
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 RUN . "${NVM_DIR}/nvm.sh" \
   && nvm install $(cat .node-version) \
   && nvm alias default $(cat .node-version)
+
 RUN . "${NVM_DIR}/nvm.sh" \
-  && npm install -g yarn-deduplicate \
-  && yarn-deduplicate yarn.lock \
-  && npm set progress=false
-RUN . "${NVM_DIR}/nvm.sh" \
-  && yarn config set cache-folder ${HOME}/.yarn_cache \
   && yarn kbn bootstrap --prefer-offline --no-audit --link-duplicates
 
 RUN . "${NVM_DIR}/nvm.sh" \
   && yarn kbn clean
 
+WORKDIR /home/node
+RUN rm -fr kibana
 
 
-FROM node:${NODE_VERSION}
+FROM node:${NODE_VERSION}-bullseye
 
-ARG GID=1001
-ARG UID=1001
-
-RUN groupadd -f --gid ${GID} kibana \
-  && useradd --uid ${UID} --gid ${GID} --groups 0 --home-dir /usr/share/kibana --no-create-home kibana \
-  && chown kibana:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share /usr/share
-
-USER kibana
-ENV HOME=/usr/share/kibana
+USER node
+ENV HOME=/home/node
 ENV NVM_DIR=${HOME}/.nvm
 ENV NODE_OPTIONS= --max-old-space-size=4096
 ENV FORCE_COLOR=1
@@ -66,11 +61,11 @@ ENV BABEL_DISABLE_CACHE=true
 
 COPY --from=src ${HOME} ${HOME}
 USER root
-RUN chown kibana:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share /usr/share /usr/share/kibana
-
-USER kibana
+RUN chown node:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share
+RUN echo ". \"${NVM_DIR}/nvm.sh\"" > ${HOME}/.bashrc
+USER node
 WORKDIR ${HOME}
 
 EXPOSE 5601
 ENTRYPOINT ["/bin/bash"]
-CMD [". \"${NVM_DIR}/nvm.sh\" && bash"]
+CMD ["-l", "-c", ". \"${NVM_DIR}/nvm.sh\" && bash"]

--- a/.ci/docker/kibana-yarn/Dockerfile
+++ b/.ci/docker/kibana-yarn/Dockerfile
@@ -63,9 +63,10 @@ COPY --from=src ${HOME} ${HOME}
 USER root
 RUN chown node:0 /usr/local /usr/local/bin /usr/local/lib /usr/local/share
 RUN echo ". \"${NVM_DIR}/nvm.sh\"" > ${HOME}/.bashrc
+
 USER node
 WORKDIR ${HOME}
 
 EXPOSE 5601
-ENTRYPOINT ["/bin/bash"]
-CMD ["-l", "-c", ". \"${NVM_DIR}/nvm.sh\" && bash"]
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash"]

--- a/.ci/docker/kibana-yarn/Dockerfile
+++ b/.ci/docker/kibana-yarn/Dockerfile
@@ -21,7 +21,7 @@ ENV DISABLE_BOOTSTRAP_VALIDATION=true
 WORKDIR /home/node
 RUN git clone --depth 1 --branch main --single-branch --jobs 5 https://github.com/elastic/kibana.git \
   && git config --global user.email "none@example.com" \
-  && git config --global user.name "None" && echo "5"
+  && git config --global user.name "None"
 
 WORKDIR /home/node/kibana
 RUN git --version && echo 1

--- a/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
+++ b/src/test/groovy/BuildKibanaDockerImageStepTests.groovy
@@ -18,6 +18,7 @@
 import org.junit.Before
 import org.junit.Test
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
 
 class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
 
@@ -34,8 +35,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         def result = script.call(baseDir: 'foo', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: main'))
         assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec main, into foo'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:main"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:main were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:main"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:main was pushed"))
         assertTrue(env.DEPLOY_NAME == 'main')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-main')
         assertJobStatusSuccess()
@@ -46,8 +49,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         def result = script.call(packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: main'))
         assertTrue(assertMethodCallContainsPattern('log', 'Cloning Kibana repository, refspec main, into base_dir/build'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:main"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:main were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:main"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:main was pushed"))
         assertTrue(env.DEPLOY_NAME == 'main')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-main')
         assertJobStatusSuccess()
@@ -57,8 +62,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_with_branch_refspec() throws Exception {
         def result = script.call(refspec: 'foo', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: foo'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:foo were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:foo"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:foo was pushed"))
         assertTrue(env.DEPLOY_NAME == 'foo')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-foo')
         assertJobStatusSuccess()
@@ -68,8 +75,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_with_PR_refspec_uppercase() throws Exception {
         def result = script.call(refspec: 'PR/111111', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/111111'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr111111 were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:pr111111"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:pr111111 was pushed"))
         assertTrue(env.DEPLOY_NAME == 'pr111111')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-pr111111')
         assertJobStatusSuccess()
@@ -79,8 +88,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_with_PR_refspec_lowercase() throws Exception {
         def result = script.call(refspec: 'pr/222222', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/222222'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr222222 were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:pr222222"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:pr222222 was pushed"))
         assertTrue(env.DEPLOY_NAME == 'pr222222')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-pr222222')
         assertJobStatusSuccess()
@@ -90,8 +101,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
     void test_with_PR_refspec_no_case() throws Exception {
         def result = script.call(refspec: 'pR/333333', packageJSON: 'buildKibana/package.json')
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/333333'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333"))
-        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} and docker.elastic.co/observability-ci/kibana:pr333333 were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT to docker.elastic.co/observability-ci/kibana:pr333333"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "docker.elastic.co/observability-ci/kibana:pr333333 was pushed"))
         assertTrue(env.DEPLOY_NAME == 'pr333333')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-pr333333')
         assertJobStatusSuccess()
@@ -102,8 +115,10 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         def registry = 'hub.docker.com'
         def result = script.call(refspec: 'pr/444444', packageJSON: 'buildKibana/package.json', dockerRegistry: registry)
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/444444'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444"))
-        assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:${SHA} and ${registry}/observability-ci/kibana:pr444444 were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:${SHA}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${registry}/kibana/kibana:8.0.0-SNAPSHOT to ${registry}/observability-ci/kibana:pr444444"))
+        assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:${SHA} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "${registry}/observability-ci/kibana:pr444444 was pushed"))
         assertTrue(env.DEPLOY_NAME == 'pr444444')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-pr444444')
         assertJobStatusSuccess()
@@ -117,10 +132,32 @@ class BuildKibanaDockerImageStepTests extends ApmBasePipelineTest {
         def target = 'the_target'
         def result = script.call(refspec: 'pr/555555', packageJSON: 'buildKibana/package.json', targetTag: targetTag, dockerRegistry: registry, dockerImageSource: src, dockerImageTarget: target)
         assertTrue(assertMethodCallContainsPattern('log', 'Kibana refspec is: PR/555555'))
-        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:${targetTag} and ${target}:pr55555"))
-        assertTrue(assertMethodCallContainsPattern('log', "${target}:${targetTag} and ${target}:pr555555 were pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:${targetTag}"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging ${src}:8.0.0-SNAPSHOT to ${target}:pr55555"))
+        assertTrue(assertMethodCallContainsPattern('log', "${target}:${targetTag} was pushed"))
+        assertTrue(assertMethodCallContainsPattern('log', "${target}:pr555555 was pushed"))
         assertTrue(env.DEPLOY_NAME == 'pr555555')
         assertTrue(env.KIBANA_DOCKER_TAG == '8.0.0-SNAPSHOT-pr555555')
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_skip_ubuntu() throws Exception {
+        def result = script.call(refspec: 'pr/555555', skipUbuntu: true,  packageJSON: 'buildKibana/package.json')
+        assertTrue(env.BUILD_DOCKER_UBUNTU == '')
+        assertTrue(env.BUILD_DOCKER_CLOUD == '1')
+        assertFalse(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT"))
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana-ci/kibana-cloud:8.0.0-SNAPSHOT"))
+        assertJobStatusSuccess()
+    }
+
+    @Test
+    void test_skip_cloud() throws Exception {
+        def result = script.call(refspec: 'pr/555555', skipCloud: true, packageJSON: 'buildKibana/package.json')
+        assertTrue(env.BUILD_DOCKER_UBUNTU == '1')
+        assertTrue(env.BUILD_DOCKER_CLOUD == '')
+        assertTrue(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT"))
+        assertFalse(assertMethodCallContainsPattern('log', "Tagging docker.elastic.co/kibana-ci/kibana-cloud:8.0.0-SNAPSHOT"))
         assertJobStatusSuccess()
     }
 }


### PR DESCRIPTION
feat: create a cache Docker image for build Kibana Docker images

## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* improve build Kibana Docker images
* create a cache Docker image for build Kibana Docker images

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

In recent changes in the Kibana build system, it is possible to build only Ubuntu or Cloud Docker images this speeds up the build by about 7-10 min. Using a Docker image prepared with all the Node modules in cache reduces the build time of the Kibana binaries by about 25 min.
