### PR TITLE
githubPrCheckApproved with support for Elastic members

### DIFF
--- a/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
+++ b/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
@@ -140,6 +140,21 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_no_allowed_but_member_of_elastic() throws Exception {
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [] })
+    helper.registerAllowedMethod("githubPrInfo", [Map.class], {
+      return [title: 'dummy PR', user: [login: 'username'], author_association: 'NONE']
+      })
+    helper.registerAllowedMethod("githubPrReviews", [Map.class], { return [] })
+    helper.registerAllowedMethod('isMemberOfOrg', [Map.class], { m -> return true })
+    env.CHANGE_ID = 1
+    def ret = script.call()
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void testHasWritePermission() throws Exception {
     helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], {
       return [

--- a/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
+++ b/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
@@ -151,6 +151,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
     def ret = script.call()
     printCallStack()
     assertTrue(ret)
+    assertTrue(assertMethodCallContainsPattern('isMemberOfOrg', 'user=username'))
     assertJobStatusSuccess()
   }
 

--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -43,12 +43,14 @@ def call(Map args = [:]){
 
   // The PR is approved to be executed in the CI for the below reasons:
   // - An user with write permissions raised the PR.
+  // - IsMemberOf the Elastic Org.
   // - An authorized bot created the PR.
   // - If it has already been approved by a member or collaborator.
   // - A trusted user for that particular repo.
   //
   approved = user != null && (isPrApproved(reviews) ||
                               hasWritePermission(token, repoName, user) ||
+                              isMemberOfOrg(user: user, org: 'elastic') ||
                               isAuthorizedBot(user, userType) ||
                               isAuthorizedUser(repoName, user))
 


### PR DESCRIPTION
## What does this PR do?

Allow Elasticians to run builds in the CI even if they don't have write access

## Why is it important?

Otherwise Elasticians cannot contribute smoothly

## Related issues

See https://github.com/elastic/elastic-agent-shipper/pull/21

<img width="861" alt="image" src="https://user-images.githubusercontent.com/2871786/163123144-f0f4446a-0f7f-46d0-a3ba-cd1e11e0ad0e.png">

