### PR TITLE
hotfix: move folder.groovy to the root CI jobDSL path

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/folder.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/folder.groovy
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+folder('apm-shared') {
+  displayName('APM shared folder')
+  description('Folder for shared CI jobs')
+}
+
+folder('apm-shared/docker-images') {
+  displayName('Docker images folder')
+  description('Folder for the Docker image build jobs')
+}
+
+folder('apm-shared/oblt-test-env') {
+  displayName('Oblt test Clusters')
+  description('Folder for Oblt test Clusters CI jobs')
+}

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ metadata.txt
 
 out.html
 .vscode
+.ci/jobDSL/bin
 
 test-infra/__pycache__
 test-infra/.pytest_cache


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
The path of the folder.groovy was changed in the pipeline but the file was in the same place this make the Job generator to fail. This PR move the file and adds a path created by VSCode to .gitignore

## Related issues
related to https://github.com/elastic/apm-pipeline-library/pull/1578
