### PR TITLE
chore: pass elastic-agent version to runE2E

### DIFF
--- a/vars/runE2E.groovy
+++ b/vars/runE2E.groovy
@@ -66,6 +66,7 @@ def createParameters(Map args = [:]) {
   ]
 
   addStringParameterIfValue(args.get('beatVersion', ''), 'BEAT_VERSION', parameters)
+  addStringParameterIfValue(args.get('elasticAgentVersion', ''), 'ELASTIC_AGENT_VERSION', parameters)
   addStringParameterIfValue(args.get('gitHubCheckSha1', ''), 'GITHUB_CHECK_SHA1', parameters)
   addStringParameterIfValue(args.get('gitHubCheckRepo', ''), 'GITHUB_CHECK_REPO', parameters)
   addStringParameterIfValue(args.get('gitHubCheckName', ''), 'GITHUB_CHECK_NAME', parameters)


### PR DESCRIPTION
## What does this PR do?
It adds the elastic-agent version as an optional parameter.
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
We need both versions, as the e2e tests could be triggered by Beats (a change on filebeat) and by a change in the elastic-agent

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Relates https://github.com/elastic/e2e-testing/pull/2172
