### PR TITLE
Automate release versions for 7 and last 8

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -78,19 +78,19 @@ pipeline {
 
 def fetchVersions() {
   // To store all the latest release versions
-  def latestVersions = artifactsApi(action: 'latest-release-versions')
-
-  def current7 = latestVersions.findAll { it ==~ /7\.\d+\.\d+/ }.sort().last()
-  def last8 = latestVersions.findAll { it ==~ /8\.\d+\.\d+/ }.sort().last()
-
+  def latestReleaseVersions = artifactsApi(action: 'latest-release-versions')
+  // To store all the latest release versions
+  def latestVersions = artifactsApi(action: 'latest-versions')
+  def current7 = latestReleaseVersions.findAll { it ==~ /7\.\d+\.\d+/ }.sort().last()
+  def current8 = latestVelatestReleaseVersionsrsions.findAll { it ==~ /8\.\d+\.\d+/ }.sort().last()
   // NOTE: 6 major branch is now EOL (we keep this for backward compatibility)
   releaseVersions[bumpUtils.current6Key()] = '6.8.23'
   releaseVersions[bumpUtils.current7Key()] = current7
   releaseVersions[bumpUtils.nextMinor7Key()] = increaseVersion(current7, 1)
   releaseVersions[bumpUtils.nextPatch7Key()] = increaseVersion(current7, 1)
-  releaseVersions[bumpUtils.current8Key()] = '8.1.0'
-  releaseVersions[bumpUtils.nextMinor8Key()] = '8.2.0'
-  releaseVersions[bumpUtils.nextPatch8Key()] = last8
+  releaseVersions[bumpUtils.current8Key()] = current8
+  releaseVersions[bumpUtils.nextMinor8Key()] = latestVersions.main.version.replaceAll('-SNAPSHOT','')
+  releaseVersions[bumpUtils.nextPatch8Key()] = increaseVersion(current8, 1)
 }
 
 def increaseVersion(version, i) {

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -54,7 +54,7 @@ pipeline {
     }
     stage('Fetch latest versions') {
       steps {
-        fetchVersion()
+        fetchVersions()
       }
     }
     stage('Send Pull Request'){

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -43,6 +43,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
+    booleanParam(name: 'FORCE', defaultValue: false, description: 'If true, skips the release version validation.')
   }
   stages {
     stage('Checkout') {
@@ -116,10 +117,14 @@ def createPullRequest(Map args = [:]) {
     return
   }
 
-  // In case docker images are not available yet, let's skip the PR automation.
-  if (!bumpUtils.areStackVersionsAvailable(args.stackVersions)) {
-    log(level: 'INFO', text: "Versions '${args.stackVersions}' are not available yet.")
-    return
+  if (params.FORCE) {
+    log(level: 'INFO', text: "Skip version validation.")
+  } else {
+    // In case docker images are not available yet, let's skip the PR automation.
+    if (!bumpUtils.areStackVersionsAvailable(args.stackVersions)) {
+      log(level: 'INFO', text: "Versions '${args.stackVersions}' are not available yet.")
+      return
+    }
   }
 
   if (bumpUtils.areChangesToBePushed("${args.branchName}")) {

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -82,7 +82,7 @@ def fetchVersions() {
   // To store all the latest release versions
   def latestVersions = artifactsApi(action: 'latest-versions')
   def current7 = latestReleaseVersions.findAll { it ==~ /7\.\d+\.\d+/ }.sort().last()
-  def current8 = latestVelatestReleaseVersionsrsions.findAll { it ==~ /8\.\d+\.\d+/ }.sort().last()
+  def current8 = latestReleaseVersions.findAll { it ==~ /8\.\d+\.\d+/ }.sort().last()
   // NOTE: 6 major branch is now EOL (we keep this for backward compatibility)
   releaseVersions[bumpUtils.current6Key()] = '6.8.23'
   releaseVersions[bumpUtils.current7Key()] = current7


### PR DESCRIPTION
### What

Automate the versions when a new release is out, for such it uses the `artifacts-api` in addition to the incremental patch version.

Add a FORCE flag to create the PR regardless if those versions have not been created yet, that's a common use case until the first snapshot build for `main` or `7.17` is not yet public available, with the new version.

### Test

This [build](https://apm-ci.elastic.co/job/apm-shared/job/update-stack-release-version-pipeline/118/) produced https://github.com/elastic/apm-pipeline-library/pull/1634