### PR TITLE
golang: onboard elastic-agent-inputs

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -56,6 +56,12 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
+  - repo: elastic-agent-inputs
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency
   - repo: elastic-agent-libs
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -60,6 +60,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
   - repo: elastic-agent-libs


### PR DESCRIPTION
## What does this PR do?

onboard elastic-agent-inputs for the golang autobump, it uses the current golang version `1.18` rather than `1.17`


## Related issues

Uses https://github.com/elastic/elastic-agent-inputs/pull/13

Closes https://github.com/elastic/apm-pipeline-library/issues/1712