### PR TITLE
chore: remove deprecated parameter

### DIFF
--- a/src/test/groovy/RunE2EStepTests.groovy
+++ b/src/test/groovy/RunE2EStepTests.groovy
@@ -134,9 +134,11 @@ class RunE2EStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_createParameters() throws Exception {
-    assertTrue(script.createParameters().size() == 4)
-    assertTrue(script.createParameters(testMatrixFile: '.ci/test.yml').size() == 5)
-    assertTrue(script.createParameters(testMatrixFile: '.ci/test.yml', gitHubCheckName: 'bar').size() == 6)
+    def initialSize = 3
+
+    assertTrue(script.createParameters().size() == initialSize)
+    assertTrue(script.createParameters(testMatrixFile: '.ci/test.yml').size() == (initialSize + 1))
+    assertTrue(script.createParameters(testMatrixFile: '.ci/test.yml', gitHubCheckName: 'bar').size() == (initialSize + 2))
   }
 
   @Test

--- a/vars/README.md
+++ b/vars/README.md
@@ -2826,7 +2826,6 @@ Trigger the end 2 end testing job. https://beats-ci.elastic.co/job/e2e-tests/job
 * *forceSkipGitChecks*: whether to check for Git changes to filter by modified sources. Optional (default true)
 * *forceSkipPresubmit*: whether to execute the pre-submit tests: unit and precommit. Optional (default false)
 * *kibanaVersion*: Docker tag of the kibana to be used for the tests. Optional
-* *nightlyScenarios*: whether to  include the scenarios marked as @nightly in the test execution. Optional (default false)
 * *notifyOnGreenBuilds*: whether to notify to Slack with green builds. Optional (default false for PRs)
 * *slackChannel*: the Slack channel(s) where errors will be posted. Optional.
 * *runTestsSuites*: a comma-separated list of test suites to run (default: empty to run all test suites). Optional

--- a/vars/README.md
+++ b/vars/README.md
@@ -2482,6 +2482,7 @@ emails on Failed builds that are not pull request.
 * newPRComment: The map of the data to be populated as a comment. Default empty.
 * aggregateComments: Whether to create only one single GitHub PR Comment with all the details. Default true.
 * jobName: The name of the job, e.g. `Beats/beats/main`.
+* notifyCoverageComment: Whether to add a comment in the PR with the coverage summary as a comment. Default: `true`.
 
 ## notifyStalledBeatsBumps
 Evaluate if the latest bump update was merged a few days ago and if so

--- a/vars/runE2E.groovy
+++ b/vars/runE2E.groovy
@@ -62,7 +62,6 @@ def createParameters(Map args = [:]) {
     booleanParam(name: 'forceSkipGitChecks', value: args.get('forceSkipGitChecks', true)),
     booleanParam(name: 'forceSkipPresubmit', value: args.get('forceSkipPresubmit', true)),
     booleanParam(name: 'notifyOnGreenBuilds', value: args.get('notifyOnGreenBuilds', !isPR())),
-    booleanParam(name: 'NIGHTLY_SCENARIOS', value: args.get('nightlyScenarios', false)),
   ]
 
   addStringParameterIfValue(args.get('beatVersion', ''), 'BEAT_VERSION', parameters)

--- a/vars/runE2E.txt
+++ b/vars/runE2E.txt
@@ -19,7 +19,6 @@ Trigger the end 2 end testing job. https://beats-ci.elastic.co/job/e2e-tests/job
 * *forceSkipGitChecks*: whether to check for Git changes to filter by modified sources. Optional (default true)
 * *forceSkipPresubmit*: whether to execute the pre-submit tests: unit and precommit. Optional (default false)
 * *kibanaVersion*: Docker tag of the kibana to be used for the tests. Optional
-* *nightlyScenarios*: whether to  include the scenarios marked as @nightly in the test execution. Optional (default false)
 * *notifyOnGreenBuilds*: whether to notify to Slack with green builds. Optional (default false for PRs)
 * *slackChannel*: the Slack channel(s) where errors will be posted. Optional.
 * *runTestsSuites*: a comma-separated list of test suites to run (default: empty to run all test suites). Optional


### PR DESCRIPTION
## What does this PR do?
It removes the NIGHTLY_SCENARIOS from the build step.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
That parameter has been deprecated and it's of no use. The e2e are focusing in providing profile descriptors, driven by the `testMatrixFile`
<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Related to https://github.com/elastic/e2e-testing/pull/2531
