### PR TITLE
Fetch latest available release for the 8 major

### DIFF
--- a/src/test/groovy/BumpUtilsStepTests.groovy
+++ b/src/test/groovy/BumpUtilsStepTests.groovy
@@ -158,6 +158,13 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_getPatchFor7() throws Exception {
+    def result = script.getPatch('7.15.0')
+    printCallStack()
+    assertEquals(result, "0")
+  }
+
+  @Test
   void test_getMajorMinorFor7_with_wrong_format() throws Exception {
     try {
       result = script.getMajorMinor('7.15')
@@ -173,6 +180,30 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
   void test_getMajorMinor_with_empty_value() throws Exception {
     try {
       result = script.getMajorMinor('')
+    } catch(e) {
+      // NOOP
+      println e
+    }
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('error', 1))
+  }
+
+  @Test
+  void test_getPatch_with_empty_value() throws Exception {
+    try {
+      result = script.getPatch('')
+    } catch(e) {
+      // NOOP
+      println e
+    }
+    printCallStack()
+    assertTrue(assertMethodCallOccurrences('error', 1))
+  }
+
+  @Test
+  void test_getPatchFor7_with_wrong_format() throws Exception {
+    try {
+      result = script.getPatch('7.15')
     } catch(e) {
       // NOOP
       println e

--- a/vars/README.md
+++ b/vars/README.md
@@ -682,6 +682,14 @@ The more common use case is when there are two minor versions in development at 
 
 * branch: the branch name or supported pattern. Mandatory
 
+## getBranchUnifiedRelease
+Download the properties file for the given branch in the unified release
+
+```
+  // Download the properties file for the main branch
+  getBranchUnifiedRelease('8.1'))
+```
+
 ## getBranchesFromAliases
 This step parses the given list of branch aliases and return
 the branch name.

--- a/vars/bumpUtils.groovy
+++ b/vars/bumpUtils.groovy
@@ -76,6 +76,18 @@ def getMajorMinor(String version) {
   error('getMajorMinor: version is not major.minor.patch formatted')
 }
 
+def getPatch(String version) {
+  if (!version?.trim()) {
+    error('getPatch: version cannot be empty, please use the format major.minor.patch')
+  }
+  def parts = version?.split('\\.')
+  if (parts.size() == 3) {
+    return parts[2]
+  }
+  error('getPatch: version is not major.minor.patch formatted')
+}
+
+
 def getCurrentMinorReleaseFor8() {
   return getValueForPropertyKey(current8Key())
 }

--- a/vars/getBranchUnifiedRelease.groovy
+++ b/vars/getBranchUnifiedRelease.groovy
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Download the properties file for the given branch in the unified release
+
+  // Download the properties file for the main branch
+  getBranchUnifiedRelease('8.1'))
+*/
+def call(String branch){
+  def fileName = "${branch}.properties"
+  def token = getGithubToken()
+  def ret = githubApiCall(token: token,
+                          method: 'GET',
+                          failNever: true,
+                          allowEmptyResponse: true,
+                          url: "https://api.github.com/repos/elastic/infra/contents/cd/release/versions/${fileName}")
+  def content = 'status=unknown'
+  if (ret?.content?.trim()) {
+    content = new String(Base64.getMimeDecoder().decode(ret.content))
+  }
+  return readProperties(text: content)
+}

--- a/vars/getBranchUnifiedRelease.txt
+++ b/vars/getBranchUnifiedRelease.txt
@@ -1,0 +1,6 @@
+Download the properties file for the given branch in the unified release
+
+```
+  // Download the properties file for the main branch
+  getBranchUnifiedRelease('8.1'))
+```


### PR DESCRIPTION
## What does this PR do?

Update current and next patch for the 8 Major only when the release is available

## Why is it important?

Avoid bumping the version when the release is not available yet, therefore https://github.com/elastic/apm-pipeline-library/pull/1639 won't be created since `8.2.0` has not been released.

This is a quite opinionated approach 