### PR TITLE
Add new signature to notify results as GitHub issues

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -281,13 +281,14 @@ def notifyGitHubCommandsInPR(Map args = [:]) {
 */
 def createGitHubIssue(Map args = [:]) {
   def body = args.get('comment', '')
+  def buildStatus = args.get('buildStatus', 'unknown')
+  def title = args.get('githubTitle', "Build ${env.BUILD_NUMBER} for ${env.BRANCH_NAME} with status '${buildStatus}'")
   // In case body is empty let's fallback to the previous behaviour for compatibility reasons.
   if (!body?.trim()) {
     def arguments = args
     arguments['archiveFile'] = false
     body = generateBuildReport(arguments)
   }
-  def title = "[${env.BRANCH_NAME}@${env.GIT_BASE_COMMIT}] Failed build - auto-generated"
   def labels = 'automation,ci-reported'
   if (args.containsKey('githubLabels') && args.githubLabels?.trim()) {
     labels += ",${args.githubLabels}"

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -279,7 +279,7 @@ def notifyGitHubCommandsInPR(Map args = [:]) {
 /**
  * This method creates a GitHub issue with the build result
 */
-def notifyGitHubIssue(Map args = [:]) {
+def createGitHubIssue(Map args = [:]) {
   def body = args.get('comment', '')
   // In case body is empty let's fallback to the previous behaviour for compatibility reasons.
   if (!body?.trim()) {
@@ -296,7 +296,7 @@ def notifyGitHubIssue(Map args = [:]) {
   if (args.containsKey('githubAssignees') && args.githubAssignees?.trim()) {
      issueArgs += [assign: args.githubAssignees]
   }
-  catchError(buildResult: 'SUCCESS', message: 'notifyGitHubIssue: Error creating the GitHub issue') {
+  catchError(buildResult: 'SUCCESS', message: 'createGitHubIssue: Error creating the GitHub issue') {
     retryWithSleep(retries: 2, seconds: 5, backoff: true) {
       output = githubCreateIssue(issueArgs)
     }

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -280,12 +280,9 @@ def notifyGitHubCommandsInPR(Map args = [:]) {
  * This method creates a GitHub issue with the build result
 */
 def notifyGitHubIssue(Map args = [:]) {
-  // As long as the build.md file exists then there is no need to generate it again
-  def body
-  if (fileExists('build.md')) {
-    body = readFile(file: 'build.md')
-  } else {
-    // let's fallback to generate the build report again
+  def body = args.get('comment', '')
+  // In case body is empty let's fallback to the previous behaviour for compatibility reasons.
+  if (!body?.trim()) {
     def arguments = args
     arguments['archiveFile'] = false
     body = generateBuildReport(arguments)

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -294,7 +294,7 @@ def notifyGitHubIssue(Map args = [:]) {
   }
   def issueArgs = [ title: title, description: body, labels: labels ]
   if (args.containsKey('githubAssignees') && args.githubAssignees?.trim()) {
-     issueArgs += [assignee: args.githubAssignees]
+     issueArgs += [assign: args.githubAssignees]
   }
   catchError(buildResult: 'SUCCESS', message: 'notifyGitHubIssue: Error creating the GitHub issue') {
     retryWithSleep(retries: 2, seconds: 5, backoff: true) {

--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -291,8 +291,12 @@ def notifyGitHubIssue(Map args = [:]) {
     body = generateBuildReport(arguments)
   }
   def title = "[${env.BRANCH_NAME}@${env.GIT_BASE_COMMIT}] Failed build - auto-generated"
-  def issueArgs = [ title: title, description: body, labels: 'automation,ci-reported' ]
-  if (args.containsKey('githubAssignees') && args.get('githubAssignees', '').trim()) {
+  def labels = 'automation,ci-reported'
+  if (args.containsKey('githubLabels') && args.githubLabels?.trim()) {
+    labels += ",${args.githubLabels}"
+  }
+  def issueArgs = [ title: title, description: body, labels: labels ]
+  if (args.containsKey('githubAssignees') && args.githubAssignees?.trim()) {
      issueArgs += [assignee: args.githubAssignees]
   }
   catchError(buildResult: 'SUCCESS', message: 'notifyGitHubIssue: Error creating the GitHub issue') {

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -1064,6 +1064,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     script.notifyGitHubIssue()
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported}'))
   }
 
   @Test
@@ -1072,6 +1073,22 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
     script.notifyGitHubIssue(githubAssignees: 'foo')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'assignee=foo'))
+  }
+
+  @Test
+  void test_notifyGitHubIssue_with_null_assignee() throws Exception {
+    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
+    script.notifyGitHubIssue(githubAssignees: null)
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
+  }
+
+  @Test
+  void test_notifyGitHubIssue_with_labels() throws Exception {
+    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
+    script.notifyGitHubIssue(githubLabels: 'foo')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported,foo}'))
   }
 
   @Test

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -1059,37 +1059,37 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
-  void test_notifyGitHubIssue() throws Exception {
-    script.notifyGitHubIssue(comment: 'my build report')
+  void test_createGitHubIssue() throws Exception {
+    script.createGitHubIssue(comment: 'my build report')
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported}'))
   }
 
   @Test
-  void test_notifyGitHubIssue_with_assignee() throws Exception {
-    script.notifyGitHubIssue(githubAssignees: 'foo', comment: 'my build report')
+  void test_createGitHubIssue_with_assignee() throws Exception {
+    script.createGitHubIssue(githubAssignees: 'foo', comment: 'my build report')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'assignee=foo'))
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'assign=foo'))
   }
 
   @Test
-  void test_notifyGitHubIssue_with_null_assignee() throws Exception {
-    script.notifyGitHubIssue(githubAssignees: null, comment: 'my build report')
+  void test_createGitHubIssue_with_null_assignee() throws Exception {
+    script.createGitHubIssue(githubAssignees: null, comment: 'my build report')
     printCallStack()
-    assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
+    assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assign'))
   }
 
   @Test
-  void test_notifyGitHubIssue_with_labels() throws Exception {
-    script.notifyGitHubIssue(githubLabels: 'foo', comment: 'my build report')
+  void test_createGitHubIssue_with_labels() throws Exception {
+    script.createGitHubIssue(githubLabels: 'foo', comment: 'my build report')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported,foo}'))
   }
 
   @Test
-  void test_notifyGitHubIssue_if_no_buildmd() throws Exception {
-    script.notifyGitHubIssue(
+  void test_createGitHubIssue_if_no_buildmd() throws Exception {
+    script.createGitHubIssue(
       build: readJSON(file: 'build-info.json'),
       buildStatus: 'SUCCESS',
       changeSet: readJSON(file: 'changeSet-info.json'),

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -1088,6 +1088,13 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_createGitHubIssue_with_title() throws Exception {
+    script.createGitHubIssue(githubLabels: 'foo', comment: 'my build report', githubTitle: 'my-title')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'title=my-title'))
+  }
+
+  @Test
   void test_createGitHubIssue_if_no_buildmd() throws Exception {
     script.createGitHubIssue(
       build: readJSON(file: 'build-info.json'),

--- a/src/test/groovy/NotificationManagerStepTests.groovy
+++ b/src/test/groovy/NotificationManagerStepTests.groovy
@@ -1060,8 +1060,7 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_notifyGitHubIssue() throws Exception {
-    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
-    script.notifyGitHubIssue()
+    script.notifyGitHubIssue(comment: 'my build report')
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported}'))
@@ -1069,31 +1068,27 @@ class NotificationManagerStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_notifyGitHubIssue_with_assignee() throws Exception {
-    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
-    script.notifyGitHubIssue(githubAssignees: 'foo')
+    script.notifyGitHubIssue(githubAssignees: 'foo', comment: 'my build report')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'assignee=foo'))
   }
 
   @Test
   void test_notifyGitHubIssue_with_null_assignee() throws Exception {
-    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
-    script.notifyGitHubIssue(githubAssignees: null)
+    script.notifyGitHubIssue(githubAssignees: null, comment: 'my build report')
     printCallStack()
     assertFalse(assertMethodCallContainsPattern('githubCreateIssue', 'assignee'))
   }
 
   @Test
   void test_notifyGitHubIssue_with_labels() throws Exception {
-    helper.registerAllowedMethod('readFile', [Map.class], { 'my generated build report' })
-    script.notifyGitHubIssue(githubLabels: 'foo')
+    script.notifyGitHubIssue(githubLabels: 'foo', comment: 'my build report')
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('githubCreateIssue', 'labels=automation,ci-reported,foo}'))
   }
 
   @Test
   void test_notifyGitHubIssue_if_no_buildmd() throws Exception {
-    helper.registerAllowedMethod('fileExists', [String.class], { return false })
     script.notifyGitHubIssue(
       build: readJSON(file: 'build-info.json'),
       buildStatus: 'SUCCESS',

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -308,7 +308,7 @@ def notifySlack(def args=[:]) {
   }
 }
 
-def notifyGithubIssue(Map args=[:]) {
+def notifyGithubIssue(def args=[:]) {
   if(args.when) {
     log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in github.")
     catchError(message: "There were some failures when notifying results in github", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -50,7 +50,7 @@ def call(Map args = [:]) {
   def notifySlackComment = args.containsKey('slackComment') ? args.slackComment : false
   def analyzeFlakey = args.containsKey('analyzeFlakey') ? args.analyzeFlakey : false
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
-  def notifyGithubIssue = args.containsKey('githubIssue') ? args.githubIssue : false
+  def githubIssue = args.containsKey('githubIssue') ? args.githubIssue : false
   def githubAssignees = args.get('githubAssignees', '')
   def githubLabels = args.get('githubLabels', '')
 
@@ -108,7 +108,7 @@ def call(Map args = [:]) {
         // Notify only if there are notifications and they should be aggregated and env.GITHUB_CHECK feature flag is enabled.
         aggregateGitHubCheck(when: (aggregateComments && notifications?.size() > 0 && env.GITHUB_CHECK?.equals('true')), notifications: notifications)
 
-        notifyGithubIssue(data: data, when: notifyGithubIssue)
+        notifyGithubIssue(data: data, when: githubIssue)
       }
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -50,7 +50,7 @@ def call(Map args = [:]) {
   def notifySlackComment = args.containsKey('slackComment') ? args.slackComment : false
   def analyzeFlakey = args.containsKey('analyzeFlakey') ? args.analyzeFlakey : false
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
-  def githubIssue = args.containsKey('githubIssue') ? args.githubIssue : false
+  def notifyGHIssue = args.containsKey('githubIssue') ? args.githubIssue : false
   def githubAssignees = args.get('githubAssignees', '')
   def githubLabels = args.get('githubLabels', '')
 
@@ -108,7 +108,7 @@ def call(Map args = [:]) {
         // Notify only if there are notifications and they should be aggregated and env.GITHUB_CHECK feature flag is enabled.
         aggregateGitHubCheck(when: (aggregateComments && notifications?.size() > 0 && env.GITHUB_CHECK?.equals('true')), notifications: notifications)
 
-        notifyGithubIssue(data: data, when: githubIssue)
+        createGitHubIssue(data: data, when: notifyGHIssue)
       }
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -308,11 +308,11 @@ def notifySlack(def args=[:]) {
   }
 }
 
-def notifyGithubIssue(def args=[:]) {
+def createGitHubIssue(def args=[:]) {
   if(args.when) {
     log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in github.")
     catchError(message: "There were some failures when notifying results in github", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-      (new NotificationManager()).notifyGithubIssue(args.data)
+      (new NotificationManager()).createGitHubIssue(args.data)
     }
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -82,6 +82,9 @@ def call(Map args = [:]) {
         data['jobName'] = jobName
         data['githubAssignees'] = githubAssignees
         data['githubLabels'] = githubLabels
+        if (args.containsKey('githubTitle')) {
+          data['githubTitle'] = githubTitle
+        }
         data['disableGHIssueCreation'] = flakyDisableGHIssueCreation
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -52,6 +52,7 @@ def call(Map args = [:]) {
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
   def notifyGithubIssue = args.get('githubIssue', false)
   def githubAssignees = args.get('githubAssignees', '')
+  def githubLabels = args.get('githubLabels', '')
 
   node('master || metal || linux'){
     stage('Reporting build status'){
@@ -80,6 +81,7 @@ def call(Map args = [:]) {
         data['enabled'] = slackNotify
         data['jobName'] = jobName
         data['githubAssignees'] = githubAssignees
+        data['githubLabels'] = githubLabels
         data['disableGHIssueCreation'] = flakyDisableGHIssueCreation
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -50,7 +50,7 @@ def call(Map args = [:]) {
   def notifySlackComment = args.containsKey('slackComment') ? args.slackComment : false
   def analyzeFlakey = args.containsKey('analyzeFlakey') ? args.analyzeFlakey : false
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
-  def notifyGithubIssue = args.get('githubIssue', false)
+  def notifyGithubIssue = args.containsKey('githubIssue') ? args.githubIssue : false
   def githubAssignees = args.get('githubAssignees', '')
   def githubLabels = args.get('githubLabels', '')
 

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -50,6 +50,8 @@ def call(Map args = [:]) {
   def notifySlackComment = args.containsKey('slackComment') ? args.slackComment : false
   def analyzeFlakey = args.containsKey('analyzeFlakey') ? args.analyzeFlakey : false
   def newPRComment = args.containsKey('newPRComment') ? args.newPRComment : [:]
+  def notifyGithubIssue = args.get('githubIssue', false)
+  def githubAssignees = args.get('githubAssignees', '')
 
   node('master || metal || linux'){
     stage('Reporting build status'){
@@ -77,7 +79,7 @@ def call(Map args = [:]) {
         data['credentialId'] = slackCredentials
         data['enabled'] = slackNotify
         data['jobName'] = jobName
-
+        data['githubAssignees'] = githubAssignees
         data['disableGHIssueCreation'] = flakyDisableGHIssueCreation
         // Allow to aggregate the comments, for such it disables the default notifications.
         data['disableGHComment'] = aggregateComments
@@ -103,6 +105,8 @@ def call(Map args = [:]) {
 
         // Notify only if there are notifications and they should be aggregated and env.GITHUB_CHECK feature flag is enabled.
         aggregateGitHubCheck(when: (aggregateComments && notifications?.size() > 0 && env.GITHUB_CHECK?.equals('true')), notifications: notifications)
+
+        notifyGithubIssue(data: data, when: notifyGithubIssue)
       }
 
       catchError(message: 'There were some failures when sending data to elasticsearch', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -298,6 +302,15 @@ def notifySlack(def args=[:]) {
     log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in slack.")
     catchError(message: "There were some failures when notifying results in slack", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
       (new NotificationManager()).notifySlack(args.data)
+    }
+  }
+}
+
+def notifyGithubIssue(def args=[:]) {
+  if(args.when) {
+    log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in github.")
+    catchError(message: "There were some failures when notifying results in github", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+      (new NotificationManager()).notifyGithubIssue(args.data)
     }
   }
 }

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -308,7 +308,7 @@ def notifySlack(def args=[:]) {
   }
 }
 
-def notifyGithubIssue(def args=[:]) {
+def notifyGithubIssue(Map args=[:]) {
   if(args.when) {
     log(level: 'DEBUG', text: "notifyBuildResult: Notifying results in github.")
     catchError(message: "There were some failures when notifying results in github", buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -42,3 +42,4 @@ emails on Failed builds that are not pull request.
 * notifyCoverageComment: Whether to add a comment in the PR with the coverage summary as a comment. Default: `true`.
 * githubIssue: Whether to create a GitHub issue with the build status. Default: `false`.
 * githubAssignees: What GitHub assignees to be added in the GitHub issue. Default value uses ``.
+* githubLabels: What GitHub labels to be added in the GitHub issue in addition to `automation,ci-reported`. Optional

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -40,3 +40,5 @@ emails on Failed builds that are not pull request.
 * aggregateComments: Whether to create only one single GitHub PR Comment with all the details. Default true.
 * jobName: The name of the job, e.g. `Beats/beats/main`.
 * notifyCoverageComment: Whether to add a comment in the PR with the coverage summary as a comment. Default: `true`.
+* githubIssue: Whether to create a GitHub issue with the build status. Default: `false`.
+* githubAssignees: What GitHub assignees to be added in the GitHub issue. Default value uses ``.

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -43,3 +43,4 @@ emails on Failed builds that are not pull request.
 * githubIssue: Whether to create a GitHub issue with the build status. Default: `false`.
 * githubAssignees: What GitHub assignees to be added in the GitHub issue. Default value uses ``.
 * githubLabels: What GitHub labels to be added in the GitHub issue in addition to `automation,ci-reported`. Optional
+* githubTitle: What GitHub title to be added in the GitHub issue. Default: `Build ${env.BUILD_NUMBER} for ${env.BRANCH_NAME} with status '${buildStatus}'`.


### PR DESCRIPTION
## What does this PR do?

Leverage the build notifications to support GitHub issues creation when the build in the CI fails or when it's forced to do it so.

## Why is it important?

Centralise the notifications in GitHub so the person on-call need to look for certain issues with some filters

## Issues

Notifies https://github.com/elastic/beats/pull/31954