### PR TITLE
releaseManagerAnalyser and releaseManagerNotification step

### DIFF
--- a/resources/scripts/release-manager-analyser.sh
+++ b/resources/scripts/release-manager-analyser.sh
@@ -3,21 +3,20 @@
 # This script is executed after the release snapshot stage.
 # to help with the debugging/troubleshooting
 #
-set -uo pipefail
-set +e
+set -uxo pipefail
 RAW_OUTPUT=${RAW_OUTPUT:?'Missing the release manager output file'}
 REPORT=${REPORT:?'Missing the release manager report file'}
 
 if [ -f "$RAW_OUTPUT" ] ; then
-    echo "There are some errors, let's guess what they are about:" > "$REPORT"
-    if grep 'Vault responded with HTTP status code' "$RAW_OUTPUT" ; then
-        echo 'Environmental issue with Vault. Try again' >> "$REPORT"
+    echo "There were some errors while running the release manager, let's analyse them." > "$REPORT"
+    if grep -q -i 'Vault responded with HTTP status code' "$RAW_OUTPUT" ; then
+        echo '* Environmental issue with Vault. Try again' >> "$REPORT"
     fi
-    if grep 'Cannot write to file' "$RAW_OUTPUT" ; then
-        echo 'Artifacts were not generated. Likely a genuine issue' >> "$REPORT"
+    if grep -q -i 'Cannot write to file' "$RAW_OUTPUT" ; then
+        echo '* Artifacts were not generated. Likely a genuine issue' >> "$REPORT"
     fi
-    if grep 'does not exist' "$RAW_OUTPUT" ; then
-        echo 'Build file does not exist in the unified release. Likely the branch is not supported yet. Contact the release platform team' >> "$REPORT"
+    if grep -q -i 'does not exist' "$RAW_OUTPUT" ; then
+        echo '* Build file does not exist in the unified release. Likely the branch is not supported yet. Contact the release platform team' >> "$REPORT"
     fi
 else
     echo "WARN: $RAW_OUTPUT does not exist"

--- a/resources/scripts/release-manager-analyser.sh
+++ b/resources/scripts/release-manager-analyser.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This script is executed after the release snapshot stage.
+# to help with the debugging/troubleshooting
+#
+set -uo pipefail
+set +e
+RAW_OUTPUT=${RAW_OUTPUT:?'Missing the release manager output file'}
+REPORT=${REPORT:?'Missing the release manager report file'}
+
+if [ -f "$RAW_OUTPUT" ] ; then
+    echo "There are some errors, let's guess what they are about:" > "$REPORT"
+    if grep 'Vault responded with HTTP status code' "$RAW_OUTPUT" ; then
+        echo 'Environmental issue with Vault. Try again' >> "$REPORT"
+    fi
+    if grep 'Cannot write to file' "$RAW_OUTPUT" ; then
+        echo 'Artifacts were not generated. Likely a genuine issue' >> "$REPORT"
+    fi
+    if grep 'does not exist' "$RAW_OUTPUT" ; then
+        echo 'Build file does not exist in the unified release. Likely the branch is not supported yet. Contact the release platform team' >> "$REPORT"
+    fi
+else
+    echo "WARN: $RAW_OUTPUT does not exist"
+fi

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -569,6 +569,11 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     helper.registerAllowedMethod('preCommitToJunit', [Map.class], null)
     helper.registerAllowedMethod('publishHTML', [Map.class],  null)
     helper.registerAllowedMethod('randomNumber', [Map.class], { m -> return m.min })
+    helper.registerAllowedMethod('releaseManagerAnalyser', [Map.class], { "" })
+    helper.registerAllowedMethod('releaseNotification', [Map.class], { m ->
+      def script = loadScript('vars/releaseNotification.groovy')
+      return script.call(m)
+    })
     helper.registerAllowedMethod('retryWithSleep', [Map.class, Closure.class], { m, c ->
       def script = loadScript('vars/retryWithSleep.groovy')
       return script.call(m, c)

--- a/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class ReleaseManagerAnalyserStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/releaseManagerAnalyser.groovy')
+  }
+
+  @Test
+  void test() throws Exception {
+    script.call(file: 'report.txt')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'RAW_OUTPUT=report.txt, REPORT=release-manager-report.out'))
+    assertTrue(assertMethodCallOccurrences('setEnvVar', 1))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_missing_file() throws Exception {
+    testMissingArgument('file') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_windows() throws Exception {
+    testWindows() {
+      script.call()
+    }
+  }
+
+}

