### PR TITLE
Retry only for the vault access in withVaultToken

### DIFF
--- a/src/test/groovy/WithVaultTokenStepTests.groovy
+++ b/src/test/groovy/WithVaultTokenStepTests.groovy
@@ -81,6 +81,5 @@ class WithVaultTokenStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('sh', 'rm .vault-token'))
-    assertJobStatusFailure()
   }
 }

--- a/vars/withVaultToken.groovy
+++ b/vars/withVaultToken.groovy
@@ -29,12 +29,11 @@ def call(Map args = [:], Closure body) {
   getVaultSecret.readSecretWrapper {
     // When running in the CI with multiple parallel stages
     // the access could be considered as a DDOS attack. Let's sleep a bit if it fails.
-    def token
     retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-      token = getVaultSecret.getVaultToken(env.VAULT_ADDR, env.VAULT_ROLE_ID, env.VAULT_SECRET_ID)
-    }
-    dir(path) {
-      writeFile file: tokenFile, text: token
+      def token = getVaultSecret.getVaultToken(env.VAULT_ADDR, env.VAULT_ROLE_ID, env.VAULT_SECRET_ID)
+      dir(path) {
+        writeFile file: tokenFile, text: token
+      }
     }
     try {
       body()


### PR DESCRIPTION
## What does this PR do?

Retry logic only for the vault access in withVaultToken

## Why is it important?

Otherwise it runs the given body, but the retry was only aimed to add stability while accessing Vault.

