### PR TITLE
enable runE2E in fleet-ci

### DIFF
--- a/vars/runE2E.groovy
+++ b/vars/runE2E.groovy
@@ -22,8 +22,8 @@
 */
 def call(Map args = [:]) {
 
-  if (!env.JENKINS_URL?.contains('beats-ci')) {
-    error('runE2e: e2e pipeline is defined in https://beats-ci.elastic.co/')
+  if (!env.JENKINS_URL?.contains('beats-ci') || !env.JENKINS_URL?.contains('fleet-ci') ) {
+    error('runE2e: e2e pipeline is defined in either https://beats-ci.elastic.co/ or https://fleet-ci.elastic.co/')
   }
 
   // As long as elastic/beats and elastic/e2e-testing don't match each other with


### PR DESCRIPTION
## What does this PR do?

Support for `fleet-ci`

## Why is it important?

Otherwise we cannot use `fleet-ci` as expected to run the e2e-testing framework