--- a/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
@@ -26,14 +26,18 @@ class ReleaseManagerAnalyserStepTests extends ApmBasePipelineTest {
   void setUp() throws Exception {
     super.setUp()
     script = loadScript('vars/releaseManagerAnalyser.groovy')
+    helper.registerAllowedMethod('readFile', [Map.class], { '''
+There were some errors while running the release manager, let's analyse them.
+* Environmental issue with Vault. Try again.
+'''})
   }
 
   @Test
   void test() throws Exception {
-    script.call(file: 'report.txt')
+    def ret = script.call(file: 'report.txt')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withEnv', 'RAW_OUTPUT=report.txt, REPORT=release-manager-report.out'))
-    assertTrue(assertMethodCallOccurrences('setEnvVar', 1))
+    assertTrue(ret.contains('Try again'))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/ReleaseManagerNotificationStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerNotificationStepTests.groovy
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class ReleaseManagerNotificationStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/releaseManagerNotification.groovy')
+    addEnvVar('SLACK_CHANNEL', '#foo')
+    addEnvVar('NOTIFY_TO', 'to@acme.com')
+  }
+
+  @Test
+  void test() throws Exception {
+    def ret = script.call(file: 'report.txt', body: 'my-body', subject: 'my-subject')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=#foo, color=null, message=my-subject. my-body'))
+    assertTrue(assertMethodCallContainsPattern('emailext', 'subject=my-subject, to=to@acme.com, body=my-body'))
+    assertTrue(assertMethodCallOccurrences('releaseManagerAnalyser', 0))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_analyse_and_failures() throws Exception {
+    helper.registerAllowedMethod('releaseManagerAnalyser', [Map.class], { 'There were some errors while running the release manager.'})
+    script.call(file: 'report.txt', body: 'my-body', subject: 'my-subject', analyse: true)
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('releaseManagerAnalyser', 1))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=#foo, color=null, message=my-subject. my-body'))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'There were some errors while running the release manager'))
+    assertTrue(assertMethodCallContainsPattern('emailext', 'subject=my-subject, to=to@acme.com, body=my-body'))
+    assertTrue(assertMethodCallContainsPattern('emailext', 'There were some errors while running the release manager'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_analyse_and_without_failures() throws Exception {
+    helper.registerAllowedMethod('releaseManagerAnalyser', [Map.class], { '' })
+    script.call(file: 'report.txt', body: 'my-body', subject: 'my-subject', analyse: true)
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('releaseManagerAnalyser', 1))
+    assertTrue(assertMethodCallContainsPattern('slackSend', 'channel=#foo, color=null, message=my-subject. my-body, tokenCredentialId='))
+    assertTrue(assertMethodCallContainsPattern('emailext', '{subject=my-subject, to=to@acme.com, body=my-body}'))
+    assertJobStatusSuccess()
+  }
+}

--- a/vars/releaseManagerAnalyser.groovy
+++ b/vars/releaseManagerAnalyser.groovy
@@ -27,6 +27,6 @@ def call(Map args = [:]) {
   def output = args.containsKey('file') ? args.file : error('releaseManagerAnalyser: file parameter is required.')
   withEnv(["RAW_OUTPUT=${output}", "REPORT=${reportFile}"]) {
     sh(label: 'Release Manager analyser', script: libraryResource('scripts/release-manager-analyser.sh'))
-    setEnvVar('DIGESTED_MESSAGE', "${readFile(file: '${reportFile}')}")
+    setEnvVar('DIGESTED_MESSAGE', readFile(file: reportFile))
   }
 }

--- a/vars/releaseManagerAnalyser.groovy
+++ b/vars/releaseManagerAnalyser.groovy
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Given the release manager output then it analyseS the failure if any, and provides
+an environment variable, DIGESTED_MESSAGE, with the digested output to the end user.
+*/
+def call(Map args = [:]) {
+  if(!isUnix()){
+    error('releaseManagerAnalyser: windows is not supported yet.')
+  }
+  def reportFile = 'release-manager-report.out'
+  def output = args.containsKey('file') ? args.file : error('releaseManagerAnalyser: file parameter is required.')
+  withEnv(["RAW_OUTPUT=${output}", "REPORT=${reportFile}"]) {
+    sh(label: 'Release Manager analyser', script: libraryResource('scripts/release-manager-analyser.sh'))
+    setEnvVar('DIGESTED_MESSAGE', "${readFile(file: '${reportFile}')}")
+  }
+}

--- a/vars/releaseManagerAnalyser.groovy
+++ b/vars/releaseManagerAnalyser.groovy
@@ -16,17 +16,19 @@
 // under the License.
 
 /**
-Given the release manager output then it analyseS the failure if any, and provides
-an environment variable, DIGESTED_MESSAGE, with the digested output to the end user.
+Given the release manager output then it analyses the failure if any, and returns
+the digested output to the end user.
 */
 def call(Map args = [:]) {
   if(!isUnix()){
     error('releaseManagerAnalyser: windows is not supported yet.')
   }
+  def ret = ''
   def reportFile = 'release-manager-report.out'
   def output = args.containsKey('file') ? args.file : error('releaseManagerAnalyser: file parameter is required.')
   withEnv(["RAW_OUTPUT=${output}", "REPORT=${reportFile}"]) {
     sh(label: 'Release Manager analyser', script: libraryResource('scripts/release-manager-analyser.sh'))
-    setEnvVar('DIGESTED_MESSAGE', readFile(file: reportFile))
+    ret = readFile(file: reportFile)
   }
+  return ret
 }

--- a/vars/releaseManagerAnalyser.txt
+++ b/vars/releaseManagerAnalyser.txt
@@ -1,17 +1,9 @@
-Given the release manager output then it analyseS the failure if any, and provides
-an environment variable, `DIGESTED_MESSAGE`, with the digested output to the end user.
+Given the release manager output then it analyses the failure if any, and returns
+the digested output to the end user.
 
 ```
-
 // analyse the release manager build output
-releaseManagerAnalyser(file: 'release-manager.out')
-
-// send an email\slack with the diggested message
-releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
-                      slackColor: args.slackStatus,
-                      slackCredentialsId: 'jenkins-slack-integration-token',
-                      to: "${env.NOTIFY_TO}",
-                      body: "${DIGESTED_MESSAGE}")
+def output = releaseManagerAnalyser(file: 'release-manager.out')
 
 ```
 

--- a/vars/releaseManagerAnalyser.txt
+++ b/vars/releaseManagerAnalyser.txt
@@ -1,0 +1,18 @@
+Given the release manager output then it analyseS the failure if any, and provides
+an environment variable, `DIGESTED_MESSAGE`, with the digested output to the end user.
+
+```
+
+// analyse the release manager build output
+releaseManagerAnalyser(file: 'release-manager.out')
+
+// send an email\slack with the diggested message
+releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      body: "${DIGESTED_MESSAGE}")
+
+```
+
+* file: the file with the release manager output. Mandatory.

--- a/vars/releaseManagerNotification.groovy
+++ b/vars/releaseManagerNotification.groovy
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Send notifications with the release manager status by email and slack
+in addition to analyse the release manager output to find any known
+errors.
+*/
+def call(Map args = [:]) {
+
+  def newArgs = args
+  // if enabled and digested data then append the output.
+  if (args.get('analyse', false)) {
+    def digestedBuild = releaseManagerAnalyser(file: args.file)
+    if (digestedBuild.trim()) {
+      newArgs.body = args.body + "\n${digestedBuild}"
+    }
+  }
+  releaseNotification(newArgs)
+}

--- a/vars/releaseManagerNotification.txt
+++ b/vars/releaseManagerNotification.txt
@@ -1,10 +1,13 @@
-Given the release manager output then it analyses the failure if any, and returns
-the digested output to the end user.
+Send notifications with the release manager status by email and slack
+in addition to analyse the release manager output to find any known
+errors.
 
 ```
-// analyse the release manager build output
-def output = releaseManagerAnalyser(file: 'release-manager.out')
-
+releaseManagerNotification(slackColor: 'danger',
+                           analyse: true,
+                           file: 'release-manager-output.txt'
+                           subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed",
+                           body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
 ```
 
 * file: the file with the release manager output. Mandatory.

--- a/vars/releaseManagerNotification.txt
+++ b/vars/releaseManagerNotification.txt
@@ -1,0 +1,17 @@
+Given the release manager output then it analyses the failure if any, and returns
+the digested output to the end user.
+
+```
+// analyse the release manager build output
+def output = releaseManagerAnalyser(file: 'release-manager.out')
+
+```
+
+* file: the file with the release manager output. Mandatory.
+* analyse: whether to analyse the release manager output to look for kwown errors. Optional.
+* body: this is the body email that will be also added to the subject when using slack notifications. Optional
+* slackChannel: the slack channel, multiple channels may be provided as a comma, semicolon, or space delimited string. Default `env.SLACK_CHANNEL`
+* slackColor: an optional value that can either be one of good, warning, danger, or any hex color code (eg. #439FE0)
+* slackCredentialsId: the slack credentialsId. Default 'jenkins-slack-integration-token'
+* subject: this is subject email that will be also aggregated to the body when using slack notifications. Optional
+* to: who should receive an email. Default `env.NOTIFY_TO`


### PR DESCRIPTION
## What does this PR do?

Centralise the releaseManagerAnalyser and releaseManagerNotification steps

## Why is it important?

Help consumers to use the pipeline step then they don't need to worry about implementing anything but using the releaseManagerNotification step to notify and enrich the details with the analyser output

## Related issues

Closes https://github.com/elastic/apm-server/pull/7663 as it will use the new step instead


## Test


![image](https://user-images.githubusercontent.com/2871786/160394829-654a221a-86e3-4446-a2f0-34f9b5f43fd0.png)


![image](https://user-images.githubusercontent.com/2871786/160394851-1525f3be-654e-4178-bd9f-fcd3d80ed3ac.png)


<img width="1905" alt="image" src="https://user-images.githubusercontent.com/2871786/160395100-aceb6acb-6d25-42c5-812a-328469377c14.png">
