### PR TITLE
automation: add support for elastic-agent

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -34,6 +34,12 @@ projects:
       - main
     enabled: true
     labels: dependency,backport-skip
+  - repo: elastic-agent
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency,backport-skip
   - repo: fleet-server
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -47,6 +47,16 @@ projects:
     reusePullRequest: false
     labels: dependency,backport-skip
     reviewer: elastic/observablt-robots-on-call
+  - repo: elastic-agent
+    script: .ci/bump-stack-version.sh
+    branches:
+      - main
+      - 8.<minor>
+      - 7.<minor>
+      - 7.<minor-1>
+    enabled: true
+    reusePullRequest: false
+    labels: dependency,backport-skip
   - repo: fleet-server
     script: .ci/bump-stack-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Prepare the bump automation for the elastic-agent


## Actions

@narph , can you please review if `.ci/bump-stack-version.sh` and `.ci/bump-go-release-version.sh` are available in the repository? And whether they are gonna work as expected? Those scripts are the ones in charge to bump the golang version when a new one is available or bujmp the snapshot versions when needed, that's the way it works in Beats so far, 

Maybe for the `elastic-agent` is not needed...