### PR TITLE
Support node labels for k8s pods

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -52,3 +52,10 @@ projects:
       - main
     enabled: true
     labels: dependency
+  - repo: observability-robots
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency
+    reviewer: elastic/observablt-robots-on-call

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -544,6 +544,10 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       def script = loadScript('vars/is64x86.groovy')
       return script.call()
     })
+    helper.registerAllowedMethod('isK8s', {
+      def script = loadScript('vars/isK8s.groovy')
+      return script.call()
+    })
     helper.registerAllowedMethod('log', [Map.class], {m -> println m.text})
     helper.registerAllowedMethod('lookForGitHubIssues', [Map.class], {[]})
     helper.registerAllowedMethod('nodeOS', [], { return 'linux'})

--- a/vars/isK8s.groovy
+++ b/vars/isK8s.groovy
@@ -16,47 +16,13 @@
 // under the License.
 
 /**
- Return the name of the Operating system based on the labels of the Node.
+ Whether the node is a k8s pod template
 
- def os = nodeOS()
+ whenTrue(isK8s()) {
+   ...
+ }
 
 */
 def call() {
-  def labels = env.NODE_LABELS?.toLowerCase()
-  def matches = []
-
-  if (isLinux(labels) || (isArm() && !isDarwin(labels)) || isK8s()) {
-    matches.add('linux')
-  }
-
-  if (isWindows(labels)) {
-    matches.add('windows')
-  }
-
-  if (isDarwin(labels)) {
-    matches.add('darwin')
-  }
-
-
-  if(matches.size() == 0){
-    error("Unhandled OS name in NODE_LABELS: " + labels)
-  }
-
-  if(matches.size() > 1){
-    error("Labels conflict OS name in NODE_LABELS: " + labels)
-  }
-
-  return matches[0]
-}
-
-def isLinux(labels){
-  return labels.contains('linux')
-}
-
-def isDarwin(labels){
-  return labels.contains('darwin') || labels.contains('macos')
-}
-
-def isWindows(labels){
-  return labels.contains('windows')
+  return env.POD_LABEL?.trim() ? true : false
 }

--- a/vars/isK8s.txt
+++ b/vars/isK8s.txt
@@ -1,0 +1,7 @@
+Whether the node is a k8s pod template
+
+```
+  whenTrue(isK8s()) {
+   ...
+  }
+```

--- a/vars/nodeArch.groovy
+++ b/vars/nodeArch.groovy
@@ -30,7 +30,7 @@ def call() {
     matches.add('i386')
   }
 
-  if (is64bit(labels)) {
+  if (is64bit(labels) || isK8s()) {
     matches.add('x86_64')
   }
 
@@ -68,4 +68,8 @@ def isArm(labels){
 
 def isArm64(labels){
   return labels.contains('aarch64') || labels.contains('arm64')
+}
+
+def isK8s() {
+  return env.POD_LABEL?.trim() ? true : false
 }

--- a/vars/nodeArch.groovy
+++ b/vars/nodeArch.groovy
@@ -69,7 +69,3 @@ def isArm(labels){
 def isArm64(labels){
   return labels.contains('aarch64') || labels.contains('arm64')
 }
-
-def isK8s() {
-  return env.POD_LABEL?.trim() ? true : false
-}

--- a/vars/nodeOS.groovy
+++ b/vars/nodeOS.groovy
@@ -25,7 +25,7 @@ def call() {
   def labels = env.NODE_LABELS?.toLowerCase()
   def matches = []
 
-  if (isLinux(labels) || (isArm() && !isDarwin(labels)) || isK8s(labels)) {
+  if (isLinux(labels) || (isArm() && !isDarwin(labels)) || isK8s()) {
     matches.add('linux')
   }
 

--- a/vars/nodeOS.groovy
+++ b/vars/nodeOS.groovy
@@ -25,7 +25,7 @@ def call() {
   def labels = env.NODE_LABELS?.toLowerCase()
   def matches = []
 
-  if (isLinux(labels) || (isArm() && !isDarwin(labels))) {
+  if (isLinux(labels) || (isArm() && !isDarwin(labels)) || isK8s(labels)) {
     matches.add('linux')
   }
 
@@ -36,6 +36,7 @@ def call() {
   if (isDarwin(labels)) {
     matches.add('darwin')
   }
+
 
   if(matches.size() == 0){
     error("Unhandled OS name in NODE_LABELS: " + labels)
@@ -58,4 +59,8 @@ def isDarwin(labels){
 
 def isWindows(labels){
   return labels.contains('windows')
+}
+
+def isK8s() {
+  return env.POD_LABEL?.trim() ? true : false
 }


### PR DESCRIPTION
## What does this PR do?

If `POD_LABEL` then set default behaviours

## Why is it important?

Support for k8s pods 

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1443
