### PR TITLE
ci: build opbeans-php

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
@@ -217,7 +217,8 @@ def opbeansDockerImages = [
   "opbeans-frontend",
   "opbeans-java",
   "opbeans-go",
-  "opbeans-loadgen",
+  "opbeans-loadgen",,
+  "opbeans-php",
   "opbeans-ruby"
   /** FIXME disable until it is fully implemented: git@github.com:elastic/opbeans-flask/pull/5
   "opbeans-flask",*/

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
@@ -217,7 +217,7 @@ def opbeansDockerImages = [
   "opbeans-frontend",
   "opbeans-java",
   "opbeans-go",
-  "opbeans-loadgen",,
+  "opbeans-loadgen",
   "opbeans-php",
   "opbeans-ruby"
   /** FIXME disable until it is fully implemented: git@github.com:elastic/opbeans-flask/pull/5


### PR DESCRIPTION
### What

Build the docker images for the opbeans-php

### Why

Cache artifacts

### Issue

Caused by https://github.com/elastic/opbeans-php/pull/10


