### PR TITLE
Update weekly email to use the right condition and support 8.2

### DIFF
--- a/.ci/.weekly-tests-email.yml
+++ b/.ci/.weekly-tests-email.yml
@@ -17,6 +17,7 @@ projects:
   - repo: beats
     branches:
       - main
+      - 8.<next-minor>
       - 8.<minor>
       - 8.<minor-1>
       - 7.<minor>
@@ -25,6 +26,7 @@ projects:
   - repo: elastic-agent
     branches:
       - main
+      - 8.<next-minor>
       - 8.<minor>
       - 8.<minor-1>
     enabled: true
@@ -32,6 +34,7 @@ projects:
   - repo: e2e-testing
     branches:
       - main
+      - 8.<next-minor>
       - 8.<minor>
       - 8.<minor-1>
       - 7.<minor>

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -119,7 +119,7 @@ def runWatcherForBranch(Map args = [:]){
 def generateSteps(Map args = [:]) {
   def projects = readYaml(file: '.ci/.weekly-tests-email.yml')
   projects['projects'].each { project ->
-    if (project.get('enabled', 'true').equals('true')) {
+    if (project.get('enabled', true)) {
       runWatcherForBranch(project: project.repo,
                           to: project.email,
                           branches: project.branches)

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -21,7 +21,7 @@ pipeline {
   agent { label 'ubuntu && immutable' }
   environment {
     NOTIFY_TO = credentials('notify-to')
-    PIPELINE_LOG_LEVEL = 'DEBUG'
+    PIPELINE_LOG_LEVEL = 'INFO'
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     DOCKERELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     BEATS_MAILING_LIST = "${params.BEATS_MAILING_LIST}"

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -104,8 +104,11 @@ def runWatcherForBranch(Map args = [:]){
 
   branches.each { branch ->
     try {
-      runWatcher(watcher: "report-${args.project}-top-failing-tests-weekly-${branch}",
-                 subject: "[${args.project}@${branch}] ${env.YYYY_MM_DD}: Top failing ${args.project} tests in ${branch} branch - last 7 days",
+      def watcherName = "report-${args.project}-top-failing-tests-weekly-${branch}"
+      def subject = "[${args.project}@${branch}] ${env.YYYY_MM_DD}: Top failing ${args.project} tests in ${branch} branch - last 7 days"
+      log(level: 'INFO', text: "runWatcherForBranch: ${watcherName} - ${subject}")
+      runWatcher(watcher: "${watcherName}",
+                 subject: "${subject}",
                  sendEmail: params.DRY_RUN_MODE,
                  to: args.to,
                  debugFileName: "${args.project}-${branch}.txt")

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -21,7 +21,7 @@ pipeline {
   agent { label 'ubuntu && immutable' }
   environment {
     NOTIFY_TO = credentials('notify-to')
-    PIPELINE_LOG_LEVEL='INFO'
+    PIPELINE_LOG_LEVEL = 'DEBUG'
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     DOCKERELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     BEATS_MAILING_LIST = "${params.BEATS_MAILING_LIST}"

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -94,7 +94,7 @@ def runNotifyStalledBeatsBumps(Map args = [:]) {
   branches.each { branch ->
     notifyStalledBeatsBumps(branch: branch,
                             subject: "[${branch}] ${YYYY_MM_DD}: Elastic Stack version has not been updated recently.",
-                            sendEmail: params.DRY_RUN_MODE,
+                            sendEmail: !params.DRY_RUN_MODE,
                             to: args.to)
   }
 }
@@ -109,7 +109,7 @@ def runWatcherForBranch(Map args = [:]){
       log(level: 'INFO', text: "runWatcherForBranch: ${watcherName} - ${subject}")
       runWatcher(watcher: "${watcherName}",
                  subject: "${subject}",
-                 sendEmail: params.DRY_RUN_MODE,
+                 sendEmail: !params.DRY_RUN_MODE,
                  to: args.to,
                  debugFileName: "${args.project}-${branch}.txt")
     } catch(err) {

--- a/vars/runWatcher.groovy
+++ b/vars/runWatcher.groovy
@@ -53,6 +53,7 @@ def call(Map args = [:]) {
             def body = logAction.logging?.logged_text
             log(level: 'DEBUG', text: "runWatcher: The REST API call returned ${body}")
             if (sendEmail && to?.trim()) {
+                log(level: 'INFO', text: "runWatcher: email has been enabled (${to}).")
                 mail(to: to,
                     subject: subject,
                     body: body,
@@ -63,6 +64,8 @@ def call(Map args = [:]) {
                   writeFile(file: args.get('debugFileName'), text: "${body}")
                   archiveArtifacts(allowEmptyArchive: true, artifacts: args.get('debugFileName'))
                 }
+            } else {
+              log(level: 'INFO', text: "runWatcher: email has been explicitly disabled.")
             }
             return body
         } else {


### PR DESCRIPTION
## What does this PR do?

* Use the right primitive in the validation
* add `next-minor` to resolve the `8.2` branch
* Use reverse logic for the dry-run

## Test

Validated in this [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-schedule-weekly/detail/apm-schedule-weekly/168/pipeline)