### PR TITLE
weekly test report for elastic-agent and e2e-testing

### DIFF
--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -37,6 +37,7 @@ pipeline {
   parameters {
     string(name: 'BEATS_MAILING_LIST', defaultValue: 'beats-contrib@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
     string(name: 'ELASTIC_AGENT_MAILING_LIST', defaultValue: 'beats-contrib@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
+    string(name: 'E2E_TESTING_MAILING_LIST', defaultValue: 'observability-robots-internal@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
   }
   triggers {
     cron('H H(1-4) * * 1')
@@ -53,6 +54,11 @@ pipeline {
         // TODO: as soon as minor is 8.2 then we can use the below branches
         // runWatcherForBranch(project: 'elastic-agent', branches: ['main', '8.<minor>', '8.<next-patch>'], to: env.ELASTIC_AGENT_MAILING_LIST)
         runWatcherForBranch(project: 'elastic-agent', branches: ['main'], to: env.ELASTIC_AGENT_MAILING_LIST)
+      }
+    }
+    stage('Top failing e2e-testing tests - last 7 days') {
+      steps {
+        runWatcherForBranch(project: 'e2e-testing', branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'], to: env.ELASTIC_AGENT_MAILING_LIST)
       }
     }
     stage('Sync GitHub labels') {

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -37,7 +37,7 @@ pipeline {
   parameters {
     string(name: 'BEATS_MAILING_LIST', defaultValue: 'beats-contrib@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
     string(name: 'ELASTIC_AGENT_MAILING_LIST', defaultValue: 'beats-contrib@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
-    string(name: 'E2E_TESTING_MAILING_LIST', defaultValue: 'observability-robots-internal@elastic.co', description: 'the Beats Mailing List to send the emails with the weekly reports.')
+    string(name: 'E2E_TESTING_MAILING_LIST', defaultValue: 'observability-robots-internal@elastic.co', description: 'the e2e-testing Mailing List to send the emails with the weekly reports.')
   }
   triggers {
     cron('H H(1-4) * * 1')
@@ -58,7 +58,7 @@ pipeline {
     }
     stage('Top failing e2e-testing tests - last 7 days') {
       steps {
-        runWatcherForBranch(project: 'e2e-testing', branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'], to: env.ELASTIC_AGENT_MAILING_LIST)
+        runWatcherForBranch(project: 'e2e-testing', branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'], to: env.E2E_TESTING_MAILING_LIST)
       }
     }
     stage('Sync GitHub labels') {

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -50,8 +50,9 @@ pipeline {
     }
     stage('Top failing Elastic Agent tests - last 7 days') {
       steps {
-        setEnvVar('YYYY_MM_DD', new Date().format("yyyy-MM-dd", TimeZone.getTimeZone('UTC')))
-        runWatcherForBranch(project: 'elastic-agent', branches: ['main', '8.<minor>', '8.<next-patch>'], to: env.ELASTIC_AGENT_MAILING_LIST)
+        // TODO: as soon as minor is 8.2 then we can use the below branches
+        // runWatcherForBranch(project: 'elastic-agent', branches: ['main', '8.<minor>', '8.<next-patch>'], to: env.ELASTIC_AGENT_MAILING_LIST)
+        runWatcherForBranch(project: 'elastic-agent', branches: ['main'], to: env.ELASTIC_AGENT_MAILING_LIST)
       }
     }
     stage('Sync GitHub labels') {
@@ -112,7 +113,7 @@ def runWatcherForBranch(Map args = [:]){
   def quietPeriod = 0
   branches.each { branch ->
     runWatcher(watcher: "report-${args.project}-top-failing-tests-weekly-${branch}",
-               subject: "[${branch}] ${env.YYYY_MM_DD}: Top failing Beats tests in ${branch} branch - last 7 days",
+               subject: "[${args.project}@${branch}] ${env.YYYY_MM_DD}: Top failing ${args.project} tests in ${branch} branch - last 7 days",
                sendEmail: true,
                to: args.to,
                debugFileName: "${args.project}-${branch}.txt")


### PR DESCRIPTION
## What does this PR do?

Support weekly email reporting for the https://github.com/elastic/elastic-agent/ and https://github.com/elastic/e2e-testing/

## Why is it important?

It's now an independent repository and @mdelapenya asked for the e2e-testing one

I also created the watchers
 
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/2871786/159325889-04a682bc-dadb-4d05-84d0-1159d91cc9a6.png">

<img width="470" alt="image" src="https://user-images.githubusercontent.com/2871786/159328714-aefe5575-3bbc-47b3-8c3b-41371173ffcd.png">

## Test

See [build](https://apm-ci.elastic.co/job/apm-shared/job/apm-schedule-weekly/163/) that I was able to use the upstream branch `feature/elastic-agent-weekly-report` and my elastic email to avoid spamming people



<img width="1330" alt="image" src="https://user-images.githubusercontent.com/2871786/159328823-4315343b-cf2b-4182-9d9c-f0424e04d8f3.png">
