### PR TITLE
override go version for fleet-server

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -53,6 +53,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
   - repo: golang-crossbuild


### PR DESCRIPTION
## What does this PR do?

Add fleet-server to the override golang version

## Related issues
Similar to https://github.com/elastic/apm-pipeline-library/pull/1693

