### PR TITLE
GitHub build comment should not report syntax error if there are test errors

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -115,9 +115,8 @@ ${description}
   </details>
 <%} else if (!buildStatus?.equals('ABORTED')) {%>
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
-  <p>
-  > This error is likely related to the pipeline itself. Click <a href="${env?.BUILD_URL}console">here</a>
-  > and then you will see the error (either incorrect syntax or an invalid configuration).
-  </p>
+
+> This error is likely related to the pipeline itself. Click <a href="${env?.BUILD_URL}console">here</a>
+> and then you will see the error (either incorrect syntax or an invalid configuration).
 <%}%>
 <%}%>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -113,7 +113,7 @@ ${description}
   <%}%>
   </p>
   </details>
-<%} else if (!buildStatus?.equals('ABORTED')) {%>
+<%} else if (!buildStatus?.equals('ABORTED') && testsSummary?.failed == 0) {%>
 ### Pipeline error [![1](https://img.shields.io/badge/1%20-red)](${env?.BUILD_URL}/console)
 
 > This error is likely related to the pipeline itself. Click <a href="${env?.BUILD_URL}console">here</a>


### PR DESCRIPTION
## What does this PR do?

If there are test errors then it should not be reported as a syntax error

## Why is it important?

Avoid misleading


<img width="1302" alt="image" src="https://user-images.githubusercontent.com/2871786/167845590-c40e99e0-ae30-4708-8885-2d6b47c8d528.png">
