### PR TITLE
Fix OTEL_ELASTIC_URL with spaces

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -17,7 +17,7 @@
 
 <!-- BUILD BADGES-->
 > _the below badges are clickable and redirect to their specific view in the CI or DOCS_
-[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim() && !buildStatus?.equals('ABORTED')) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>  <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL})<%}%>
+[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim() && !buildStatus?.equals('ABORTED')) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>  <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL.replaceAll(' ','+')})<%}%>
 
 <!-- BUILD SUMMARY-->
 <details><summary>Expand to view the summary</summary>

--- a/resources/slack-markdown.template
+++ b/resources/slack-markdown.template
@@ -14,5 +14,5 @@
 *Tests*: `${(testsSummary?.failed) ?: 0}` test/s failed out of ${(testsSummary?.total) ?: 0} (click ${testsUrl} for further details)
 ${stepsMessage}
 <% if (observabilityUrl && observabilityUrl?.trim()) {%>
-:APM: Click ${obs11Url} to see the APM traces.
+:APM: Click ${obs11Url.replaceAll(' ','+')} to see the APM traces.
 <%}%>

--- a/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
+++ b/src/test/groovy/GenerateBuildDataIntegrationTests.groovy
@@ -291,7 +291,7 @@ class GenerateBuildDataIntegrationTests {
     env.put('JOB_NAME', "project/${jobName}")
     env.put('JOB_URL', tradditionalUrl + "/${jobName}")
     env.put('ORG_NAME', 'acme')
-    env.put('OTEL_ELASTIC_URL', 'https://kibana.elastic.dev/app/apm/services/jenkins/transactions/view?rangeFrom=2021-03-06T21:41:11.403Z&rangeTo=2021-03-06T22:01:11.403Z&transactionName=load-testing/cron_gce&transactionType=unknown&latencyAggregationType=avg&traceId=38f56b69e3b7c76c8e914b2d467d0475&transactionId=b877b754e2e3a8c4')
+    env.put('OTEL_ELASTIC_URL', 'https://kibana.elastic.dev/app/apm/services/jenkins/transactions/view?rangeFrom=2021-03-06T21:41:11.403Z&rangeTo=2021-03-06T22:01:11.403Z&transactionName=BUILD load-testing/cron_gce&transactionType=unknown&latencyAggregationType=avg&traceId=38f56b69e3b7c76c8e914b2d467d0475&transactionId=b877b754e2e3a8c4')
     env.put('REPO_NAME', 'project')
     File location = new File("target/${targetFolder}")
     location.mkdirs()

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -596,7 +596,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_notify_slack_with_otel() throws Exception {
-    addEnvVar('OTEL_ELASTIC_URL', 'https://kibana.elastic.dev/app/apm/services/jenkins/transactions/view?rangeFrom=2021-03-06T21:41:11.403Z&rangeTo=2021-03-06T22:01:11.403Z&transactionName=load-testing/cron_gce&transactionType=unknown&latencyAggregationType=avg&traceId=abc&transactionId=123')
+    addEnvVar('OTEL_ELASTIC_URL', 'https://kibana.elastic.dev/app/apm/services/jenkins/transactions/view?rangeFrom=2021-03-06T21:41:11.403Z&rangeTo=2021-03-06T22:01:11.403Z&transactionName=BUILD load-testing/cron_gce&transactionType=unknown&latencyAggregationType=avg&traceId=abc&transactionId=123')
     script.notifySlack(
       build: readJSON(file: "build-info-manual.json"),
       buildStatus: "SUCCESS",
@@ -606,6 +606,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     )
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('slackSend', 'https://kibana.elastic.dev'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'transactionName=BUILD+load-testing/cron_gce'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Fix the space in the env variable

## Why is it important?

We don't manage the existing CI controllers so we need to patch this temporarily. Even though it is already fixed in the plugin -> https://github.com/jenkinsci/opentelemetry-plugin/pull/361

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1585
