### PR TITLE
Update junit2otel step

### DIFF
--- a/src/test/groovy/Junit2OtelStepTests.groovy
+++ b/src/test/groovy/Junit2OtelStepTests.groovy
@@ -28,8 +28,6 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
   void setUp() throws Exception {
     super.setUp()
 
-    env.JUNIT_2_OTLP = "true"
-
     helper.registerAllowedMethod('isInstalled', [Map.class], { return true })
     helper.registerAllowedMethod('isUnix', [], { true })
 
@@ -196,18 +194,6 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myrepo-v1.2.3-myrepo'"))
     assertTrue(assertMethodCallContainsPattern('libraryResource', 'scripts/junit2otel.sh'))
-    assertJobStatusSuccess()
-  }
-
-  @Test
-  void test_results_without_feature_flag() throws Exception {
-    env.JUNIT_2_OTLP = ""
-
-    script.call(testResults: 'test-results/TEST-*.xml')
-
-    printCallStack()
-    assertFalse(assertMethodCallContainsPattern('log', "Sending traces for 'junit2otel-unknown-junit2otel'"))
-    assertFalse(assertMethodCallContainsPattern('libraryResource', 'scripts/junit2otel.sh'))
     assertJobStatusSuccess()
   }
 

--- a/src/test/groovy/Junit2OtelStepTests.groovy
+++ b/src/test/groovy/Junit2OtelStepTests.groovy
@@ -99,10 +99,7 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_results_with_otel_variables() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
-    env.JUNIT_OTEL_SERVICE_VERSION = "1.2.3"
-    env.JUNIT_OTEL_TRACE_NAME = "mytrace"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice', serviceVersion: '1.2.3', traceName: 'mytrace')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-1.2.3-mytrace'"))
@@ -112,10 +109,8 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_results_with_otel_and_branch_version() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
     env.BRANCH_NAME = "feature/foo"
-    env.JUNIT_OTEL_TRACE_NAME = "mytrace"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice', traceName: 'mytrace')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-feature/foo-mytrace'"))
@@ -125,10 +120,8 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_results_with_otel_and_pr_version() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
     env.CHANGE_ID = "PR-123"
-    env.JUNIT_OTEL_TRACE_NAME = "mytrace"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice', traceName: 'mytrace')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-PR-123-mytrace'"))
@@ -138,10 +131,8 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_results_with_otel_and_tag_version() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
     env.TAG_NAME = "v1.2.3"
-    env.JUNIT_OTEL_TRACE_NAME = "mytrace"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice', traceName: 'mytrace')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-v1.2.3-mytrace'"))
@@ -152,8 +143,7 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
   @Test
   void test_results_with_repo_variables() throws Exception {
     env.REPO = "myrepo"
-    env.JUNIT_OTEL_SERVICE_VERSION = "1.2.3"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceVersion: '1.2.3')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myrepo-1.2.3-myrepo'"))
@@ -199,8 +189,7 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_service_name() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-master-junit2otel'"))
@@ -209,9 +198,8 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_service_name_and_repo() throws Exception {
-    env.JENKINS_OTEL_SERVICE_NAME = "myservice"
     env.REPO = "myrepo"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceName: 'myservice')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'myservice-junit-master-myrepo'"))
