### PR TITLE
Support arguments for the coverageReport step

### DIFF
--- a/vars/README.md
+++ b/vars/README.md
@@ -350,7 +350,12 @@ It requires to initialise the pipeline with githubEnv() first.
 
 ```
  coverageReport("path_to_base_folder")
+ coverageReport(baseDir: "path_to_base_folder", reportFiles: 'coverage*.html', coverageFiles: 'coverage*.xml')
 ```
+
+* baseDir: The path to the report directory relative to the workspace. Mandatory
+* reportFiles: Report Files. Mandatory
+* coverageFiles: Coverage Files. Mandatory
 
 ## createFileFromTemplate
 

--- a/vars/coverageReport.groovy
+++ b/vars/coverageReport.groovy
@@ -22,22 +22,26 @@
 
 */
 
-def call(baseDir) {
+def call(Map args = [:]) {
+  def baseDir = args.containsKey('baseDir') ? args.baseDir : error('coverageReport: baseDir parameter is required')
+  def reportFiles = args.containsKey('reportFiles') ? args.reportFiles : error('coverageReport: reportFiles parameter is required')
+  def coverageFiles = args.containsKey('coverageFiles') ? args.coverageFiles : error('coverageReport: coverageFiles parameter is required')
+
   publishHTML(target: [
     allowMissing: true,
     keepAll: true,
     reportDir: "${baseDir}",
-    reportFiles: 'coverage-*-report.html',
+    reportFiles: reportFiles,
     reportName: 'Coverage-Sourcecode-Files',
     reportTitles: 'Coverage'])
 
   publishCoverage(adapters: [
-    coberturaAdapter("${baseDir}/coverage-*-report.xml")],
+    coberturaAdapter("${baseDir}/${coverageFiles}")],
     sourceFileResolver: sourceFiles('STORE_ALL_BUILD'))
 
   cobertura(autoUpdateHealth: false,
     autoUpdateStability: false,
-    coberturaReportFile: "${baseDir}/coverage-*-report.xml",
+    coberturaReportFile: "${baseDir}/${coverageFiles}",
     conditionalCoverageTargets: '70, 0, 0',
     failNoReports: false,
     failUnhealthy: false,
@@ -48,4 +52,9 @@ def call(baseDir) {
     onlyStable: false,
     sourceEncoding: 'ASCII',
     zoomCoverageChart: false)
+}
+
+// for backward compatibility
+def call(String baseDir) {
+  call(baseDir: baseDir, reportFiles: 'coverage-*-report.html', coverageFiles: 'coverage-*-report.xml')
 }

--- a/vars/coverageReport.txt
+++ b/vars/coverageReport.txt
@@ -2,4 +2,9 @@
 
 ```
  coverageReport("path_to_base_folder")
+ coverageReport(baseDir: "path_to_base_folder", reportFiles: 'coverage*.html', coverageFiles: 'coverage*.xml')
 ```
+
+* baseDir: The path to the report directory relative to the workspace. Mandatory
+* reportFiles: Report Files. Mandatory
+* coverageFiles: Coverage Files. Mandatory


### PR DESCRIPTION
## What does this PR do?

Add Map arguments for the coverageReport

## Why is it important?

Allow to customise the coverage file and location

## Related issues

Notifies https://github.com/elastic/observability-test-environments/pull/2242
