### PR TITLE
Add description regarding the releases might not be available yet

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -63,7 +63,7 @@ pipeline {
         createPullRequest(repo: env.REPO,
                           branchName: 'main',
                           labels: 'automation',
-                          message: """### What \n Bump stack version with the latest one. \n ### Further details \n ${releaseVersions}""",
+                          message: """### What \n Bump stack version with the latest one. \n ### Further details \n ${releaseVersions} \n The release might not be available yet, if the CI failed please verify if the release is public available in https://www.elastic.co/downloads/past-releases#elasticsearch.""",
                           reviewer: 'elastic/observablt-robots-on-call',
                           stackVersions: releaseVersions,
                           title: '[automation] Update Elastic stack release version source of truth')


### PR DESCRIPTION
## What does this PR do?

Add a section in the description regarding the release might not be available yet

## Why is it important?

The bump automation runs on a weekly basis, so it's not push based, and consumers are the ones that might consume the latest available release or the upcoming one (they are the ones that decide what to do). Therefore the automation might differ a bit in terms of what files and versions are changed.

In order to avoid any misleading when a PR is created, let's add a more semantic in the description in terms of a PR could fail in the CI if the release has not been published yet.

## UI

See the below example:

<img width="935" alt="image" src="https://user-images.githubusercontent.com/2871786/165073907-feb79969-a01b-4391-a996-5fb1c630597e.png">

