### PR TITLE
Add releaseManager step

### DIFF
--- a/resources/scripts/release-manager.sh
+++ b/resources/scripts/release-manager.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# This script is executed by the DRA stage.
+# It requires the below environment variables:
+# - BRANCH_NAME, the project branch
+# - PROJECT, the release manager project
+# - TYPE, the type of release (snapshot or staging)
+# - VERSION, the version (either a release or a snapshot)
+# - FOLDER, the relative folder where the binaries are stored
+# - VAULT_ADDR
+# - VAULT_ROLE_ID
+# - VAULT_SECRET_ID
+#
+# It uses env variables to help to run this script with a simpler jenkins
+# pipeline call.
+#
+set -uexo pipefail
+
+readonly TYPE=${TYPE:-snapshot}
+# shellcheck source=/dev/null
+source /usr/local/bin/bash_standard_lib.sh
+
+# set required permissions on artifacts and directory
+chmod -R a+r "$FOLDER"/*
+chmod -R a+w "$FOLDER"
+
+# ensure the latest image has been pulled
+IMAGE=docker.elastic.co/infra/release-manager:latest
+(retry 3 docker pull --quiet "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
+docker images --filter=reference=$IMAGE
+
+# Generate checksum files and upload to GCS
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID \
+  -e VAULT_SECRET_ID \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  "$IMAGE" \
+    cli collect \
+      --project "${PROJECT}" \
+      --branch "${BRANCH_NAME}" \
+      --commit "$(git rev-parse HEAD)" \
+      --workflow "${TYPE}" \
+      --artifact-set main \
+      --version "${VERSION}"

--- a/resources/scripts/release-manager.sh
+++ b/resources/scripts/release-manager.sh
@@ -7,6 +7,7 @@
 # - TYPE, the type of release (snapshot or staging)
 # - VERSION, the version (either a release or a snapshot)
 # - FOLDER, the relative folder where the binaries are stored
+# - OUTPUT_FILE, the file where the logs are stored.
 # - VAULT_ADDR
 # - VAULT_ROLE_ID
 # - VAULT_SECRET_ID
@@ -17,6 +18,8 @@
 set -uexo pipefail
 
 readonly TYPE=${TYPE:-snapshot}
+readonly OUTPUT_FILE=${OUTPUT_FILE:-release-manager-report.out}
+
 # shellcheck source=/dev/null
 source /usr/local/bin/bash_standard_lib.sh
 
@@ -43,4 +46,4 @@ docker run --rm \
       --commit "$(git rev-parse HEAD)" \
       --workflow "${TYPE}" \
       --artifact-set main \
-      --version "${VERSION}"
+      --version "${VERSION}" | tee "$OUTPUT_FILE"

--- a/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerAnalyserStepTests.groovy
@@ -36,7 +36,7 @@ There were some errors while running the release manager, let's analyse them.
   void test() throws Exception {
     def ret = script.call(file: 'report.txt')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'RAW_OUTPUT=report.txt, REPORT=release-manager-report.out'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'RAW_OUTPUT=report.txt, REPORT=folder/release-manager-report.out'))
     assertTrue(ret.contains('Try again'))
     assertJobStatusSuccess()
   }

--- a/src/test/groovy/ReleaseManagerStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerStepTests.groovy
@@ -32,16 +32,16 @@ class ReleaseManagerStepTests extends ApmBasePipelineTest {
   void test_defaults() throws Exception {
     script.call(project: 'apm-server', version: '1.2.3-SNAPSHOT')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=apm-server, TYPE=snapshot, VERSION=1.2.3-SNAPSHOT, FOLDER=build/distribution'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=apm-server, TYPE=snapshot, VERSION=1.2.3-SNAPSHOT-SNAPSHOT, FOLDER=build/distribution, OUTPUT_FILE=release-manager-report.out'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
     assertJobStatusSuccess()
   }
 
   @Test
   void test_with_all_values() throws Exception {
-    script.call(project: 'beats', version: '1.2.3', type: 'staging', artifactsFolder: 'build/dist')
+    script.call(project: 'beats', version: '1.2.3', type: 'staging', artifactsFolder: 'build/dist', outputFile: 'foo.txt')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=beats, TYPE=staging, VERSION=1.2.3, FOLDER=build/dist'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=beats, TYPE=staging, VERSION=1.2.3, FOLDER=build/dist, OUTPUT_FILE=foo.txt'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
     assertJobStatusSuccess()
   }

--- a/src/test/groovy/ReleaseManagerStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerStepTests.groovy
@@ -30,9 +30,9 @@ class ReleaseManagerStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_defaults() throws Exception {
-    script.call(project: 'apm-server', version: '1.2.3-SNAPSHOT')
+    script.call(project: 'apm-server', version: '1.2.3')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=apm-server, TYPE=snapshot, VERSION=1.2.3-SNAPSHOT-SNAPSHOT, FOLDER=build/distribution, OUTPUT_FILE=release-manager-report.out'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=apm-server, TYPE=snapshot, VERSION=1.2.3, FOLDER=build/distribution, OUTPUT_FILE=release-manager-report.out'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
     assertJobStatusSuccess()
   }
@@ -44,6 +44,17 @@ class ReleaseManagerStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=beats, TYPE=staging, VERSION=1.2.3, FOLDER=build/dist, OUTPUT_FILE=foo.txt'))
     assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
     assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_snapshot() throws Exception {
+    try {
+      script.call(project: 'apm-server', version: '1.2.3-SNAPSHOT')
+    } catch(e) {
+      // NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', '-SNAPSHOT'))
   }
 
   @Test

--- a/src/test/groovy/ReleaseManagerStepTests.groovy
+++ b/src/test/groovy/ReleaseManagerStepTests.groovy
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+
+class ReleaseManagerStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/releaseManager.groovy')
+  }
+
+  @Test
+  void test_defaults() throws Exception {
+    script.call(project: 'apm-server', version: '1.2.3-SNAPSHOT')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=apm-server, TYPE=snapshot, VERSION=1.2.3-SNAPSHOT, FOLDER=build/distribution'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_all_values() throws Exception {
+    script.call(project: 'beats', version: '1.2.3', type: 'staging', artifactsFolder: 'build/dist')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PROJECT=beats, TYPE=staging, VERSION=1.2.3, FOLDER=build/dist'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'Release Manager'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_missing_project() throws Exception {
+    testMissingArgument('project') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_with_missing_version() throws Exception {
+    testMissingArgument('version') {
+      script.call(project: 'foo')
+    }
+  }
+
+  @Test
+  void test_windows() throws Exception {
+    testWindows() {
+      script.call()
+    }
+  }
+
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -2666,6 +2666,7 @@ releaseManager(project: 'apm-server',
 * version:  the version (either a release or a snapshot). Mandatory.
 * type: the type of release (snapshot or staging). Default 'snapshot'. Optional.
 * artifactsFolder: the relative folder where the binaries are stored. Default 'build/distribution'. Optional
+* outputFile: the file where the log output is stored to. Default 'release-manager-report.out'. Optional
 
 ## releaseManagerAnalyser
 Given the release manager output then it analyses the failure if any, and returns

--- a/vars/README.md
+++ b/vars/README.md
@@ -981,6 +981,7 @@ Make a REST API call to Github. It manage to hide the call and the token in the 
 * method: what kind of request. Default 'POST' when using the data parameter. Optional.
 * data: Data to post to the API. Pass as a Map.
 * noCache: whether to force the API call without the already cached data if any. Default false.
+* failNever: NEVER fail the step, regardless of step result
 
 [Github REST API](https://developer.github.com/v3/)
 
@@ -1737,6 +1738,15 @@ Check if the build was triggered by a Branch index.
 
 ```
 def branchIndexTrigger = isBranchIndexTrigger()
+```
+
+## isBranchUnifiedReleaseAvailable
+Whether the given branch is an active branch in the unified release
+
+```
+whenTrue(isBranchUnifiedReleaseAvailable('main')) {
+  //
+}
 ```
 
 ## isBuildFailure
@@ -2635,6 +2645,61 @@ def value = randomString(size: 15)
 ```
 
 * size: the random string size.
+
+## releaseManager
+Given the project, release type and version it runs the release manager
+
+```
+// release a snapshot 8.2.0-SNAPSHOT for the APM Server and pick the files from build/dist
+releaseManager(project: 'apm-server',
+               version: '8.2.0-SNAPSHOT',
+               type: 'snapshot',
+               artifactsFolder: 'build/dist')
+
+// release a staging 8.2.0 for the APM Server
+releaseManager(project: 'apm-server',
+               version: '8.2.0',
+               type: 'staging')
+```
+
+* project: the release manager project. Mandatory.
+* version:  the version (either a release or a snapshot). Mandatory.
+* type: the type of release (snapshot or staging). Default 'snapshot'. Optional.
+* artifactsFolder: the relative folder where the binaries are stored. Default 'build/distribution'. Optional
+
+## releaseManagerAnalyser
+Given the release manager output then it analyses the failure if any, and returns
+the digested output to the end user.
+
+```
+// analyse the release manager build output
+def output = releaseManagerAnalyser(file: 'release-manager.out')
+
+```
+
+* file: the file with the release manager output. Mandatory.
+
+## releaseManagerNotification
+Send notifications with the release manager status by email and slack
+in addition to analyse the release manager output to find any known
+errors.
+
+```
+releaseManagerNotification(slackColor: 'danger',
+                           analyse: true,
+                           file: 'release-manager-output.txt'
+                           subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed",
+                           body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+```
+
+* file: the file with the release manager output. Mandatory.
+* analyse: whether to analyse the release manager output to look for kwown errors. Optional.
+* body: this is the body email that will be also added to the subject when using slack notifications. Optional
+* slackChannel: the slack channel, multiple channels may be provided as a comma, semicolon, or space delimited string. Default `env.SLACK_CHANNEL`
+* slackColor: an optional value that can either be one of good, warning, danger, or any hex color code (eg. #439FE0)
+* slackCredentialsId: the slack credentialsId. Default 'jenkins-slack-integration-token'
+* subject: this is subject email that will be also aggregated to the body when using slack notifications. Optional
+* to: who should receive an email. Default `env.NOTIFY_TO`
 
 ## releaseNotification
 Send notifications with the release status by email and slack.

--- a/vars/README.md
+++ b/vars/README.md
@@ -2650,9 +2650,9 @@ def value = randomString(size: 15)
 Given the project, release type and version it runs the release manager
 
 ```
-// release a snapshot 8.2.0-SNAPSHOT for the APM Server and pick the files from build/dist
+// release a snapshot 8.2.0 for the APM Server and pick the files from build/dist
 releaseManager(project: 'apm-server',
-               version: '8.2.0-SNAPSHOT',
+               version: '8.2.0',
                type: 'snapshot',
                artifactsFolder: 'build/dist')
 

--- a/vars/releaseManager.groovy
+++ b/vars/releaseManager.groovy
@@ -31,7 +31,6 @@ def call(Map args = [:]) {
   if (version.contains('-SNAPSHOT')) {
     error('releaseManager: version parameter cannot contain the suffix -SNAPSHOT.')
   }
-
   withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}", "OUTPUT_FILE=${outputFile}"]) {
     getVaultSecret.readSecretWrapper {
       sh(label: 'Release Manager', script: libraryResource('scripts/release-manager.sh'))

--- a/vars/releaseManager.groovy
+++ b/vars/releaseManager.groovy
@@ -26,8 +26,13 @@ def call(Map args = [:]) {
   def version = args.containsKey('version') ? args.version : error('releaseManager: version parameter is required.')
   def type = args.get('type', 'snapshot')
   def artifactsFolder = args.get('artifactsFolder', 'build/distribution')
+  def outputFile = args.get('outputFile', 'release-manager-report.out')
 
-  withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}"]) {
+  if (type.equals('snapshot')) {
+    version = version + '-SNAPSHOT'
+  }
+
+  withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}", "OUTPUT_FILE=${outputFile}"]) {
     sh(label: 'Release Manager', script: libraryResource('scripts/release-manager.sh'))
   }
 }

--- a/vars/releaseManager.groovy
+++ b/vars/releaseManager.groovy
@@ -28,8 +28,8 @@ def call(Map args = [:]) {
   def artifactsFolder = args.get('artifactsFolder', 'build/distribution')
   def outputFile = args.get('outputFile', 'release-manager-report.out')
 
-  if (type.equals('snapshot')) {
-    version = version + '-SNAPSHOT'
+  if (version.contains('-SNAPSHOT')) {
+    error('releaseManager: version parameter cannot contain the suffix -SNAPSHOT.')
   }
 
   withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}", "OUTPUT_FILE=${outputFile}"]) {

--- a/vars/releaseManager.groovy
+++ b/vars/releaseManager.groovy
@@ -33,6 +33,8 @@ def call(Map args = [:]) {
   }
 
   withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}", "OUTPUT_FILE=${outputFile}"]) {
-    sh(label: 'Release Manager', script: libraryResource('scripts/release-manager.sh'))
+    getVaultSecret.readSecretWrapper {
+      sh(label: 'Release Manager', script: libraryResource('scripts/release-manager.sh'))
+    }
   }
 }

--- a/vars/releaseManager.groovy
+++ b/vars/releaseManager.groovy
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Given the project, release type and version it runs the release manager
+*/
+def call(Map args = [:]) {
+  if(!isUnix()){
+    error('releaseManager: windows is not supported yet.')
+  }
+  def project = args.containsKey('project') ? args.project : error('releaseManager: project parameter is required.')
+  def version = args.containsKey('version') ? args.version : error('releaseManager: version parameter is required.')
+  def type = args.get('type', 'snapshot')
+  def artifactsFolder = args.get('artifactsFolder', 'build/distribution')
+
+  withEnv(["PROJECT=${project}", "TYPE=${type}", "VERSION=${version}", "FOLDER=${artifactsFolder}"]) {
+    sh(label: 'Release Manager', script: libraryResource('scripts/release-manager.sh'))
+  }
+}

