### PR TITLE
golang: onboard new projects to the autobump

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -49,6 +49,27 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
+  - repo: elastic-agent-autodiscover
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    overrideGoVersion: "1.17"
+    enabled: true
+    labels: dependency
+  - repo: elastic-agent-libs
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    overrideGoVersion: "1.17"
+    enabled: true
+    labels: dependency
+  - repo: elastic-agent-system-metrics
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    overrideGoVersion: "1.17"
+    enabled: true
+    labels: dependency
   - repo: fleet-server
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Onboard new projects to the Golang auto-bump


## Issues

Notifies https://github.com/elastic/elastic-agent-autodiscover/pull/11 https://github.com/elastic/elastic-agent-libs/pull/53 and  https://github.com/elastic/elastic-agent-system-metrics/pull/29



