### PR TITLE
fix: update maintenance branches

### DIFF
--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -21,8 +21,8 @@ projects:
     branches:
       - main
       - 8.<minor>
+      - 8.<minor-1>
       - 7.<minor>
-      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
@@ -31,8 +31,8 @@ projects:
     branches:
       - main
       - 8.<minor>
+      - 8.<minor-1>
       - 7.<minor>
-      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,build-monitoring,backport-skip,Team:Beats-On-Call
@@ -41,8 +41,8 @@ projects:
     branches:
       - main
       - 8.<minor>
+      - 8.<minor-1>
       - 7.<minor>
-      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
@@ -52,8 +52,8 @@ projects:
     branches:
       - main
       - 8.<minor>
+      - 8.<minor-1>
       - 7.<minor>
-      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
@@ -62,8 +62,8 @@ projects:
     branches:
       - main
       - 8.<minor>
+      - 8.<minor-1>
       - 7.<minor>
-      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip


### PR DESCRIPTION
## What does this PR do?
It removes the bumps to `7.minor-1` adding them for `8.minor-1`

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
7.17.1 appeared causing 7.16 to disappear 🤷 
<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
