### PR TITLE
core: bump docker image for the jenkins local instance

### DIFF
--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/infra/jenkins:202111081526.13f733a5d475
+FROM docker.elastic.co/infra/jenkins:202205181458.f1daa9ac6ec5
 
 
 COPY configs/plugins.txt /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
## What does this PR do?

Bump the version matching the existing version in production