### PR TITLE
bump automation for golang versions

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -50,5 +50,9 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+      - "1.19"
+      - "1.18"
+      - "1.17"
+      - "1.16"
     enabled: true
     labels: dependency

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -120,6 +120,17 @@ def createPullRequest(Map args = [:]) {
   if (!args?.goReleaseVersion?.trim()) {
     error('createPullRequest: goReleaseVersion is empty. Review the goVersion for the branch ' + args.branchName)
   }
+
+  // If branch is not main the it's likely needed to search for the go version that matches the given branch
+  // ie. 1.16 branch should be go1.16, 1.17 branch should be go1.17 and so on
+  def goReleaseVersion = args?.goReleaseVersion
+  if (!args.branchName?.equals('main')) {
+    goReleaseVersion = goVersion(action: 'latest', unstable: false, glob: args.branchName)
+    if (!goReleaseVersion?.trim()) {
+      error('createPullRequest: goReleaseVersion is empty. Review the goVersion for the branch ' + args.branchName)
+    }
+  }
+
   bumpUtils.createBranch(prefix: 'update-go-version', suffix: args.branchName)
   sh(script: "${args.scriptFile} '${args.goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
 

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -132,7 +132,7 @@ def createPullRequest(Map args = [:]) {
   }
 
   bumpUtils.createBranch(prefix: 'update-go-version', suffix: args.branchName)
-  sh(script: "${args.scriptFile} '${args.goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
+  sh(script: "${args.scriptFile} '${goReleaseVersion}'", label: "Prepare changes for ${args.repo}")
 
   if (params.DRY_RUN_MODE) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(repo: ${args.repo}, labels: ${args.labels}, message: '${args.message}', base: '${args.branchName}', title: '${args.title}', assign: '${args.assign}', reviewer: '${args.reviewer}')")


### PR DESCRIPTION
## What does this PR do?

Update golang version for the https://github.com/elastic/golang-crossbuild

## Why is it important?

Maintain multiple active golang-versions without the need to manually bump those versions.

## Related issues

Required https://github.com/elastic/golang-crossbuild/pull/156
