### PR TITLE
getBranchesFromAliases : support minor index alias

### DIFF
--- a/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
+++ b/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
@@ -59,7 +59,7 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract_with_0() throws Exception {
-    def ret = script.subtractBranchIfPossible('8.0', 1)
+    def ret = script.subtractBranchIfPossible('8.1', '1')
     printCallStack()
     assert ret.equals('8.0')
     assertJobStatusSuccess()
@@ -67,17 +67,25 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract() throws Exception {
-    def ret = script.subtractBranchIfPossible('8.2', 1)
+    def ret = script.subtractBranchIfPossible('8.2', '1')
     printCallStack()
-    assert ret.equals('8.2')
+    assert ret.equals('8.1')
     assertJobStatusSuccess()
   }
 
   @Test
   void test_subtract_with_major_branch() throws Exception {
-    def ret = script.subtractBranchIfPossible('8', 1)
+    def ret = script.subtractBranchIfPossible('8', '1')
     printCallStack()
     assert ret.equals('8')
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_subtract_with_major_branch_overflow() throws Exception {
+    def ret = script.subtractBranchIfPossible('8.2', '5')
+    printCallStack()
+    assert ret.equals('8.2')
     assertJobStatusSuccess()
   }
 }

--- a/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
+++ b/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
@@ -59,7 +59,7 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract_with_0() throws Exception {
-    def ret = script.subtractBranchIfPossible('8.1', '1')
+    def ret = script.subtract('8.1', '1')
     printCallStack()
     assert ret.equals('8.0')
     assertJobStatusSuccess()
@@ -67,7 +67,7 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract() throws Exception {
-    def ret = script.subtractBranchIfPossible('8.2', '1')
+    def ret = script.subtract('8.2', '1')
     printCallStack()
     assert ret.equals('8.1')
     assertJobStatusSuccess()
@@ -75,7 +75,7 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract_with_major_branch() throws Exception {
-    def ret = script.subtractBranchIfPossible('8', '1')
+    def ret = script.subtract('8', '1')
     printCallStack()
     assert ret.equals('8')
     assertJobStatusSuccess()
@@ -83,7 +83,7 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_subtract_with_major_branch_overflow() throws Exception {
-    def ret = script.subtractBranchIfPossible('8.2', '5')
+    def ret = script.subtract('8.2', '5')
     printCallStack()
     assert ret.equals('8.2')
     assertJobStatusSuccess()

--- a/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
+++ b/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
@@ -56,4 +56,28 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
     assert ret.equals(['foo', '8.0'])
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_subtract_with_0() throws Exception {
+    def ret = script.subtractBranchIfPossible('8.0', 1)
+    printCallStack()
+    assert ret.equals('8.0')
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_subtract() throws Exception {
+    def ret = script.subtractBranchIfPossible('8.2', 1)
+    printCallStack()
+    assert ret.equals('8.2')
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_subtract_with_major_branch() throws Exception {
+    def ret = script.subtractBranchIfPossible('8', 1)
+    printCallStack()
+    assert ret.equals('8')
+    assertJobStatusSuccess()
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -689,6 +689,10 @@ the branch name.
 This is handy to support a dynamic branch generation without the need to
 update the name of the branch when a new minor release branch is created.
 
+This format supports passing an index, separated by the minus operator: '<minor-1>', which will retrieve the previous
+version for the last minor. If the index overflows the number of the total existing minors, the first minor will be retrieved (i.e.
+'<minor-1999>').
+
 ```
 // Return the branch name for the main, 8.minor and 8.next-minor branches
 def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-minor>'])
@@ -696,7 +700,7 @@ def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-mi
 ```
 
 
-* aliases: the branch aliases (supported format major.<minor>, major.<next-patch>, major.<next-minor>). Mandatory
+* aliases: the branch aliases (supported format major.<minor>, major.<minor-1>, major.<next-patch>, major.<next-minor>). Mandatory
 
 ## getBuildInfoJsonFiles
 Grab build related info from the Blueocean REST API and store it on JSON files.

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -41,13 +41,14 @@ def call(Map args = [:]) {
 }
 
 def getBranchNameFromAlias(alias) {
-  // special macro to look for the latest minor version -1
-  if (alias.contains('8.<minor-1>')) {
-   return subtractBranchIfPossible(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), 1)
+  // special macro to look for the latest minor version - subtrahend
+  if (alias.contains('8.<minor-')) {
+    def minorParts = alias.split('-')
+    return subtractBranchIfPossible(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), minorParts[1])
   }
   // special macro to look for the latest minor version
   if (alias.contains('8.<minor>')) {
-   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
   }
   if (alias.contains('8.<next-minor>')) {
     return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
@@ -65,15 +66,27 @@ def getBranchNameFromAlias(alias) {
   return alias
 }
 
-def subtractBranchIfPossible(String branch, int subtrahend) {
+def subtractBranchIfPossible(String branch, String subtrahend) {
   def parts = branch.split('\\.')
   def major = parts[0]
   if (parts.size() == 1) {
     return branch
   }
-  def minor = parts[1]
-  if (minor?.equals('0')) {
+  def index = parseInt(subtrahend, 0)
+  def minor = parseInt(parts[1], 0)
+  def newMinor = (minor - index)
+  if (newMinor < 0) {
     return branch
   }
-  return major + "." + (minor  - subtrahend)
+  return major + "." + newMinor
+}
+
+def parseInt(String value, int defaultValue) {
+  def ret = defaultValue
+  try {
+    ret = Integer.parseInt(value)
+  } catch (Exception ex) {
+    echo("parseInt: index will be considered as zero: " + ex)
+  }
+  return ret
 }

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -41,6 +41,10 @@ def call(Map args = [:]) {
 }
 
 def getBranchNameFromAlias(alias) {
+  // special macro to look for the latest minor version -1
+  if (alias.contains('8.<minor-1>')) {
+   return subtractBranchIfPossible(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), 1)
+  }
   // special macro to look for the latest minor version
   if (alias.contains('8.<minor>')) {
    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
@@ -59,4 +63,17 @@ def getBranchNameFromAlias(alias) {
     return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
   }
   return alias
+}
+
+def subtractBranchIfPossible(String branch, int subtrahend) {
+  def parts = branch.split('\\.')
+  def major = parts[0]
+  if (parts.size() == 1) {
+    return branch
+  }
+  def minor = parts[1]
+  if (minor?.equals('0')) {
+    return branch
+  }
+  return major + "." + (minor  - subtrahend)
 }

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -44,7 +44,7 @@ def getBranchNameFromAlias(alias) {
   // special macro to look for the latest minor version - subtrahend
   if (alias.contains('8.<minor-')) {
     def minorParts = alias.split('-')
-    return subtractBranchIfPossible(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), minorParts[1])
+    return subtract(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), minorParts[1])
   }
   // special macro to look for the latest minor version
   if (alias.contains('8.<minor>')) {
@@ -66,7 +66,7 @@ def getBranchNameFromAlias(alias) {
   return alias
 }
 
-def subtractBranchIfPossible(String branch, String subtrahend) {
+def subtract(String branch, String subtrahend) {
   def parts = branch.split('\\.')
   def major = parts[0]
   if (parts.size() == 1) {

--- a/vars/getBranchesFromAliases.txt
+++ b/vars/getBranchesFromAliases.txt
@@ -11,4 +11,4 @@ def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-mi
 ```
 
 
-* aliases: the branch aliases (supported format major.<minor>, major.<next-patch>, major.<next-minor>). Mandatory
+* aliases: the branch aliases (supported format major.<minor>, major.<minor-1>, major.<next-patch>, major.<next-minor>). Mandatory

--- a/vars/getBranchesFromAliases.txt
+++ b/vars/getBranchesFromAliases.txt
@@ -4,6 +4,10 @@ the branch name.
 This is handy to support a dynamic branch generation without the need to
 update the name of the branch when a new minor release branch is created.
 
+This format supports passing an index, separated by the minus operator: '<minor-1>', which will retrieve the previous
+version for the last minor. If the index overflows the number of the total existing minors, the first minor will be retrieved (i.e.
+'<minor-1999>').
+
 ```
 // Return the branch name for the main, 8.minor and 8.next-minor branches
 def branches = getBranchesFromAliases(aliases: ['main', '8.<minor>', '8.<next-minor>'])


### PR DESCRIPTION
## What does this PR do?

Support `major.<minor-$index>`
The index will be used to retrieve a previous minor version of the stack

## Why is it important?

It could be the case where there are multiple minors in development at the same time, 7.16 and 7.17, and with previous behaviour, the automation discarded those cases where the project needed a bump in two minors (See e2e-tests, that needs bumps in 7.16 and 7.17)

## Related issues

Similar to https://github.com/elastic/apm-pipeline-library/pull/1503 and notifies https://github.com/elastic/e2e-testing/pull/2241
