### PR TITLE
ci: support warnings-ng-plugin

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
       }
       post {
         always {
-          recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc()]
+          //recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc()]
           publishChecks(name: 'example', title: 'Pipeline Check', summary: 'check through pipeline',
                         text: 'you can publish checks in pipeline script',
                         detailsURL: 'https://github.com/jenkinsci/checks-api-plugin#pipeline-usage',


### PR DESCRIPTION
## What does this PR do?

Use [warnings-ng-plugin](https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#warnings-checks-for-github-projects)

Use [publishChecks](https://github.com/jenkinsci/checks-api-plugin#pipeline-usage)

## Why is it important?

Verify if the GitHub APP works as expected