### PR TITLE
withSecretVault with support for a map of keys and environment variables

### DIFF
--- a/src/test/groovy/WithSecretVaultStepTests.groovy
+++ b/src/test/groovy/WithSecretVaultStepTests.groovy
@@ -29,17 +29,17 @@ class WithSecretVaultStepTests extends ApmBasePipelineTest {
     env.BRANCH_NAME = "branch"
     env.CHANGE_ID = "29480a51"
     env.ORG_NAME = "org"
-    env.REPO_NAME = "repo" 
+    env.REPO_NAME = "repo"
     env.GITHUB_TOKEN = "TOKEN"
   }
 
 @Test
 void testUserKey() throws Exception {
-  
+
   def isOK = false
   try {
-    
-    script.call(secret: VaultSecret.SECRET_ALT_USERNAME.toString(), user_key: 'alt_user_key', user_var_name: 'U1', pass_var_name: 'P1' ){
+
+    script.backward(secret: VaultSecret.SECRET_ALT_USERNAME.toString(), user_key: 'alt_user_key', user_var_name: 'U1', pass_var_name: 'P1' ){
       if(binding.getVariable("U1") == "username"
         && binding.getVariable("P1") == "user_password"){
         isOK = true
@@ -55,11 +55,11 @@ void testUserKey() throws Exception {
 
 @Test
 void testPassKey() throws Exception {
-  
+
   def isOK = false
   try {
-    
-    script.call(secret: VaultSecret.SECRET_ALT_PASSKEY.toString(), pass_key: 'alt_pass_key', user_var_name: 'U1', pass_var_name: 'P1' ){
+
+    script.backward(secret: VaultSecret.SECRET_ALT_PASSKEY.toString(), pass_key: 'alt_pass_key', user_var_name: 'U1', pass_var_name: 'P1' ){
       if(binding.getVariable("U1") == "username"
         && binding.getVariable("P1") == "user_password"){
         isOK = true
@@ -76,10 +76,11 @@ void testPassKey() throws Exception {
   @Test
   void testMissingArguments() throws Exception {
     try {
-      script.call(secret: VaultSecret.SECRET.toString(), user_var_name: 'foo'){
+      script.backward(secret: VaultSecret.SECRET.toString(), user_var_name: 'foo'){
         //NOOP
       }
     } catch(e){
+      println e
       //NOOP
     }
     printCallStack()
@@ -90,7 +91,7 @@ void testPassKey() throws Exception {
   @Test
   void testSecretError() throws Exception {
     try {
-      script.call(secret: VaultSecret.SECRET_ERROR.toString(), user_var_name: 'foo', pass_var_name: 'bar'){
+      script.backward(secret: VaultSecret.SECRET_ERROR.toString(), user_var_name: 'foo', pass_var_name: 'bar'){
         //NOOP
       }
     } catch(e){
@@ -104,7 +105,7 @@ void testPassKey() throws Exception {
   @Test
   void testSecretNotFound() throws Exception {
     try{
-      script.call(secret: 'secretNotExists', user_var_name: 'foo', pass_var_name: 'bar'){
+      script.backward(secret: 'secretNotExists', user_var_name: 'foo', pass_var_name: 'bar'){
         //NOOP
       }
     } catch(e){
@@ -118,7 +119,7 @@ void testPassKey() throws Exception {
   @Test
   void test() throws Exception {
     def isOK = false
-    script.call(secret: VaultSecret.SECRET.toString(), user_var_name: 'foo', pass_var_name: 'bar'){
+    script.backward(secret: VaultSecret.SECRET.toString(), user_var_name: 'foo', pass_var_name: 'bar'){
       isOK = true
     }
 
@@ -130,7 +131,7 @@ void testPassKey() throws Exception {
   @Test
   void testParams() throws Exception {
     def isOK = false
-    script.call(secret: VaultSecret.SECRET.toString(), user_var_name: 'U1', pass_var_name: 'P1'){
+    script.backward(secret: VaultSecret.SECRET.toString(), user_var_name: 'U1', pass_var_name: 'P1'){
       if(binding.getVariable("U1") == "username"
         && binding.getVariable("P1") == "user_password"){
         isOK = true

--- a/src/test/groovy/WithSecretVaultStepTests.groovy
+++ b/src/test/groovy/WithSecretVaultStepTests.groovy
@@ -141,4 +141,19 @@ void testPassKey() throws Exception {
     assertTrue(isOK)
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_with_data() throws Exception {
+    def isOK = false
+    script.call(secret: VaultSecret.SECRET_ALT_USERNAME.toString(), data: [ 'alt_user_key': 'U1', 'password': 'P1'] ){
+      if(binding.getVariable("U1") == "username"
+        && binding.getVariable("P1") == "user_password"){
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertJobStatusSuccess()
+    assertTrue(isOK)
+  }
+
 }

--- a/src/test/groovy/WithSecretVaultStepTests.groovy
+++ b/src/test/groovy/WithSecretVaultStepTests.groovy
@@ -17,6 +17,7 @@
 
 import org.junit.Before
 import org.junit.Test
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
 class WithSecretVaultStepTests extends ApmBasePipelineTest {
@@ -35,10 +36,8 @@ class WithSecretVaultStepTests extends ApmBasePipelineTest {
 
 @Test
 void testUserKey() throws Exception {
-
   def isOK = false
   try {
-
     script.backward(secret: VaultSecret.SECRET_ALT_USERNAME.toString(), user_key: 'alt_user_key', user_var_name: 'U1', pass_var_name: 'P1' ){
       if(binding.getVariable("U1") == "username"
         && binding.getVariable("P1") == "user_password"){
@@ -156,4 +155,15 @@ void testPassKey() throws Exception {
     assertTrue(isOK)
   }
 
+  @Test
+  void test_without_data() throws Exception {
+    def isOK = false
+    testMissingArgument('', 'Missing variables') {
+      script.call(secret: VaultSecret.SECRET.toString()) {
+        isOK = true
+      }
+    }
+    printCallStack()
+    assertFalse(isOK)
+  }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -3808,7 +3808,23 @@ environment variables:
 
 ## withSecretVault
 Grab a secret from the vault, define the environment variables which have been
-passed as parameters and mask the secrets
+passed as parameters and mask the secrets.
+
+* secret: Name of the secret on the the vault root path. Mandatory
+* data: What's the data to be read, format [ field: environmentVariable ]. Optional
+* user_var_name: the env variable for the user id secret. Deprecated
+* pass_var_name: the env variable for the pass id secret. Deprecated
+* user_key: the user field secret. Default 'user'. Deprecated
+* pass_key: the pass field secret. Default 'password'. Deprecated
+
+```
+// Read the field api_key from the secret vault and create the
+// masked environment variable API_KEY
+withSecretVault(secret: 'secret', data: [ 'api_key': 'API_KEY'] ){
+  //block
+}
+
+#### Deprecated
 
 The secret must normally have this format
 `{ data: { user: 'username', password: 'user_password'} }`

--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -32,8 +32,9 @@ def call(Map args = [:], Closure body) {
     backward(args, body)
   } else {
     def vars = [:]
+    def props = readSecretFromVault(args)
     data.each{ k, v ->
-      vars << readSecret(args, k, v)
+      vars << readSecret(props, k, v)
     }
     withEnvMask(vars: vars){
       body()
@@ -41,14 +42,11 @@ def call(Map args = [:], Closure body) {
   }
 }
 
-def readSecret(Map args = [:], key_id, environment_variable) {
-  if (!args.secret || !key_id || !environment_variable) {
+def readSecret(props, key_id, environment_variable) {
+  if (!props || !key_id || !environment_variable) {
     error "withSecretVault: Missing variables"
   }
-
-  def props = readSecretFromVault(args)
   def value = props?.data?.get(key_id)
-
   if(value == null){
     error('withSecretVault: was not possible to get authentication info')
   }

--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -17,7 +17,7 @@
 
 /**
   Grab a secret from the vault, define the environment variables which have been
-  passed as parammeters and mask the secrets
+  passed as parameters and mask the secrets
 
   withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: 'my_password_env'){
     //block
@@ -25,28 +25,53 @@
 */
 def call(Map args = [:], Closure body) {
   def secret = args?.secret
+  def data = args?.get('data', [:])
+
+  // For backward compatibility
+  if (data.isEmpty()) {
+    backward(args, body)
+  } else {
+    def vars = [:]
+    data.each{ k, v ->
+      vars << readSecret(args, k, v)
+    }
+    withEnvMask(vars: vars){
+      body()
+    }
+  }
+}
+
+def readSecret(Map args = [:], key_id, environment_variable) {
+  if (!args.secret || !key_id || !environment_variable) {
+    error "withSecretVault: Missing variables"
+  }
+
+  def props = readSecretFromVault(args)
+  def value = props?.data?.get(key_id)
+
+  if(value == null){
+    error('withSecretVault: was not possible to get authentication info')
+  }
+  return [var: "${environment_variable}", password: value]
+}
+
+def backward(Map args = [:], Closure body) {
+  def secret = args?.secret
   def user_variable = args?.user_var_name
   def user_key = args.containsKey('user_key') ? args.user_key : 'user'
   def pass_variable = args?.pass_var_name
   def pass_key = args.containsKey('pass_key') ? args.pass_key : 'password'
 
-  def role_id = args.containsKey('role_id') ? args.role_id : 'vault-role-id'
-  def secret_id = args.containsKey('secret_id') ? args.secret_id : 'vault-secret-id'
-
   if (!secret || !user_variable || !pass_variable) {
-    error "withSecretVault: Missing variables"
+    error('withSecretVault: Missing variables')
   }
 
-  def props = getVaultSecret(secret: secret, role_id: role_id, secret_id: secret_id)
-  if(props?.errors){
-    error "withSecretVault: Unable to get credentials from the vault: " + props.errors.toString()
-  }
-
+  def props = readSecretFromVault(args)
   def user = props?.data?.get(user_key)
   def password = props?.data?.get(pass_key)
 
   if(user == null || password == null){
-    error "withSecretVault: was not possible to get authentication info"
+    error("withSecretVault: was not possible to get authentication info")
   }
 
   wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [
@@ -57,4 +82,14 @@ def call(Map args = [:], Closure body) {
       body()
     }
   }
+}
+
+def readSecretFromVault(args) {
+  def role_id = args.containsKey('role_id') ? args.role_id : 'vault-role-id'
+  def secret_id = args.containsKey('secret_id') ? args.secret_id : 'vault-secret-id'
+  def props = getVaultSecret(secret: args.secret, role_id: role_id, secret_id: secret_id)
+  if(props?.errors){
+    error("withSecretVault: Unable to get credentials from the vault: " + props.errors.toString())
+  }
+  return props
 }

--- a/vars/withSecretVault.groovy
+++ b/vars/withSecretVault.groovy
@@ -19,19 +19,18 @@
   Grab a secret from the vault, define the environment variables which have been
   passed as parameters and mask the secrets
 
-  withSecretVault(secret: 'secret', user_var_name: 'my_user_env', pass_var_name: 'my_password_env'){
+  withSecretVault(secret: 'secret', data: [ 'api_key': 'API_KEY'] ){
     //block
   }
 */
 def call(Map args = [:], Closure body) {
   def secret = args?.secret
   def data = args?.get('data', [:])
-
   // For backward compatibility
   if (data.isEmpty()) {
     backward(args, body)
   } else {
-    def vars = [:]
+    def vars = []
     def props = readSecretFromVault(args)
     data.each{ k, v ->
       vars << readSecret(props, k, v)

--- a/vars/withSecretVault.txt
+++ b/vars/withSecretVault.txt
@@ -1,5 +1,17 @@
 Grab a secret from the vault, define the environment variables which have been
-passed as parameters and mask the secrets
+passed as parameters and mask the secrets.
+
+* secret: Name of the secret on the the vault root path. Mandatory
+* data: What's the data to be read, format [ field: environmentVariable ]. Mandatory
+
+```
+// Read the field api_key from the secret vault and create the
+// masked environment variable API_KEY
+withSecretVault(secret: 'secret', data: [ 'api_key': 'API_KEY'] ){
+  //block
+}
+
+#### Deprecated
 
 The secret must normally have this format
 `{ data: { user: 'username', password: 'user_password'} }`

--- a/vars/withSecretVault.txt
+++ b/vars/withSecretVault.txt
@@ -2,7 +2,11 @@ Grab a secret from the vault, define the environment variables which have been
 passed as parameters and mask the secrets.
 
 * secret: Name of the secret on the the vault root path. Mandatory
-* data: What's the data to be read, format [ field: environmentVariable ]. Mandatory
+* data: What's the data to be read, format [ field: environmentVariable ]. Optional
+* user_var_name: the env variable for the user id secret. Deprecated
+* pass_var_name: the env variable for the pass id secret. Deprecated
+* user_key: the user field secret. Default 'user'. Deprecated
+* pass_key: the pass field secret. Default 'password'. Deprecated
 
 ```
 // Read the field api_key from the secret vault and create the


### PR DESCRIPTION
## What does this PR do?

Generalise `withSecretVault` to support a data structure with the format [`secret field in vault`: `environment variable`]

## Why is it important?

Support other cases to simplify the consumers

## Issues

Notifies https://github.com/elastic/apm-server/pull/8180