### PR TITLE
jjbb: use github-app-apm-ci credentials

### DIFF
--- a/.ci/jobs/apm-pipeline-library-mbp.yml
+++ b/.ci/jobs/apm-pipeline-library-mbp.yml
@@ -17,7 +17,7 @@
           notification-context: 'apm-ci'
           repo: apm-pipeline-library
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/apm-test-pipeline-mbp.yml
+++ b/.ci/jobs/apm-test-pipeline-mbp.yml
@@ -29,7 +29,14 @@
           notification-context: 'apm-ci/test-pipeline'
           repo: apm-pipeline-library
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ## Use the GitHub APP to allow higher API rate limit and
+          ## integrations with the GitHub checks:
+          ##  https://github.com/jenkinsci/checks-api-plugin#pipeline-usage
+          ##  https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#warnings-checks-for-github-projects
+          ##
+          ## Otherwise, you can use the below User and Token
+          #   credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           ## suppress-scm-triggering: true creates the jobs but skip the builds

--- a/.ci/jobs/apm-update-specs-mbp.yml
+++ b/.ci/jobs/apm-update-specs-mbp.yml
@@ -17,7 +17,7 @@
           notification-context: 'apm-ci'
           repo: apm
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/chatops.yml
+++ b/.ci/jobs/chatops.yml
@@ -20,7 +20,7 @@
           #     - suppress-scm-triggering: true
           repo: apm-pipeline-library
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/ecs-logging-update-specs-mbp.yml
+++ b/.ci/jobs/ecs-logging-update-specs-mbp.yml
@@ -17,7 +17,7 @@
           notification-context: 'apm-ci'
           repo: ecs-logging
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:

--- a/.ci/jobs/observability-robots-mbp.yml
+++ b/.ci/jobs/observability-robots-mbp.yml
@@ -16,7 +16,7 @@
           notification-context: 'apm-ci'
           repo: observability-robots
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-apm-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:


### PR DESCRIPTION
## What does this PR do?

Use `github-app-apm-ci` credentials

## Why is it important?

Increase the GitHub API rate limit
Leverage the Multibranch Pipelines with further integrations:
- https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#warnings-checks-for-github-projects
- https://github.com/jenkinsci/checks-api-plugin#pipeline-usage