--- a/vars/releaseManager.txt
+++ b/vars/releaseManager.txt
@@ -1,0 +1,19 @@
+Given the project, release type and version it runs the release manager
+
+```
+// release a snapshot 8.2.0-SNAPSHOT for the APM Server and pick the files from build/dist
+releaseManager(project: 'apm-server',
+               version: '8.2.0-SNAPSHOT',
+               type: 'snapshot',
+               artifactsFolder: 'build/dist')
+
+// release a staging 8.2.0 for the APM Server
+releaseManager(project: 'apm-server',
+               version: '8.2.0',
+               type: 'staging')
+```
+
+* project: the release manager project. Mandatory.
+* version:  the version (either a release or a snapshot). Mandatory.
+* type: the type of release (snapshot or staging). Default 'snapshot'. Optional.
+* artifactsFolder: the relative folder where the binaries are stored. Default 'build/distribution'. Optional

--- a/vars/releaseManager.txt
+++ b/vars/releaseManager.txt
@@ -1,9 +1,9 @@
 Given the project, release type and version it runs the release manager
 
 ```
-// release a snapshot 8.2.0-SNAPSHOT for the APM Server and pick the files from build/dist
+// release a snapshot 8.2.0 for the APM Server and pick the files from build/dist
 releaseManager(project: 'apm-server',
-               version: '8.2.0-SNAPSHOT',
+               version: '8.2.0',
                type: 'snapshot',
                artifactsFolder: 'build/dist')
 

--- a/vars/releaseManager.txt
+++ b/vars/releaseManager.txt
@@ -17,3 +17,4 @@ releaseManager(project: 'apm-server',
 * version:  the version (either a release or a snapshot). Mandatory.
 * type: the type of release (snapshot or staging). Default 'snapshot'. Optional.
 * artifactsFolder: the relative folder where the binaries are stored. Default 'build/distribution'. Optional
+* outputFile: the file where the log output is stored to. Default 'release-manager-report.out'. Optional

--- a/vars/releaseManagerAnalyser.groovy
+++ b/vars/releaseManagerAnalyser.groovy
@@ -24,8 +24,8 @@ def call(Map args = [:]) {
     error('releaseManagerAnalyser: windows is not supported yet.')
   }
   def ret = ''
-  def reportFile = 'release-manager-report.out'
   def output = args.containsKey('file') ? args.file : error('releaseManagerAnalyser: file parameter is required.')
+  def reportFile = "${pwd(tmp: true)}/release-manager-report.out"
   withEnv(["RAW_OUTPUT=${output}", "REPORT=${reportFile}"]) {
     sh(label: 'Release Manager analyser', script: libraryResource('scripts/release-manager-analyser.sh'))
     ret = readFile(file: reportFile)

--- a/vars/releaseManagerAnalyser.groovy
+++ b/vars/releaseManagerAnalyser.groovy
@@ -28,7 +28,9 @@ def call(Map args = [:]) {
   def reportFile = "${pwd(tmp: true)}/release-manager-report.out"
   withEnv(["RAW_OUTPUT=${output}", "REPORT=${reportFile}"]) {
     sh(label: 'Release Manager analyser', script: libraryResource('scripts/release-manager-analyser.sh'))
-    ret = readFile(file: reportFile)
+    if (fileExists("${reportFile}")) {
+      ret = readFile(file: reportFile)
+    }
   }
   return ret
 }


### PR DESCRIPTION
## What does this PR do?

Centralise the release manager step in a shared library

## Why is it important?

Simplify the consumers since they will just call a step in the pipeline. This step is not needed to run locally at all.

## Further details


I decided to use a script with env variables rather than using a script with parameters since it will run within the jenkins step and it reduces the number of steps to be able to use it, from

```
  def resourceContent = libraryResource("my-script")
  writeFile file: scriptFile, text: resourceContent
  sh(script: """#!/bin/bash +x
            chmod 755 my-script
            ./my-script param1 param2""")
```

to

```
  withEnv(["PARAM1=XXX", "PARAM2=YYY"]) {
    sh(script: libraryResource('my-script'))
  }
```

### Test

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/2871786/160859228-07fa6274-5d42-4e71-af4d-2e930034d443.png">
