### PR TITLE
feat: Update OpenTelemetry SDK to 1.11.0

### DIFF
--- a/resources/scripts/pytest_otel/requirements.txt
+++ b/resources/scripts/pytest_otel/requirements.txt
@@ -1,7 +1,7 @@
 coverage==6.2
-opentelemetry-api==1.10.0
-opentelemetry-exporter-otlp==1.10.0
-opentelemetry-sdk==1.10.0
+opentelemetry-api==1.11.0
+opentelemetry-exporter-otlp==1.11.0
+opentelemetry-sdk==1.11.0
 psutil==5.8.0
 pytest==6.2.5
 pre-commit==2.16.0


### PR DESCRIPTION
## What does this PR do?

* It updates the OpenTelemetry SDK to 1.11.0

## Why is it important?

I ran into the issue reported on https://github.com/open-telemetry/opentelemetry-python/issues/2288 when attempting to run filebeat module integration tests (process on https://www.elastic.co/guide/en/beats/devguide/current/filebeat-modules-devguide.html#_test). This occurred while reviewing https://github.com/elastic/beats/pull/31286

Updating to 1.11.0 resolves the error.

## Testing notes

To run using this copy against my filebeat integration tests I had to:
1. activate the python env
2. `pip uninstall pytest-otel; pip uninstall opentelemetry-sdk`
3. `pip install pip install ../../apm-pipeline-library/resources/scripts/pytest_otel`

I was able to confirm the correct version was being used via `pip freeze | grep opentelemetry`

At one point I also did a `pip install -r requirements.txt` from the `pytest_otel` directory. I'm uncertain if this is required on a clean virtual env or not.