### PR TITLE
Enable to disable Elasticsearch in withClusterEnv

### DIFF
--- a/src/test/groovy/WithClusterEnvStepTests.groovy
+++ b/src/test/groovy/WithClusterEnvStepTests.groovy
@@ -37,8 +37,22 @@ class WithClusterEnvStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('withEnvMask', 'var=ELASTICSEARCH_URL'))
     assertFalse(assertMethodCallContainsPattern('withEnvMask', 'var=KIBANA_URL'))
     assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_without_elasticsearch() throws Exception {
+    def isOK = false
+    script.call(cluster: 'foo', elasticsearch: false) {
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertJobStatusSuccess()
+    assertFalse(assertMethodCallContainsPattern('withElasticsearchDeploymentEnv', 'foo'))
+    assertFalse(assertMethodCallContainsPattern('withEnvMask', 'var=ELASTICSEARCH_URL'))
   }
 
   @Test

--- a/vars/README.md
+++ b/vars/README.md
@@ -487,6 +487,13 @@ Print a text on color on a xterm.
 * *colorfg*: Foreground color.(default, red, green, yellow,...)
 * *colorbg*: Background color.(default, red, green, yellow,...)
 
+## errorIfEmpty
+If the given value is empty or null then it throws an error
+
+```
+errorIfEmpty(my_value, "it is not supported.")
+```
+
 ## fastCheckout
 Only make a Git checkout of the refspec passed as parameter, and not tags, this make the checkout faster.
 This checkout does not work with tags.
@@ -1803,6 +1810,15 @@ It requires [Github Pipeline plugin](https://plugins.jenkins.io/pipeline-github/
 * *comment:* GitHub comment (by default `env.GITHUB_COMMENT`).
 * *repository*: The GitHub repository (by default `env.REPO_NAME`).
 * *org*: the GitHub organisation (by default `elastic`).
+
+## isEmpty
+If the given value is empty or null
+
+```
+whenTrue(isEmpty("")) {
+  //
+}
+```
 
 ## isGitRegionMatch
 Given the list of patterns, the CHANGE_TARGET, GIT_BASE_COMMIT env variables and the kind of match then it
@@ -3416,6 +3432,7 @@ for the Cloud deployments, aka clusters.
 ```
 
 * cluster: Name of the cluster that was already created. Mandatory
+* elasticsearch: Whether to configure the environment variables with the Elasticsearch URL/User/Pass. Optional
 * kibana: Whether to configure the environment variables with the Kibana URL. Optional
 
 NOTE: secrets for the test clusters are located in Vault, see `getTestClusterSecret`

--- a/vars/withClusterEnv.groovy
+++ b/vars/withClusterEnv.groovy
@@ -27,12 +27,24 @@
 def call(Map args = [:], Closure body) {
   log(level: 'INFO', text: 'withClusterEnv')
 
-  withElasticsearchDeploymentEnv(args) {
+  // For backward compatibilites, let's keep the previous behaviour,
+  // and keep Elasticsearch enable by default .
+  withElasticsearch(args, args.get('elasticsearch', true)) {
     // For backward compatibilites, let's keep the previous behaviour,
     // and enable the kibana env variable context explicitly.
     withKibana(args, args.get('kibana', false)) {
       body()
     }
+  }
+}
+
+def withElasticsearch(args, enabled, body) {
+  if (enabled) {
+    withElasticsearchDeploymentEnv(args) {
+      body()
+    }
+  } else {
+    body()
   }
 }
 

--- a/vars/withClusterEnv.txt
+++ b/vars/withClusterEnv.txt
@@ -8,6 +8,7 @@ for the Cloud deployments, aka clusters.
 ```
 
 * cluster: Name of the cluster that was already created. Mandatory
+* elasticsearch: Whether to configure the environment variables with the Elasticsearch URL/User/Pass. Optional
 * kibana: Whether to configure the environment variables with the Kibana URL. Optional
 
 NOTE: secrets for the test clusters are located in Vault, see `getTestClusterSecret`


### PR DESCRIPTION
## What does this PR do?

Keep the default behaviour but allow to disable the Elasticsearch env variables.

## Why is it important?

Fine granularity to configure the step accordingly.

