### PR TITLE
jobdsl: add daily and ci-metrics jobs in fleet-ci

### DIFF
--- a/.ci/fleet-ci-schedule-daily.groovy
+++ b/.ci/fleet-ci-schedule-daily.groovy
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(4-5) * * 1-5')
+  }
+  stages {
+    stage('Run Tasks'){
+      steps {
+        build(job: 'fleet-shared/gather-ci-metrics-pipeline',
+          parameters: [
+            string(name: 'MTIME_FILTER', value: '1'),
+            string(name: 'AGENT_PREFIX', value: 'fleet-ci')
+          ],
+          propagate: false,
+          wait: false
+        )
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/jobDSL/jobs/fleet-ci/fleet-shared/fleet-schedule-daily.groovy
+++ b/.ci/jobDSL/jobs/fleet-ci/fleet-shared/fleet-schedule-daily.groovy
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pipelineJob("fleet-shared/fleet-schedule-daily") {
+  displayName('Jobs scheduled daily')
+  description('Jobs scheduled daily from Monday to Friday.')
+  disabled(false)
+  quietPeriod(10)
+  logRotator {
+    numToKeep(10)
+    daysToKeep(7)
+    artifactNumToKeep(10)
+    artifactDaysToKeep(-1)
+  }
+  parameters {
+    stringParam("branch_specifier", "main", "the Git branch specifier to build.")
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            github("elastic/apm-pipeline-library", "ssh")
+            credentials("f6c7695a-671e-4f4f-a331-acdce44ff9ba")
+          }
+          branch('${branch_specifier}')
+          extensions {
+            wipeOutWorkspace()
+          }
+        }
+      }
+      lightweight(false)
+      scriptPath(".ci/fleet-ci-schedule-daily.groovy")
+    }
+  }
+}

--- a/.ci/jobDSL/jobs/fleet-ci/fleet-shared/gather-ci-metrics-pipeline.groovy
+++ b/.ci/jobDSL/jobs/fleet-ci/fleet-shared/gather-ci-metrics-pipeline.groovy
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pipelineJob("fleet-shared/gather-ci-metrics-pipeline") {
+  displayName('Gather CI metrics')
+  description('Gather CI metrics')
+  disabled(false)
+  quietPeriod(10)
+  logRotator {
+    numToKeep(10)
+    daysToKeep(7)
+    artifactNumToKeep(10)
+    artifactDaysToKeep(-1)
+  }
+  parameters {
+    stringParam("branch_specifier", "main", "the Git branch specifier to build.")
+    stringParam("MTIME_FILTER", "1", "filter for the find mtime")
+    stringParam("AGENT_PREFIX", "fleet-ci", "the agent prefix name")
+  }
+  definition {
+    cpsScm {
+      scm {
+        git {
+          remote {
+            github("elastic/observability-robots", "ssh")
+            credentials("f6c7695a-671e-4f4f-a331-acdce44ff9ba")
+          }
+          branch('${branch_specifier}')
+          extensions {
+            wipeOutWorkspace()
+          }
+        }
+      }
+      lightweight(false)
+      scriptPath(".ci/gather-ci-metrics.groovy")
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Enable the daily job in `fleet-ci` and the `ci-metrics` one.

## Why is it important?

1) Gather details about some stats we have in place for the other two CI controllers
2) Leverage the existing JJB/JJBB since it does not work with different CI controllers, while JobDSL can do the heavy-lift.
