### PR TITLE
fix: remove pytest timming import

### DIFF
--- a/resources/scripts/pytest_otel/src/pytest_otel/__init__.py
+++ b/resources/scripts/pytest_otel/src/pytest_otel/__init__.py
@@ -8,7 +8,6 @@ import traceback
 
 import _pytest._code
 import _pytest.skipping
-from _pytest import timing
 import pytest
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* Remove unused impor

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

It causes an error on pytest <6

```
   File "/app/venv/lib/python3.7/site-packages/pytest_otel/__init__.py", line 11, in <module>
     from _pytest import timing
 ImportError: cannot import name 'timing' from '_pytest' (/app/venv/lib/python3.7/site-packages/_pytest/__init__.py)
```

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1622
