### PR TITLE
fix <minor-1> manipulation

### DIFF
--- a/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
+++ b/src/test/groovy/GetBranchesFromAliasesStepTests.groovy
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertTrue
 class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
 
   class BumpUtilsMock {
-    String getCurrentMinorReleaseFor8(){ "8.0.0" }
-    String getMajorMinor(String value){ "8.0" }
+    String getCurrentMinorReleaseFor8(){ "8.3.0" }
+    String getMajorMinor(String value){ "8.3" }
   }
 
   @Override
@@ -53,7 +53,15 @@ class GetBranchesFromAliasesStepTests extends ApmBasePipelineTest {
   void test_alias_with_macro() throws Exception {
     def ret = script.call(aliases:[ 'foo', '8.<minor>' ])
     printCallStack()
-    assert ret.equals(['foo', '8.0'])
+    assert ret.equals(['foo', '8.3'])
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_alias_with_macro_minor() throws Exception {
+    def ret = script.call(aliases:[ 'foo', '8.<minor>', '8.<minor-2>' ])
+    printCallStack()
+    assert ret.equals(['foo', '8.3', '8.1'])
     assertJobStatusSuccess()
   }
 

--- a/vars/getBranchesFromAliases.groovy
+++ b/vars/getBranchesFromAliases.groovy
@@ -44,7 +44,7 @@ def getBranchNameFromAlias(alias) {
   // special macro to look for the latest minor version - subtrahend
   if (alias.contains('8.<minor-')) {
     def minorParts = alias.split('-')
-    return subtract(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), minorParts[1])
+    return subtract(bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8()), minorParts[1].replaceAll('>', ''))
   }
   // special macro to look for the latest minor version
   if (alias.contains('8.<minor>')) {


### PR DESCRIPTION
## What does this PR do?

Fix the string transformation to remove the extra `>` and add some UTs for this particular use case

## Why is it important?

Otherwise:

```
13:33:26  parseInt: index will be considered as zero: java.lang.NumberFormatException: For input string: "1>"
```
