### PR TITLE
Read k8s-elasticsearch for the cloud deployment

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -45,9 +45,6 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     SECRET_AWS_PROVISIONER('service-account/aws-provisioner'),
     SECRET_AZURE('secret/apm-team/ci/apm-agent-dotnet-azure'),
     SECRET_AZURE_VM_EXTENSION('secret/observability-team/ci/service-account/azure-vm-extension'),
-    SECRET_CLOUD_ERROR('secret/observability-team/ci/test-clusters/error/ec-deployment'),
-    SECRET_CLOUD_FOO('secret/observability-team/ci/test-clusters/foo/ec-deployment'),
-    SECRET_CLOUD_MISSING('secret/observability-team/ci/test-clusters/missing/ec-deployment'),
     SECRET_CLUSTER_ERROR('secret/observability-team/ci/test-clusters/error/k8s-elasticsearch'),
     SECRET_CLUSTER_FOO('secret/observability-team/ci/test-clusters/foo/k8s-elasticsearch'),
     SECRET_CLUSTER_MISSING('secret/observability-team/ci/test-clusters/missing/k8s-elasticsearch'),
@@ -703,23 +700,14 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
     if(VaultSecret.SECRET_AZURE_VM_EXTENSION.equals(s)){
       return [data: [ password: 'password_1', username: 'username_1', subscription: 'subscription_id_1', tenant: 'tenant_id_1' ]]
     }
-    if(VaultSecret.SECRET_CLOUD_ERROR.equals(s)){
-      return [errors: 'Error message']
-    }
-    if(VaultSecret.SECRET_CLOUD_FOO.equals(s)){
-      return [data: [ username: 'username-1', password: 'password-1', cluster: [ cloud_id: 'my-cloud_id-1' ]]]
-    }
-    if(VaultSecret.SECRET_CLOUD_MISSING.equals(s)){
-      return [data: [ username: 'username-1', password: 'password-1' ]]
-    }
     if(VaultSecret.SECRET_CLUSTER_ERROR.equals(s) || VaultSecret.SECRET_FLEET_CLUSTER_ERROR.equals(s) || VaultSecret.SECRET_KIBANA_CLUSTER_ERROR.equals(s)){
       return [errors: 'Error message']
     }
     if(VaultSecret.SECRET_CLUSTER_FOO.equals(s) || VaultSecret.SECRET_FLEET_CLUSTER_FOO.equals(s) || VaultSecret.SECRET_KIBANA_CLUSTER_FOO.equals(s)){
-      return [data: [ value: [ username: 'username-1', password: 'password-1', url: 'my-url-1', fleet_url: 'my-fleet-url-1', token: 'my-token-1']]]
+      return [data: [ value: [ username: 'username-1', password: 'password-1', url: 'my-url-1', fleet_url: 'my-fleet-url-1', token: 'my-token-1', cluster: [ cloud_id: 'my-cloud_id-1', username: 'username-1', password: 'password-1' ]]]]
     }
     if(VaultSecret.SECRET_CLUSTER_MISSING.equals(s) || VaultSecret.SECRET_FLEET_CLUSTER_MISSING.equals(s) || VaultSecret.SECRET_KIBANA_CLUSTER_MISSING.equals(s)){
-      return [data: [ value: [ username: 'username-1', password: 'password-1' ]]]
+      return [data: [ value: [ username: 'username-1', password: 'password-1' ], cluster: [ username: 'username-1', password: 'password-1' ]]]
     }
     if(VaultSecret.SECRET_CODECOV.equals(s)){
       return [data: [ value: 'codecov-token']]

--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -707,7 +707,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
       return [errors: 'Error message']
     }
     if(VaultSecret.SECRET_CLOUD_FOO.equals(s)){
-      return [data: [ username: 'username-1', password: 'password-1', cloud_id: 'my-cloud_id-1' ]]
+      return [data: [ username: 'username-1', password: 'password-1', cluster: [ cloud_id: 'my-cloud_id-1' ]]]
     }
     if(VaultSecret.SECRET_CLOUD_MISSING.equals(s)){
       return [data: [ username: 'username-1', password: 'password-1' ]]

--- a/vars/withCloudEnv.groovy
+++ b/vars/withCloudEnv.groovy
@@ -26,15 +26,16 @@
 def call(Map args = [:], Closure body) {
   log(level: 'INFO', text: 'withCloudEnv')
   def cluster = args.containsKey('cluster') ? args.cluster : error('withCloudEnv: cluster parameter is required.')
-  def secret = "${getTestClusterSecret()}/${cluster}/ec-deployment"
+  def secret = "${getTestClusterSecret()}/${cluster}/k8s-elasticsearch"
   def props = getVaultSecret(secret: secret)
   if (props?.errors) {
     error "withCloudEnv: Unable to get credentials from the vault: ${props.errors.toString()}"
   }
-  def value = props?.data
-  def cloud_id = value?.cloud_id
-  def username = value?.username
-  def password = value?.password
+  def valueJson = props?.data?.value
+  def data = toJSON(valueJson)
+  def cloud_id = data?.cluster?.cloud_id
+  def username = data?.username
+  def password = data?.password
   validateField(cloud_id, "withCloudEnv: was not possible to get the authentication info for the cloud_id field.")
   validateField(username, "withCloudEnv: was not possible to get the authentication info for the username field.")
   validateField(password, "withCloudEnv: was not possible to get the authentication info for the password field.")

--- a/vars/withCloudEnv.groovy
+++ b/vars/withCloudEnv.groovy
@@ -36,20 +36,14 @@ def call(Map args = [:], Closure body) {
   def cloud_id = data?.cluster?.cloud_id
   def username = data?.username
   def password = data?.password
-  validateField(cloud_id, "withCloudEnv: was not possible to get the authentication info for the cloud_id field.")
-  validateField(username, "withCloudEnv: was not possible to get the authentication info for the username field.")
-  validateField(password, "withCloudEnv: was not possible to get the authentication info for the password field.")
+  errorIfEmpty(cloud_id, "withCloudEnv: was not possible to get the authentication info for the cloud_id field.")
+  errorIfEmpty(username, "withCloudEnv: was not possible to get the authentication info for the username field.")
+  errorIfEmpty(password, "withCloudEnv: was not possible to get the authentication info for the password field.")
   withEnvMask(vars: [
     [var: 'CLOUD_USERNAME', password: username],
     [var: 'CLOUD_PASSWORD', password: password],
     [var: 'CLOUD_ID', password: cloud_id]
   ]){
     body()
-  }
-}
-
-def validateField(String value, String errorMessage) {
-  if(value == null || value?.trim() == ""){
-    error errorMessage
   }
 }

--- a/vars/withCloudEnv.txt
+++ b/vars/withCloudEnv.txt
@@ -8,5 +8,9 @@ Wrap the cloud credentials and entrypoints as environment variables that are mas
 
 * cluster: Name of the cluster that was already created. Mandatory
 
-NOTE: secrets for the test clusters are defined in the 'secret/observability-team/ci/test-clusters'
-      vault location
+Environment variables:
+* `CLOUD_ID`
+* `CLOUD_PASSWORD`
+* `CLOUD_USERNAME`
+
+NOTE: secrets for the test clusters are located in Vault, see `getTestClusterSecret`


### PR DESCRIPTION
## What does this PR do?

Update the vault secret to use the one with the specific cloud deployment details

## Why is it important?

`ec-deployment` is not supported anymore

## Related issues

Relates https://github.com/elastic/observability-test-environments/pull/2352