### PR TITLE
fix generateBuildReport: net.sf.json.JSONNull

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -74,7 +74,7 @@ ${errorStackTrace}
 
 <!-- STEPS ERRORS IF ANY -->
 <% errorGitHub = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Notifies GitHub')}%>
-<% errorGithubPrCheckApproved = stepsErrors?.find{it?.result == "FAILURE" && it?.displayDescription?.contains('githubPrCheckApproved')}%>
+<% errorGithubPrCheckApproved = stepsErrors?.find{it?.result == "FAILURE" && !it?.get('displayDescription', '') instanceof net.sf.json.JSONNull && it?.displayDescription.contains('githubPrCheckApproved')}%>
 <% errorDeleteDir = stepsErrors?.find{it?.result == "FAILURE" && it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
 <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" &&
                                       !it?.displayName?.contains('Notifies GitHub') &&


### PR DESCRIPTION
## What does this PR do?

fix generateBuildReport: net.sf.json.JSONNull

## Why is it important?

Corner Case

## Related issues
Closes [#ISSUE](https://github.com/elastic/apm-pipeline-library/issues/1616)
