### PR TITLE
refactor: weekly email based on yaml file

### DIFF
--- a/.ci/.weekly-tests-email.yml
+++ b/.ci/.weekly-tests-email.yml
@@ -1,0 +1,39 @@
+---
+## This is the file that contains what projects are subscribed to send
+## a weekly email with the top test failures
+##
+## The data structure:
+##  repo: the repository name
+##  branches: the list of branches that should benefit from this automation.
+##  enabled: whether the automation has been enabled for this project.
+##  email: to
+##
+##  NOTE:
+##  <minor> is a special token that refers to the latest minor branch.
+##  <minor-1> is a special token that refers to the previous latest minor branch.
+##  The automation will resolve the correct version at runtime, so you don't need to change it.
+##
+projects:
+  - repo: beats
+    branches:
+      - main
+      - 8.<minor>
+      - 8.<minor-1>
+      - 7.<minor>
+    enabled: true
+    email: beats-contrib@elastic.co
+  - repo: elastic-agent
+    branches:
+      - main
+      - 8.<minor>
+      - 8.<minor-1>
+    enabled: true
+    email: beats-contrib@elastic.co
+  - repo: e2e-testing
+    branches:
+      - main
+      - 8.<minor>
+      - 8.<minor-1>
+      - 7.<minor>
+    enabled: true
+    email: observability-robots-internal@elastic.co


### PR DESCRIPTION
## What does this PR do?

Refactor the weekly email with the top 7 days test failures with a YAML file.

## Why is it important?

Easy to onboard new projects if needed.

Additionally, It won't fail if an email stage failed.

## Test

I ran [this. build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-schedule-weekly/detail/apm-schedule-weekly/165/pipeline/28)