### PR TITLE
fix net.sf.json.JSONNull.contains()

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -79,6 +79,7 @@ ${errorStackTrace}
 <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" &&
                                       !it?.displayName?.contains('Notifies GitHub') &&
                                       !it?.displayName?.contains('Archive JUnit') &&
+                                      !it?.get('displayDescription', '') instanceof net.sf.json.JSONNull &&
                                       !it?.displayDescription?.contains('githubPrCheckApproved') &&
                                       !it?.displayDescription?.contains('approval-list/elastic') &&
                                       !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>

--- a/src/test/resources/steps-errors-allowed-to-run.json
+++ b/src/test/resources/steps-errors-allowed-to-run.json
@@ -1,7 +1,7 @@
 [
   {
     "displayDescription": null,
-    "displayName": "Force a null displayDesription",
+    "displayName": "Force a null displayDescription",
     "durationInMillis": 23,
     "id": "81",
     "input": null,

--- a/src/test/resources/steps-errors-allowed-to-run.json
+++ b/src/test/resources/steps-errors-allowed-to-run.json
@@ -1,5 +1,17 @@
 [
   {
+    "displayDescription": null,
+    "displayName": "Force a null displayDesription",
+    "durationInMillis": 23,
+    "id": "81",
+    "input": null,
+    "result": "FAILURE",
+    "startTime": "2021-09-22T09:32:09.201+0000",
+    "state": "FINISHED",
+    "type": "STEP",
+    "url": "https://apm-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/apm-agent-nodejs/pipelines/ecs-logging-nodejs-mbp/pipelines/PR-101/runs/1/steps/81/log"
+  },
+  {
     "displayDescription": "approval-list/elastic/ecs-logging-nodejs.yml",
     "displayName": "Load a resource file from a shared library",
     "durationInMillis": 23,


### PR DESCRIPTION
## What does this PR do?

fix generateBuildReport: net.sf.json.JSONNull

## Why is it important?

another corner case

## Related issues
Similar to https://github.com/elastic/apm-pipeline-library/pull/1617