### PR TITLE
If no aborted then notify the pipeline syntax error

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -117,7 +117,7 @@ ${description}
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
   <p>
   > This error is likely related to the pipeline itself. Click <a href="${env?.BUILD_URL}console">here</a>
-  > then you will see the error  (either a wrong syntax or configuration).
+  > and then you will see the error (either incorrect syntax or an invalid configuration).
   </p>
 <%}%>
 <%}%>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -116,8 +116,8 @@ ${description}
 <%} else if (!buildStatus?.equals('ABORTED')) {%>
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
   <p>
-  This error is likely related to the pipeline itself. Please go to the traditional console output <a href=\"${env?.BUILD_URL}/console\">here</a>"
-  You will see the error (either a wrong syntax or configuration)
+  > This error is likely related to the pipeline itself. Click <a href="${env?.BUILD_URL}console">here</a>
+  > then you will see the error  (either a wrong syntax or configuration).
   </p>
 <%}%>
 <%}%>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -113,7 +113,7 @@ ${description}
   <%}%>
   </p>
   </details>
-<%} else {%>
+<%} else if (!buildStatus?.equals('ABORTED')) {%>
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
   <p>
   This error is likely related to the pipeline itself. Please go to the traditional console output <a href=\"${env?.BUILD_URL}/console\">here</a>"

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -269,7 +269,6 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Build Failed'))
     assertTrue(assertMethodCallContainsPattern('githubPrComment', 'Pipeline error'))
-    assertTrue(assertMethodCallContainsPattern('githubPrComment', 'go to the traditional console output'))
     assertJobStatusSuccess()
   }
 


### PR DESCRIPTION
## What does this PR do?

Notify syntax error if no aborted, otherwise

![image](https://user-images.githubusercontent.com/2871786/159050824-2cf2463e-ab39-4d1c-aa71-8c5a57457c16.png)


## Why is it important?

Avoid misleading messages related to aborted builds

## Issues

Relates to https://github.com/elastic/apm-pipeline-library/issues/1555 and caused by https://github.com/elastic/apm-pipeline-library/pull/1557