### PR TITLE
isCommentTrigger: support for write and org member

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -509,6 +509,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return script.call(m)
     })
     helper.registerAllowedMethod('isInternalCI', { return false })
+    helper.registerAllowedMethod('isMemberOfOrg', [Map.class], { m -> return false })
     helper.registerAllowedMethod('isStaticWorker', [Map.class], { m ->
       def script = loadScript('vars/isStaticWorker.groovy')
       return script.call(m)

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -499,6 +499,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return script.call()
     })
     helper.registerAllowedMethod('isCommentTrigger', { return false })
+    helper.registerAllowedMethod('isCommentTrigger', [Map.class], { return false })
     helper.registerAllowedMethod('isBeforeGo1_16', [Map.class], { m ->
       def script = loadScript('vars/isBeforeGo1_16.groovy')
       return script.call(m)

--- a/src/test/groovy/IsMemberOfOrgStepTests.groovy
+++ b/src/test/groovy/IsMemberOfOrgStepTests.groovy
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+class IsMemberOfOrgStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/isMemberOfOrg.groovy')
+  }
+
+  @Test
+  void test_without_user_parameter() throws Exception {
+    testMissingArgument('user') {
+      ret = script.call()
+    }
+  }
+
+  @Test
+  void test_active_user() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{}') })
+    def ret = script.call(user: 'foo')
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('githubApiCall', 'orgs/elastic/members/foo'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_active_user_with_explicit_org() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return net.sf.json.JSONSerializer.toJSON('{}') })
+    def ret = script.call(user: 'foo', org: 'acme')
+    printCallStack()
+    assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('githubApiCall', 'orgs/acme/members/foo'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_no_membership() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], { return notFound() })
+    def ret = script.call(user: 'foo')
+    printCallStack()
+    assertFalse(ret)
+    assertTrue(assertMethodCallContainsPattern('githubApiCall', 'orgs/elastic/members/foo'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_no_membership_with_error() throws Exception {
+    helper.registerAllowedMethod('githubApiCall', [Map.class], {
+      throw new Exception('Forced a failure')
+    })
+    def ret = script.call(user: 'foo')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  def notFound() {
+    return net.sf.json.JSONSerializer.toJSON( """{
+        "Code": "404",
+        "message": "Not Found",
+        "documentation_url": "https://developer.github.com/v3"
+      }""")
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -1777,6 +1777,11 @@ def commentTrigger = isCommentTrigger()
 
 It requires [Github Pipeline plugin](https://plugins.jenkins.io/pipeline-github/) (>2.5)
 
+* *author:* GitHub comment author (by default `env.GITHUB_COMMENT_AUTHOR`).
+* *comment:* GitHub comment (by default `env.GITHUB_COMMENT`).
+* *repository*: The GitHub repository (by default `env.REPO_NAME`).
+* *org*: the GitHub organisation (by default `elastic`).
+
 ## isGitRegionMatch
 Given the list of patterns, the CHANGE_TARGET, GIT_BASE_COMMIT env variables and the kind of match then it
 evaluates the change list with the pattern list:
@@ -1864,6 +1869,28 @@ whenTrue(isMemberOf(user: 'my-user', team: 'my-team', org: 'acme')) {
 * user: the GitHub user. Mandatory
 * team: the GitHub team or list of GitHub teams. Mandatory
 * org: the GitHub organisation. Optional. Default: 'elastic'
+
+## isMemberOfOrg
+Check if the given GitHub user is member of the given GitHub org.
+
+```
+whenTrue(isMemberOfOrg(user: 'my-user')) {
+    //...
+}
+
+whenTrue(isMemberOfOrg(user: 'my-user')) {
+    //...
+}
+
+// using another organisation
+whenTrue(isMemberOfOrg(user: 'my-user', org: 'acme')) {
+    //...
+}
+
+```
+
+* *user*: the GitHub user. Mandatory
+* *org*: the GitHub organisation. Optional. Default: 'elastic'
 
 ## isPR
 Whether the build is based on a Pull Request or no

--- a/vars/isCommentTrigger.groovy
+++ b/vars/isCommentTrigger.groovy
@@ -34,7 +34,6 @@ def call(Map args){
   if (author && comment) {
     log(level: 'DEBUG', text: 'isCommentTrigger: only users under the elastic organisation are allowed.')
     def token = getGithubToken()
-    // User with write permissions
     if (repo) {
       found = hasWritePermissions(token, repo, author)
     }
@@ -46,6 +45,7 @@ def call(Map args){
 }
 
 def hasWritePermissions(token, repo, author) {
+  log(level: 'DEBUG', text: 'isCommentTrigger.hasWritePermissions: User with write permissions?.')
   return githubPrCheckApproved.hasWritePermission(token, repo, author)
 }
 
@@ -54,7 +54,7 @@ def isElasticMember(token, author) {
   try {
     // Either a user from the org or a user with write permissions
     def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true,
-                                          url: "https://api.github.com/orgs/elastic/members/${author}")
+                                           url: "https://api.github.com/orgs/elastic/members/${author}")
     // githubApiCall returns either a raw output or an error message if so it means the user is not a member.
     found = membershipResponse.message?.trim() ? false : true
   } catch(err) {

--- a/vars/isCommentTrigger.groovy
+++ b/vars/isCommentTrigger.groovy
@@ -15,30 +15,53 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import com.cloudbees.groovy.cps.NonCPS
 /**
   Check if the build was triggered by a comment in GitHub.
 
   def commentTrigger = isCommentTrigger()
 */
 
+// @deprecated. For backward compatibility only
 def call(){
+  return call([:])
+}
+
+def call(Map args){
+  def author = args.get('author', env.GITHUB_COMMENT_AUTHOR)
+  def comment = args.get('comment', env.GITHUB_COMMENT)
+  def repo = args.get('repository', env.REPO_NAME)
   def found = false
-  if (env.GITHUB_COMMENT_AUTHOR && env.GITHUB_COMMENT) {
+  if (author && comment) {
     log(level: 'DEBUG', text: 'isCommentTrigger: only users under the elastic organisation are allowed.')
     def token = getGithubToken()
-
-    try {
-      def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true,
-                                            url: "https://api.github.com/orgs/elastic/members/${env.GITHUB_COMMENT_AUTHOR}")
-      // githubApiCall returns either a raw output or an error message if so it means the user is not a member.
-      found = membershipResponse.message?.trim() ? false : true
-    } catch(err) {
-      log(level: 'WARN', text: "isCommentTrigger: only users under the Elastic organisation are allowed. Message: See ${err.toString()}")
-      // Then it means 404 errorcode.
-      // See https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-not-a-member
-      found = false
+    // User with write permissions
+    if (repo) {
+      found = hasWritePermissions(token, repo, author)
     }
+    if (!found) {
+      found = isElasticMember(token, author)
+    }
+  }
+  return found
+}
+
+def hasWritePermissions(token, repo, author) {
+  return githubPrCheckApproved.hasWritePermission(token, repo, author)
+}
+
+def isElasticMember(token, author) {
+  def found = false
+  try {
+    // Either a user from the org or a user with write permissions
+    def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true,
+                                          url: "https://api.github.com/orgs/elastic/members/${author}")
+    // githubApiCall returns either a raw output or an error message if so it means the user is not a member.
+    found = membershipResponse.message?.trim() ? false : true
+  } catch(err) {
+    log(level: 'WARN', text: "isCommentTrigger: only users under the Elastic organisation are allowed. Message: See ${err.toString()}")
+    // Then it means 404 errorcode.
+    // See https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-not-a-member
+    found = false
   }
   return found
 }

--- a/vars/isCommentTrigger.groovy
+++ b/vars/isCommentTrigger.groovy
@@ -30,6 +30,7 @@ def call(Map args){
   def author = args.get('author', env.GITHUB_COMMENT_AUTHOR)
   def comment = args.get('comment', env.GITHUB_COMMENT)
   def repo = args.get('repository', env.REPO_NAME)
+  def org = args.get('org', 'elastic')
   def found = false
   if (author && comment) {
     log(level: 'DEBUG', text: 'isCommentTrigger: only users under the elastic organisation are allowed.')
@@ -38,7 +39,7 @@ def call(Map args){
       found = hasWritePermissions(token, repo, author)
     }
     if (!found) {
-      found = isElasticMember(token, author)
+      found = isMemberOfOrg(user: author, org: org)
     }
   }
   return found
@@ -47,21 +48,4 @@ def call(Map args){
 def hasWritePermissions(token, repo, author) {
   log(level: 'DEBUG', text: 'isCommentTrigger.hasWritePermissions: User with write permissions?.')
   return githubPrCheckApproved.hasWritePermission(token, repo, author)
-}
-
-def isElasticMember(token, author) {
-  def found = false
-  try {
-    // Either a user from the org or a user with write permissions
-    def membershipResponse = githubApiCall(token: token, allowEmptyResponse: true,
-                                           url: "https://api.github.com/orgs/elastic/members/${author}")
-    // githubApiCall returns either a raw output or an error message if so it means the user is not a member.
-    found = membershipResponse.message?.trim() ? false : true
-  } catch(err) {
-    log(level: 'WARN', text: "isCommentTrigger: only users under the Elastic organisation are allowed. Message: See ${err.toString()}")
-    // Then it means 404 errorcode.
-    // See https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-not-a-member
-    found = false
-  }
-  return found
 }

--- a/vars/isCommentTrigger.txt
+++ b/vars/isCommentTrigger.txt
@@ -7,3 +7,7 @@ def commentTrigger = isCommentTrigger()
 ```
 
 It requires [Github Pipeline plugin](https://plugins.jenkins.io/pipeline-github/) (>2.5)
+
+* *author:* GitHub comment author (by default GITHUB_COMMENT_AUTHOR).
+* *comment:* GitHub comment (by default GITHUB_COMMENT).
+* repository: The GitHub repository. Default: `env.REPO_NAME`

--- a/vars/isCommentTrigger.txt
+++ b/vars/isCommentTrigger.txt
@@ -8,6 +8,7 @@ def commentTrigger = isCommentTrigger()
 
 It requires [Github Pipeline plugin](https://plugins.jenkins.io/pipeline-github/) (>2.5)
 
-* *author:* GitHub comment author (by default GITHUB_COMMENT_AUTHOR).
-* *comment:* GitHub comment (by default GITHUB_COMMENT).
-* repository: The GitHub repository. Default: `env.REPO_NAME`
+* *author:* GitHub comment author (by default `env.GITHUB_COMMENT_AUTHOR`).
+* *comment:* GitHub comment (by default `env.GITHUB_COMMENT`).
+* *repository*: The GitHub repository (by default `env.REPO_NAME`).
+* *org*: the GitHub organisation (by default `elastic`).

--- a/vars/isMemberOfOrg.groovy
+++ b/vars/isMemberOfOrg.groovy
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+  Check if the given GitHub user is member of the given GitHub org.
+
+  whenTrue(isMemberOfOrg(user: 'my-user')) {
+      //...
+  }
+
+  whenTrue(isMemberOfOrg(user: 'my-user')) {
+      //...
+  }
+
+  // using another organisation
+  whenTrue(isMemberOfOrg(user: 'my-user', org: 'acme')) {
+      //...
+  }
+*/
+
+def call(Map args = [:]) {
+  def user = args.containsKey('user') ? args.user : error('isMemberOfOrg: user parameter is required')
+  def org = args.containsKey('org') ? args.org : 'elastic'
+  def token = getGithubToken()
+  def found = false
+  try {
+    def membershipResponse = githubApiCall(token: token,
+                                           allowEmptyResponse: true,
+                                           url: "https://api.github.com/orgs/${org}/members/${user}")
+    // githubApiCall returns either a raw output or an error message if so it means the user is not a member.
+    found = membershipResponse.message?.trim() ? false : true
+  } catch(err) {
+    // Then it means 404 errorcode.
+    // See https://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-not-a-member
+    found = false
+  }
+  return found
+}

--- a/vars/isMemberOfOrg.txt
+++ b/vars/isMemberOfOrg.txt
@@ -1,0 +1,20 @@
+Check if the given GitHub user is member of the given GitHub org.
+
+```
+whenTrue(isMemberOfOrg(user: 'my-user')) {
+    //...
+}
+
+whenTrue(isMemberOfOrg(user: 'my-user')) {
+    //...
+}
+
+// using another organisation
+whenTrue(isMemberOfOrg(user: 'my-user', org: 'acme')) {
+    //...
+}
+
+```
+
+* *user*: the GitHub user. Mandatory
+* *org*: the GitHub organisation. Optional. Default: 'elastic'


### PR DESCRIPTION
## What does this PR do?

Enable GitHub comments from GitHub users with write permissions. For such, I refactored the `isCommentTrigger` step and created the `isMemberOfOrg`.

## Why is it important?

Add a new use case when the user has been granted with write permissions in the repository, therefore it's allowed to run in the CI.

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/1650
