### PR TITLE
fix tar with 7z without extension

### DIFF
--- a/vars/tar.groovy
+++ b/vars/tar.groovy
@@ -65,7 +65,7 @@ def compressWith7z(Map args = [:]) {
     installTools([[ tool: '7zip.portable', version: '19.0', provider: 'choco']])
   }
   withEnv(["PATH+CHOCO=C:\\ProgramData\\chocolatey\\bin"]) {
-    bat(label: 'Compress', script: "7z a -ttar -so -an ${args.dir} | 7z a -si ${args.file}")
+    bat(label: 'Compress', script: "7z a -ttar -so -an ${args.dir} | 7z a -si ${args.file}.")
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

`7z` added the `7z` extension.

## Why is it important?

Fixes 

![image](https://user-images.githubusercontent.com/2871786/158634086-adc03fac-787e-41cc-a987-a209565b1fbe.png)

## Test

<img width="873" alt="image" src="https://user-images.githubusercontent.com/2871786/158634136-2c0cc4a7-6258-441e-a061-a305ac218b7f.png">

versus

<img width="876" alt="image" src="https://user-images.githubusercontent.com/2871786/158634182-0417edda-2d4a-4e0c-974d-cab751bca128.png">
