### PR TITLE
Use https rather than git

### DIFF
--- a/src/test/groovy/GoVersionStepTests.groovy
+++ b/src/test/groovy/GoVersionStepTests.groovy
@@ -60,7 +60,7 @@ class GoVersionStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('sh', [Map.class],{'1.17beta1'})
     def obj = script.call(action: 'latest', unstable: 'true')
     assertTrue(obj.equals('1.17beta1'))
-    assertTrue(assertMethodCallContainsPattern('sh', '--refs git://github.com/golang/go'))
+    assertTrue(assertMethodCallContainsPattern('sh', '--refs https://github.com/golang/go'))
     assertTrue(assertMethodCallContainsPattern('sh', 'grep "go*" | sed "s#^go##g" | sort --version-sort -r | head -n1'))
     printCallStack()
   }

--- a/vars/goVersion.groovy
+++ b/vars/goVersion.groovy
@@ -55,7 +55,7 @@ def firstOne(String command) {
 */
 def getAllGoVersions() {
   // --sort=-version:refname is not supported in git version 2.17 yet
-  return 'git ls-remote --tags --refs git://github.com/golang/go | sed "s#.*refs/tags/##g" | grep "go*"'
+  return 'git ls-remote --tags --refs https://github.com/golang/go | sed "s#.*refs/tags/##g" | grep "go*"'
 }
 
 def getVersionsCommand(Map args = [:]) {


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/

## What does this PR do?

`git` protocol does not work anymore

## Why is it important?

fixes

```
git ls-remote --tags --refs git://github.com/golang/go
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```