### PR TITLE
ci: enable publishCoverage

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -568,6 +568,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     })
     helper.registerAllowedMethod('preCommitToJunit', [Map.class], null)
     helper.registerAllowedMethod('publishHTML', [Map.class],  null)
+    helper.registerAllowedMethod('publishCoverage', [Map.class],  null)
     helper.registerAllowedMethod('randomNumber', [Map.class], { m -> return m.min })
     helper.registerAllowedMethod('releaseManagerAnalyser', [Map.class], { "" })
     helper.registerAllowedMethod('releaseNotification', [Map.class], { m ->

--- a/src/test/groovy/CoverageReportStepTests.groovy
+++ b/src/test/groovy/CoverageReportStepTests.groovy
@@ -25,6 +25,9 @@ class CoverageReportStepTests extends ApmBasePipelineTest {
   void setUp() throws Exception {
     super.setUp()
     script = loadScript('vars/coverageReport.groovy')
+    // mock nested structure in the publishCoverage
+    helper.registerAllowedMethod('coberturaAdapter', [String.class], null)
+    helper.registerAllowedMethod('sourceFiles', [String.class], null)
   }
 
   @Test

--- a/vars/coverageReport.groovy
+++ b/vars/coverageReport.groovy
@@ -30,12 +30,11 @@ def call(baseDir) {
     reportFiles: 'coverage-*-report.html',
     reportName: 'Coverage-Sourcecode-Files',
     reportTitles: 'Coverage'])
-/*
-  The current version does not show the coverage on the source code.
+
   publishCoverage(adapters: [
     coberturaAdapter("${baseDir}/coverage-*-report.xml")],
     sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
-*/
+
   cobertura(autoUpdateHealth: false,
     autoUpdateStability: false,
     coberturaReportFile: "${baseDir}/coverage-*-report.xml",


### PR DESCRIPTION
## What does this PR do?

Enrich the CI with the source integration as stated in https://github.com/elastic/elastic-package/pull/585#issuecomment-970071779

## Why is it important?

Add source code coverage report

## Related issues
Supersedes https://github.com/elastic/integrations/pull/2986 and https://github.com/elastic/elastic-package/pull/775
