### PR TITLE
refactor withGCPEnvContext: support env only and gsutil install

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -602,6 +602,10 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       def script = loadScript('vars/withGCPEnv.groovy')
       return script.call(m, c)
     })
+    helper.registerAllowedMethod('withGCPEnvContext', [Map.class, Closure.class], { m, c ->
+      def script = loadScript('vars/withGCPEnvContext.groovy')
+      return script.call(m, c)
+    })
     helper.registerAllowedMethod('withGhEnv', [Map.class, Closure.class], { m, c ->
       def script = loadScript('vars/withGhEnv.groovy')
       return script.call(m, c)

--- a/vars/withGCPEnvContext.groovy
+++ b/vars/withGCPEnvContext.groovy
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Configure the GCP context to run the given body closure
+
+withGCPEnvContext(credentialsId: 'foo') {
+  // block
+}
+*/
+def call(Map args = [:], Closure body) {
+  def credentialsId = args.containsKey('credentialsId') ? args.credentialsId : ''
+  def secret = args.containsKey('secret') ? args.secret : ''
+  def secretFileLocation = args.containsKey('secretFileLocation') ? args.secretFileLocation : pwd(tmp: true) + "/google-cloud-credentials.json"
+
+  if (!credentialsId?.trim() && !secret?.trim()) {
+    error('withGCPEnvContext: credentialsId or secret parameters are required.')
+  }
+
+  if (secret) {
+    def props = getVaultSecret(args)
+    if (props?.errors) {
+      error "withGCPEnv: Unable to get credentials from the vault: ${props.errors.toString()}"
+    }
+    def value = props?.data
+    def credentialsContent = readCredentialsContent(value)
+    writeFile(file: secretFileLocation, text: credentialsContent)
+  }
+  try {
+    if (secret) {
+      // Somehow the login works for google bucket integrations but something
+      // it's not right when using the VM creation with terraform and GCP
+      // Setting GOOGLE_APPLICATION_CREDENTIALS seems to be the workaround
+      // https://cloud.google.com/docs/authentication/getting-started
+      withEnv(["GOOGLE_APPLICATION_CREDENTIALS=${secretFileLocation}"]){
+        body()
+      }
+    } else {
+      withCredentials([file(credentialsId: credentialsId, variable: 'FILE_CREDENTIAL')]) {
+        body()
+      }
+    }
+  } finally {
+    if (fileExists("${secretFileLocation}")) {
+      if(isUnix()){
+        sh "rm ${secretFileLocation}"
+      } else {
+        bat "del ${secretFileLocation}"
+      }
+    }
+  }
+}
+
+/**
+* Read the vault secret and look for the required fields.
+* * credentials field is the one initially supported and kept for backward compatibility reasons.
+* * value field is the fallback field, this is the case used
+*/
+def readCredentialsContent(Map vaultSecretContent) {
+  def credentialsContent = vaultSecretContent?.credentials
+  if (credentialsContent?.trim()) {
+    log(level: 'INFO', text: "readCredentialsContent: reading the 'credentials' field.")
+    return credentialsContent
+  }
+  credentialsContent = vaultSecretContent?.value
+  if (credentialsContent?.trim()) {
+    log(level: 'INFO', text: "readCredentialsContent: reading the 'value' field.")
+    return credentialsContent
+  }
+  error "withGCPEnv: Unable to read the credentials and value fields"
+}

--- a/vars/withGCPEnvContext.txt
+++ b/vars/withGCPEnvContext.txt
@@ -1,11 +1,11 @@
-Configure the GCP context, install gsutil if needed, to run the given body closure
+Configure the GCP environment context to run the given body closure
 
 ```
-withGCPEnv(credentialsId: 'foo') {
+withGCPEnvContext(credentialsId: 'foo') {
   // block
 }
 
-withGCPEnv(secret: 'secret/team/ci/service-account/gcp-provisioner') {
+withGCPEnvContext(secret: 'secret/team/ci/service-account/gcp-provisioner') {
   // block
 }
 ```


### PR DESCRIPTION
## What does this PR do?

Use `Context` when it's related to prepare the environment without installing any tools.

## Why is it important?

Potentially we can provide a light version to configure the GCP context by transforming the secrets/credentials in env variables

## Related issues
Closes #ISSUE