@@ -220,8 +208,7 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_service_version() throws Exception {
-    env.JUNIT_OTEL_SERVICE_VERSION = "1.2.3"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', serviceVersion: '1.2.3')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'junit2otel-1.2.3-junit2otel'"))
@@ -230,8 +217,7 @@ class Junit2OtelStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_trace_name() throws Exception {
-    env.JUNIT_OTEL_TRACE_NAME = "mytrace"
-    script.call(testResults: 'test-results/TEST-*.xml')
+    script.call(testResults: 'test-results/TEST-*.xml', traceName: 'mytrace')
 
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('log', "Sending traces for 'junit2otel-master-mytrace'"))

--- a/vars/junit2otel.groovy
+++ b/vars/junit2otel.groovy
@@ -31,7 +31,6 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
                     always {
                         // JUnit with OpenTelemetry traces
                         withEnv([
-                          "JUNIT_2_OTLP=true",
                           "OTEL_SERVICE_NAME=apm-pipeline-library",
                           "JUNIT_OTEL_SERVICE_VERSION=main",
                           "JUNIT_OTEL_TRACE_NAME=junit-tests"
@@ -55,33 +54,29 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
 
 */
 def call(Map args = [:]) {
-  def sendTraces = env.JUNIT_2_OTLP?.trim() ? true : false
+  if(!isUnix()){
+    error('junit: windows is not supported yet.')
+  }
 
-  if (sendTraces) {
-    if(!isUnix()){
-      error('junit: windows is not supported yet.')
-    }
+  if(!isInstalled(tool: 'docker', flag: '--version')) {
+    error('junit2otel: docker is not installed but required.')
+  }
 
-    if(!isInstalled(tool: 'docker', flag: '--version')) {
-      error('junit2otel: docker is not installed but required.')
-    }
+  withOtelEnv() {
+    def testResults = args.containsKey('testResults') ? args.testResults : error("junit2otel: testResults parameter is required.")
+    def serviceName = env.JENKINS_OTEL_SERVICE_NAME?.trim() ? env.JENKINS_OTEL_SERVICE_NAME?.trim()+"-junit" : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
+    def serviceVersion = env.JUNIT_OTEL_SERVICE_VERSION?.trim() ? env.JUNIT_OTEL_SERVICE_VERSION?.trim() : calculateFallbackServiceVersion()
+    def traceName = env.JUNIT_OTEL_TRACE_NAME?.trim() ? env.JUNIT_OTEL_TRACE_NAME?.trim() : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
 
-    withOtelEnv() {
-      def testResults = args.containsKey('testResults') ? args.testResults : error("junit2otel: testResults parameter is required.")
-      def serviceName = env.JENKINS_OTEL_SERVICE_NAME?.trim() ? env.JENKINS_OTEL_SERVICE_NAME?.trim()+"-junit" : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
-      def serviceVersion = env.JUNIT_OTEL_SERVICE_VERSION?.trim() ? env.JUNIT_OTEL_SERVICE_VERSION?.trim() : calculateFallbackServiceVersion()
-      def traceName = env.JUNIT_OTEL_TRACE_NAME?.trim() ? env.JUNIT_OTEL_TRACE_NAME?.trim() : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
-
-      withEnv([
-        "SERVICE_NAME=${serviceName}",
-        "SERVICE_VERSION=${serviceVersion}",
-        "TEST_RESULTS_GLOB=${testResults}",
-        "TRACE_NAME=${traceName}",
-        "TRACEPARENT=00-${env.TRACE_ID}-${env.SPAN_ID}-01"
-      ]){
-        log(level: 'INFO', text: "Sending traces for '${serviceName}-${serviceVersion}-${traceName}'")
-        sh(label: 'Run junit2otlp to send traces and metrics', script: libraryResource("scripts/junit2otel.sh"))
-      }
+    withEnv([
+      "SERVICE_NAME=${serviceName}",
+      "SERVICE_VERSION=${serviceVersion}",
+      "TEST_RESULTS_GLOB=${testResults}",
+      "TRACE_NAME=${traceName}",
+      "TRACEPARENT=00-${env.TRACE_ID}-${env.SPAN_ID}-01"
+    ]){
+      log(level: 'INFO', text: "Sending traces for '${serviceName}-${serviceVersion}-${traceName}'")
+      sh(label: 'Run junit2otlp to send traces and metrics', script: libraryResource("scripts/junit2otel.sh"))
     }
   }
 

--- a/vars/junit2otel.groovy
+++ b/vars/junit2otel.groovy
@@ -64,9 +64,9 @@ def call(Map args = [:]) {
 
   withOtelEnv() {
     def testResults = args.containsKey('testResults') ? args.testResults : error("junit2otel: testResults parameter is required.")
-    def serviceName = env.JENKINS_OTEL_SERVICE_NAME?.trim() ? env.JENKINS_OTEL_SERVICE_NAME?.trim()+"-junit" : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
-    def serviceVersion = env.JUNIT_OTEL_SERVICE_VERSION?.trim() ? env.JUNIT_OTEL_SERVICE_VERSION?.trim() : calculateFallbackServiceVersion()
-    def traceName = env.JUNIT_OTEL_TRACE_NAME?.trim() ? env.JUNIT_OTEL_TRACE_NAME?.trim() : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
+    def serviceName = args.containsKey('serviceName') ? args.serviceName + "-junit" : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
+    def serviceVersion = args.containsKey('serviceVersion') ? args.serviceVersion : calculateFallbackServiceVersion()
+    def traceName = args.containsKey('traceName') ? args.traceName : (env.REPO?.trim() ? env.REPO?.trim() : 'junit2otel')
 
     withEnv([
       "SERVICE_NAME=${serviceName}",

--- a/vars/junit2otel.txt
+++ b/vars/junit2otel.txt
@@ -1,9 +1,9 @@
 Wrap the junit built-in step to send OpenTelemetry traces for the test reports that are going to be
 populated later on, using the https://github.com/mdelapenya/junit2otel library.
 
-1. If the REPO variable is set, but the OTEL_SERVICE_NAME is not, then REPO will be used as service name.
-2. If the REPO variable is set, but the JUNIT_OTEL_TRACE_NAME is not, then REPO will be used as trace name.
-3. If the JUNIT_OTEL_SERVICE_VERSION is not set, then it will use, in this particular order: pull-request ID, tag name and branch name. Else, it will use 'unknown'.
+1. If the REPO variable is set, but the serviceName attribute is not passed, then REPO will be used as service name.
+2. If the REPO variable is set, but the traceName attribute is not passed, then REPO will be used as trace name.
+3. If the serviceVersion attribute is not passed, then it will use, in this particular order: pull-request ID, tag name and branch name. Else, it will use 'unknown'.
 
 ```
 
@@ -14,13 +14,7 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
                 post {
                     always {
                         // JUnit with OpenTelemetry traces
-                        withEnv([
-                            "OTEL_SERVICE_NAME=apm-pipeline-library",
-                            "JUNIT_OTEL_SERVICE_VERSION=main",
-                            "JUNIT_OTEL_TRACE_NAME=junit-tests"
-                        ]){
-                            junit2otel(testResults: 'TEST-*.xml')
-                        }
+                        junit2otel(testResults: 'TEST-*.xml', serviceName: 'apm-pipeline-library', serviceVersion: 'main', traceName: 'junit-tests')
 
                         // JUnit with attributes inferred from Repository
                         withEnv([
@@ -36,6 +30,9 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
     }
 ```
 
+* *serviceName*: name of the service. Optional
+* *serviceVersion*: version of the service. Optional
+* *traceName*: name of the trace. Optional
 * *testResults*: from the `junit` step. Mandatory
 * *allowEmptyResults*: from the `junit` step. Optional
 * *keepLongStdio*: from the `junit` step. Optional

--- a/vars/junit2otel.txt
+++ b/vars/junit2otel.txt
@@ -15,7 +15,6 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
                     always {
                         // JUnit with OpenTelemetry traces
                         withEnv([
-                            "JUNIT_2_OTLP=true",
                             "OTEL_SERVICE_NAME=apm-pipeline-library",
                             "JUNIT_OTEL_SERVICE_VERSION=main",
                             "JUNIT_OTEL_TRACE_NAME=junit-tests"
@@ -25,7 +24,6 @@ populated later on, using the https://github.com/mdelapenya/junit2otel library.
 
                         // JUnit with attributes inferred from Repository
                         withEnv([
-                            "JUNIT_2_OTLP=true",
                             "REPO=apm-pipeline-library",
                         ]){
                             junit2otel(testResults: 'TEST-*.xml')


### PR DESCRIPTION
- chore: do not protect the step with a env var
- chore: do not pass environment variables, use attributes

## What does this PR do?
It uses attributes instead of env vars when invoking the junit2otel step.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
Consumers would need to use the step and its params, not setting up the environment accordingly, which is easier for them to mantain.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Completes #1543
