### PR TITLE
fix UT for test_no_allowed_but_member_of_elastic

### DIFF
--- a/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
+++ b/src/test/groovy/GithubPrCheckApprovedStepTests.groovy
@@ -135,7 +135,7 @@ class GithubPrCheckApprovedStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_no_allowed_but_member_of_elastic() throws Exception {
-    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [] })
+    helper.registerAllowedMethod("githubRepoGetUserPermission", [Map.class], { return [:] })
     helper.registerAllowedMethod("githubPrInfo", [Map.class], {
       return [title: 'dummy PR', user: [login: 'username'], author_association: 'NONE']
       })


### PR DESCRIPTION
## What does this PR do?

Interestingly the [PR](https://github.com/elastic/apm-pipeline-library/pull/1659) didn't fail but the merge commit failed :/ 
