### PR TITLE
Add state filter for the bumpGoReleaseVersion

### DIFF
--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -105,6 +105,7 @@ def prepareArguments(Map args = [:]){
   def title = args.get('title', '').trim() ? args.title : '[automation] Update go release version'
   def assign = args.get('assign', '')
   def reviewer = args.get('reviewer', '')
+  def state = args.get('state', 'all')
 
   // If branch is not main the it's likely needed to search for the go version that matches the given branch
   // ie. 1.16 branch should be go1.16, 1.17 branch should be go1.17 and so on
@@ -119,7 +120,7 @@ def prepareArguments(Map args = [:]){
     labels = "automation,${labels}"
   }
   return [repo: repo, branchName: branch, title: "${title} ${goReleaseVersion}", labels: labels, scriptFile: scriptFile,
-          goReleaseVersion: goReleaseVersion, message: message, assign: assign, reviewer: reviewer]
+          goReleaseVersion: goReleaseVersion, message: message, assign: assign, reviewer: reviewer, state: state]
 }
 
 def createPullRequest(Map args = [:]) {

--- a/src/test/groovy/GithubPrExistsStepTests.groovy
+++ b/src/test/groovy/GithubPrExistsStepTests.groovy
@@ -53,6 +53,17 @@ class GithubPrExistsStepTests extends ApmBasePipelineTest {
     })
     def ret = script.call(title: 'bar')
     printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPullRequests', 'state=open'))
     assertFalse(ret)
+  }
+
+  @Test
+  void test_with_state() throws Exception {
+    helper.registerAllowedMethod('githubPullRequests', [Map.class], {
+      return [:]
+    })
+    script.call(title: 'bar', state: 'all')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubPullRequests', 'state=all'))
   }
 }

--- a/vars/githubPrExists.groovy
+++ b/vars/githubPrExists.groovy
@@ -25,6 +25,7 @@
 def call(Map args = [:]){
   def title = args.containsKey('title') ? args.title : error('githubPrExists: title parameter is required.')
   def labels = args.containsKey('labels') ? args.labels.split(',') : ''
-  def pullRequests = githubPullRequests(labels: labels, titleContains: title)
+  def state = args.containsKey('state') ? args.state : 'open'
+  def pullRequests = githubPullRequests(labels: labels, titleContains: title, state: state)
   return (pullRequests && pullRequests.size() > 0)
 }

--- a/vars/githubPrExists.txt
+++ b/vars/githubPrExists.txt
@@ -9,5 +9,6 @@ Pull Request details.
 
 * *labels*: Filter by labels. Optional
 * *title*: Filter by title (contains format). Mandatory
+* *state*: Filter by state {open|closed|merged|all} (default "open"). Optional
 
 NOTE: It uses `githubPullRequests`


### PR DESCRIPTION
## What does this PR do?

Filter by all PRs
 
## Why is it important?

Avoid duplicated PRs for the Golang bump when PRs are closed


For instance, https://github.com/elastic/beats/pulls?q=is%3Apr+Update+go+release+version+1.18+is%3Aclosed then a new PR should not be created.

## Test

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/2871786/162768571-1dec0b92-a26e-4abe-98ef-5bbd6a353232.png">

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fbump-go-release-version-pipeline/detail/bump-go-release-version-pipeline/62/pipeline/168