### PR TITLE
Fix Using the node  or sh  steps from this method is illegal

### DIFF
--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -109,16 +109,7 @@ private Boolean changeset(Map args = [:]) {
     }
   }
 
-  // TODO: to be refactored  with isGitRegionMatch.isPartialPatternMatch()
-
-  // Gather the diff between the target branch and the current commit.
-  def gitDiffFile = 'git-diff.txt'
-  // On branches with a very first build then GIT_PREVIOUS_COMMIT is empty, let's fallback to the GIT_BASE_COMMIT
-  def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
-  sh(script: "git diff --name-only ${from}...${env.GIT_BASE_COMMIT} > ${gitDiffFile}", returnStdout: true)
-  // Search for any pattern that matches that particular if partialMatch or fullMatch
-  def fileContent = readFile(gitDiffFile)
-  def match = anyMatchInChangeSet(fileContent, patterns, partialMatch)
+  def match = anyMatchInChangeSet(patterns, partialMatch)
   if (match) {
     markdownReason(project: args.project, reason: "* ✅ ${name} is `enabled` and matches with the patterns `${match}`.")
     return true
@@ -249,7 +240,17 @@ def isMatch(line, pattern) {
   return value
 }
 
-def anyMatchInChangeSet(fileContent, patterns, partialMatch) {
+def anyMatchInChangeSet(patterns, partialMatch) {
+  // TODO: to be refactored  with isGitRegionMatch.isPartialPatternMatch()
+
+  // Gather the diff between the target branch and the current commit.
+  def gitDiffFile = 'git-diff.txt'
+  // On branches with a very first build then GIT_PREVIOUS_COMMIT is empty, let's fallback to the GIT_BASE_COMMIT
+  def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
+  sh(script: "git diff --name-only ${from}...${env.GIT_BASE_COMMIT} > ${gitDiffFile}", returnStdout: true)
+  // Search for any pattern that matches that particular if partialMatch or fullMatch
+  def fileContent = readFile(gitDiffFile)
+
   log(level: 'DEBUG', text: "anyMatchInChangeSet: file content ${fileContent}")
 
   def match = false

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -249,7 +249,7 @@ def isMatch(line, pattern) {
 }
 
 @NonCPS
-private boolean anyMatchInChangeSet(gitDiffFile, patterns, partialMatch) {
+def anyMatchInChangeSet(gitDiffFile, patterns, partialMatch) {
   // Search for any pattern that matches that particular if partialMatch or fullMatch
   def fileContent = readFile(gitDiffFile)
   log(level: 'DEBUG', text: "anyMatchInChangeSet: file content ${fileContent}")

--- a/vars/beatsWhen.groovy
+++ b/vars/beatsWhen.groovy
@@ -249,7 +249,6 @@ def isMatch(line, pattern) {
   return value
 }
 
-@NonCPS
 def anyMatchInChangeSet(fileContent, patterns, partialMatch) {
   log(level: 'DEBUG', text: "anyMatchInChangeSet: file content ${fileContent}")
 


### PR DESCRIPTION
## What does this PR do?

There are some runtime issues while using the `noncps` with a `sh` step

## Why is it important?

It was intended to fix the issues with the serialisation but added a regression by running the noncps with a `sh` step.

<img width="891" alt="image" src="https://user-images.githubusercontent.com/2871786/161606039-a7d3c3ff-bcb0-4d0b-a706-6228d0c0e6f3.png">

https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/

## Related issues
https://github.com/elastic/apm-pipeline-library/pull/1636#issuecomment-1087855671