### PR TITLE
ci: remove sleep for git/checkout

### DIFF
--- a/vars/checkout.groovy
+++ b/vars/checkout.groovy
@@ -26,9 +26,7 @@
 def call(args) {
   log(level: 'INFO', text: 'Override default checkout')
   def ret
-  // Sleep first is the best of the worst scenarios regarding the sleep times.
-  // Further details: https://github.com/elastic/apm-pipeline-library/pull/378
-  retryWithSleep(retries: 3, seconds: 10, backoff: true, sleepFirst: true) {
+  retryWithSleep(retries: 3, seconds: 10) {
     ret = steps.checkout(args)
   }
   return ret

--- a/vars/git.groovy
+++ b/vars/git.groovy
@@ -27,7 +27,7 @@ def call(args) {
   log(level: 'INFO', text: 'Override default git')
 
   def ret
-  retryWithSleep(retries: 3, seconds: 20) {
+  retryWithSleep(retries: 3, seconds: 10) {
     ret = steps.git(args)
   }
   return ret


### PR DESCRIPTION
## What does this PR do?

Move away from the default first sleep for the checkout and reduce the sleep in git if a retry to 10 seconds.

Let's keep the retry to play safe.

## Why is it important?

https://issuetracker.google.com/issues/146072599 has been closed so we can assume this issue is not a problem anymore.
