### PR TITLE
ci: golang onboarding, bump version

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -52,3 +52,10 @@ projects:
       - main
     enabled: true
     labels: dependency
+  - repo: observability-robots
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency
+    reviewer: elastic/observablt-robots-on-call


### PR DESCRIPTION
## What does this PR do?

Enable Golang bump automation for the obs-robots project

## Why is it important?

Update Go versions to keep them up-to-date
