### PR TITLE
Enable edge 8 alias

### DIFF
--- a/resources/versions/releases.properties
+++ b/resources/versions/releases.properties
@@ -3,5 +3,6 @@ current_7=7.17.2
 next_minor_7=7.17.3
 next_patch_7=7.17.3
 current_8=8.1.2
-next_minor_8=8.3.0
+next_minor_8=8.2.0
 next_patch_8=8.1.3
+edge_8=8.3.0

--- a/src/test/groovy/BumpUtilsStepTests.groovy
+++ b/src/test/groovy/BumpUtilsStepTests.groovy
@@ -48,7 +48,7 @@ class BumpUtilsStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_areStackVersionsAvailable() throws Exception {
-    script.areStackVersionsAvailable([ current_7 : '7.15.1', current_6: '6.8.20', next_minor_7: '7.16.0', next_patch_7: '7.15.2' ])
+    script.areStackVersionsAvailable([ current_7 : '7.15.1', current_6: '6.8.20', next_minor_7: '7.16.0', next_patch_7: '7.15.2', edge_8: '9.5.0' ])
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('dockerImageExists', '6.8.20-SNAPSHOT'))
     assertTrue(assertMethodCallContainsPattern('dockerImageExists', '7.15.1-SNAPSHOT'))

--- a/vars/README.md
+++ b/vars/README.md
@@ -229,8 +229,12 @@ Utils class for the bump automation pipelines
 * `isVersionAvailable` -> if the given elastic stack version is available.
 * `parseArguments` -> parse the given arguments.
 * `prepareContext` -> prepare the git context, checkout and git config user.name.
+* `getEdgeReleaseFor8` -> retrieve the EDGE minor version for the 8 major version of the Elastic Stack.
+* `getCurrentMinorReleaseFor8` -> retrieve the LATEST known minor release for the 8 major version of the Elastic Stack.
 * `getCurrentMinorReleaseFor7` -> retrieve the LATEST known minor release for the 7 major version of the Elastic Stack.
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
+* `getNextMinorReleaseFor8` -> retrieve the NEXT minor release for the 8 major version of the Elastic Stack. It might not be public available yet.
+* `getNextPatchReleaseFor8` -> retrieve the NEXT patch release for the 8 major version of the Elastic Stack. It might not be public available yet.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16`.
@@ -2649,6 +2653,7 @@ releaseManager(project: 'apm-server',
 
 * project: the release manager project. Mandatory.
 * version:  the version (either a release or a snapshot). Mandatory.
+* branch: the branch. Default `env.BRANCH_NAME`. Optional.
 * type: the type of release (snapshot or staging). Default 'snapshot'. Optional.
 * artifactsFolder: the relative folder where the binaries are stored. Default 'build/distribution'. Optional
 * outputFile: the file where the log output is stored to. Default 'release-manager-report.out'. Optional

--- a/vars/bumpUtils.groovy
+++ b/vars/bumpUtils.groovy
@@ -76,6 +76,10 @@ def getMajorMinor(String version) {
   error('getMajorMinor: version is not major.minor.patch formatted')
 }
 
+def getEdgeReleaseFor8() {
+  return getValueForPropertyKey(edge8Key())
+}
+
 def getCurrentMinorReleaseFor8() {
   return getValueForPropertyKey(current8Key())
 }
@@ -114,6 +118,10 @@ def getValueForPropertyKey(String key) {
   return version
 }
 
+def edge8Key() {
+  return 'edge_8'
+}
+
 def current8Key() {
   return 'current_8'
 }
@@ -147,5 +155,6 @@ def areStackVersionsAvailable(stackVersions) {
   return isVersionAvailable(stackVersions.get(current6Key())) &&
     isVersionAvailable(stackVersions.get(current7Key())) &&
     isVersionAvailable(stackVersions.get(nextMinor7Key())) &&
-    isVersionAvailable(stackVersions.get(nextPatch7Key()))
+    isVersionAvailable(stackVersions.get(nextPatch7Key())) &&
+    isVersionAvailable(stackVersions.get(edge8Key()))
 }

--- a/vars/bumpUtils.txt
+++ b/vars/bumpUtils.txt
@@ -5,8 +5,12 @@ Utils class for the bump automation pipelines
 * `isVersionAvailable` -> if the given elastic stack version is available.
 * `parseArguments` -> parse the given arguments.
 * `prepareContext` -> prepare the git context, checkout and git config user.name.
+* `getEdgeReleaseFor8` -> retrieve the EDGE minor version for the 8 major version of the Elastic Stack.
+* `getCurrentMinorReleaseFor8` -> retrieve the LATEST known minor release for the 8 major version of the Elastic Stack.
 * `getCurrentMinorReleaseFor7` -> retrieve the LATEST known minor release for the 7 major version of the Elastic Stack.
 * `getCurrentMinorReleaseFor6` -> retrieve the LATEST known minor release for the 6 major version of the Elastic Stack.
+* `getNextMinorReleaseFor8` -> retrieve the NEXT minor release for the 8 major version of the Elastic Stack. It might not be public available yet.
+* `getNextPatchReleaseFor8` -> retrieve the NEXT patch release for the 8 major version of the Elastic Stack. It might not be public available yet.
 * `getNextMinorReleaseFor7` -> retrieve the NEXT minor release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getNextPatchReleaseFor7` -> retrieve the NEXT patch release for the 7 major version of the Elastic Stack. It might not be public available yet.
 * `getMajorMinor` -> retrieve the given version in Major.Minor format, f.e: given `7.16.2` it returns `7.16`.


### PR DESCRIPTION
## What does this PR do?

Support for the `edge` alias for the version in the `main` branches, therefore

- currentX -> points to the latest release.
- nextMinorX -> points to the upcoming minor release, it supports releases or BCs
- nextPatchX -> points to the upcoming minor release, it supports releases or BCs

## Why is it important?

As long as there are releases, BCs, and potential `main` release, we need a new alias to distinguish the `main` versions from releases or BCs

## Related issues
See https://github.com/elastic/apm-pipeline-library/pull/1641


## Test

This dry-run [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fupdate-stack-release-version-pipeline/detail/update-stack-release-version-pipeline/125/pipeline/61) produced

```
[current_6:6.8.23,
 current_7:7.17.2,
 next_minor_7:7.17.3,
 next_patch_7:7.17.3,
 current_8:8.1.2,
 next_minor_8:8.2.0,
 next_patch_8:8.1.3,
 edge_8:8.3.0]',
 base: 'main',
 title: '[automation] Update Elastic stack release version source of truth',
 reviewer: 'elastic/observablt-robots-on-call')
```