### PR TITLE
automate the bump of beats@main with go 1.17

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -11,6 +11,7 @@
 ##  title: the PR title, empty if you'd like to use the default one.
 ##  assign: A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request. Optional.
 ##  reviewer: A comma-separated list (no spaces around the comma) of GitHub handles to request a review from. Optional.
+##  overrideGoVersion: The major.minor version to be used since some projects do not use the latest major.minor version but the previous one. Optional.
 ##
 projects:
   - repo: apm-pipeline-library
@@ -32,6 +33,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
   - repo: elastic-agent-shipper
@@ -44,6 +46,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
   - repo: fleet-server


### PR DESCRIPTION
## What does this PR do?

Allow consumers to specify what Golang major.minor version should be used for their bump automation.

It does not support multiple branches.

## Why is it important?

Given the version 1.17 and 1.18, and `1.18` the last minor release, then the automation for Beats will try to bump `1.18.patch` rather than `1.17.patch` since the branch main drives the latest minor version for Golang.

Therefore bumps will be closed https://github.com/elastic/beats/pull/31629 since 1.18 is not yet something to be enabled but the bump for `1.17`

## Related issues
Closes #ISSUE
