### PR TITLE
githubPrCheckApproved: avoid failing and add UTs

### DIFF
--- a/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
+++ b/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
@@ -44,9 +44,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
 
   @Test
   void testNotAllow() throws Exception {
-    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], {
-      return []
-      })
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [:] })
     helper.registerAllowedMethod("githubPrInfo", [Map.class], {
       return [title: 'dummy PR', user: [login: 'username'], author_association: 'NONE']
       })
@@ -70,9 +68,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
 
   @Test
   void testIsApproved() throws Exception {
-    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], {
-      return []
-      })
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [:] })
     helper.registerAllowedMethod("githubPrInfo", [Map.class], {
       return [title: 'dummy PR', user: [login: 'username'], author_association: 'NONE']
       })
@@ -103,9 +99,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
 
   @Test
   void testIsRejected() throws Exception {
-    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], {
-      return []
-      })
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [:] })
     helper.registerAllowedMethod("githubPrInfo", [Map.class], {
       return [title: 'dummy PR', user: [login: 'username'], author_association: 'NONE']
       })
@@ -293,7 +287,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_isAuthorizedUser() throws Exception {
-    helper.registerAllowedMethod('githubRepoGetUserPermission', [Map.class], { return [] })
+    helper.registerAllowedMethod('githubRepoGetUserPermission', [Map.class], { return [:] })
     helper.registerAllowedMethod('githubPrInfo', [Map.class], {
       return [title: 'dummy PR', user: [login: 'v1v'], author_association: 'MEMBER']
     })

--- a/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
+++ b/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
@@ -307,4 +307,29 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('libraryResource', 'approval-list/org/apm-agent-go.yml'))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_hasWritePermission_with_empty_value() throws Exception {
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [:] })
+    def ret = script.hasWritePermission('token', 'repo', 'username')
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_hasWritePermission_with_match() throws Exception {
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], {
+      return [
+        "permission": "admin",
+        "user": [
+          "login": "username",
+        ]
+      ]
+    })
+    def ret = script.hasWritePermission('token', 'repo', 'username')
+    printCallStack()
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/groovy/GithubRepoGetUserPermissionStepTests.groovy
+++ b/src/test/groovy/GithubRepoGetUserPermissionStepTests.groovy
@@ -57,4 +57,15 @@ class GithubRepoGetUserPermissionStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('error', 'githubRepoGetUserPermission: no valid username.'))
   }
+
+  @Test
+  void test_invalid_repo_format() throws Exception {
+    try {
+      script.call(token: 'token', user: 1, repo: 'repo')
+    } catch(e){
+      //NOOP
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('error', 'githubRepoGetUserPermission: invalid repository format'))
+  }
 }

--- a/src/test/groovy/IsCommentTriggerStepTests.groovy
+++ b/src/test/groovy/IsCommentTriggerStepTests.groovy
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertFalse
 class IsCommentTriggerStepTests extends ApmBasePipelineTest {
 
   class ClassMock {
-    boolean hasWritePermission(token, repo, author){ return repo?.equals('acme') }
+    boolean hasWritePermission(token, repo, author){ return repo?.equals('elastic/acme') }
   }
 
   @Override

--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -93,7 +93,7 @@ def isPrApproved(reviews){
 def hasWritePermission(token, repo, user){
   def json = githubRepoGetUserPermission(token: token, repo: repo, user: user)
   log(level: 'DEBUG', text: "githubPrCheckApproved: User: ${user}, Repo: ${repo}, Permission: ${json?.permission}")
-  return json?.permission == 'admin' || json?.permission == 'write'
+  return json?.permission?.trim() == 'admin' || json?.permission?.trim() == 'write'
 }
 
 /**

--- a/vars/githubRepoGetUserPermission.groovy
+++ b/vars/githubRepoGetUserPermission.groovy
@@ -24,5 +24,8 @@ def call(Map args = [:]){
   def token =  args?.token
   def repo = args.containsKey('repo') ? args.repo : error('githubRepoGetUserPermission: no valid repository.')
   def user =  args.containsKey('user') ? args.user : error('githubRepoGetUserPermission: no valid username.')
-  return githubApiCall(token: token, url:"https://api.github.com/repos/${repo}/collaborators/${user}/permission")
+  if (repo.contains('/')) {
+    return githubApiCall(token: token, url:"https://api.github.com/repos/${repo}/collaborators/${user}/permission", failNever: false)
+  }
+  error('githubRepoGetUserPermission: invalid repository format, please use the format <org>/<repo> (elastic/beats).')
 }

--- a/vars/hasCommentAuthorWritePermissions.groovy
+++ b/vars/hasCommentAuthorWritePermissions.groovy
@@ -21,9 +21,12 @@
 def call(Map args = [:]){
   def repoName = args.containsKey('repoName') ? args.repoName : error('hasCommentAuthorWritePermissions: repoName params is required')
   def commentId = args.containsKey('commentId') ? args.commentId : error('hasCommentAuthorWritePermissions: commentId params is required')
-  def token = getGithubToken()
-  def url = "https://api.github.com/repos/${repoName}/issues/comments/${commentId}"
-  def comment = githubApiCall(token: token, url: url, noCache: true)
-  def json = githubRepoGetUserPermission(token: token, repo: repoName, user: comment?.user?.login)
-  return json?.permission == 'admin' || json?.permission == 'write'
+  if (repoName.contains('/')) {
+    def token = getGithubToken()
+    def url = "https://api.github.com/repos/${repoName}/issues/comments/${commentId}"
+    def comment = githubApiCall(token: token, url: url, noCache: true)
+    def json = githubRepoGetUserPermission(token: token, repo: repoName, user: comment?.user?.login)
+    return json?.permission?.trim() == 'admin' || json?.permission?.trim() == 'write'
+  }
+  error('hasCommentAuthorWritePermissions: invalid repository format, please use the format <org>/<repo> (elastic/beats).')
 }

--- a/vars/isCommentTrigger.groovy
+++ b/vars/isCommentTrigger.groovy
@@ -36,7 +36,7 @@ def call(Map args){
     log(level: 'DEBUG', text: 'isCommentTrigger: only users under the elastic organisation are allowed.')
     def token = getGithubToken()
     if (repo) {
-      found = hasWritePermissions(token, repo, author)
+      found = hasWritePermissions(token, org, repo, author)
     }
     if (!found) {
       found = isMemberOfOrg(user: author, org: org)
@@ -45,7 +45,7 @@ def call(Map args){
   return found
 }
 
-def hasWritePermissions(token, repo, author) {
+def hasWritePermissions(token, org, repo, author) {
   log(level: 'DEBUG', text: 'isCommentTrigger.hasWritePermissions: User with write permissions?.')
-  return githubPrCheckApproved.hasWritePermission(token, repo, author)
+  return githubPrCheckApproved.hasWritePermission(token, org + '/' + repo, author)
 }


### PR DESCRIPTION
## What does this PR do?

Avoid failing but returning something instead

## Why is it important?

There are some issues with the API call:

```
githubApiCall: The REST API call https://api.github.com/repos/integrations/collaborators/v1v/permission return the message : java.lang.Exception: httpRequest: Failure connecting to the service https://api.github.com/repos/integrations/collaborators/v1v/permission : httpRequest: Failure connecting to the service https://api.github.com/repos/integrations/collaborators/v1v/permission[](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-3063/14/pipeline/26/#step-67-log-2)[](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Fintegrations/detail/PR-3063/14/pipeline/26/#step-67-log-3) : 

Code: 404

Error: {"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
```

