### PR TITLE
Add shipper to version bump CI

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -34,6 +34,12 @@ projects:
       - main
     enabled: true
     labels: dependency,backport-skip
+  - repo: elastic-agent-shipper
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency,backport-skip
   - repo: elastic-agent
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

This is my first PR on the automation side of things, apologies if I break something. This adds the `elastic-agent-shipper` to the version bump automation. We already have the bash script in place on the repo side.

## Related issues
Related: https://github.com/elastic/elastic-agent-shipper/issues/4
