### PR TITLE
Set GOTMPDIR in withGoEnvWindows

### DIFF
--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -49,6 +49,7 @@ class WithGoEnvWindowsStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(isOK)
     assertTrue(assertMethodCallContainsPattern('bat', 'Installing Go 1.12.2'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'GOTMPDIR='))
     assertJobStatusSuccess()
   }
 

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -55,7 +55,8 @@ def call(Map args = [:], Closure body) {
     "GOROOT=${goRoot}",
     "GOPATH=${env.WORKSPACE}",
     "USERPROFILE=${userProfile}",
-    "GO_VERSION=${version}"
+    "GO_VERSION=${version}",
+    "GOTMPDIR=${env.WORKSPACE}" // https://github.com/golang/go/issues/42224#issuecomment-1021149948
   ]){
     def content = libraryResource('scripts/install-tools.bat')
     retryWithSleep(retries: 2, seconds: 5, backoff: true){


### PR DESCRIPTION
## What does this PR do?

Set GOTMPDIR

## Why is it important?

Use the workspace as the tmp place to host the Golang temporary files.

## Issue

See https://github.com/golang/go/issues/42224#issuecomment-1021149948