### PR TITLE
automation: support Golang-crossbuild with the overrideGoVersion

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -25,7 +25,6 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-      - 7.x
     enabled: true
     labels: dependency
     reviewer: elastic/observablt-robots-on-call

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -122,7 +122,7 @@ def prepareArguments(Map args = [:]){
     goReleaseVersion = goVersion(action: 'latest', unstable: false, glob: overrideGoVersion)
   }
 
-  log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, overrideGoVersion: ${overrideGoVersion}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
+  log(level: 'INFO', text: "prepareArguments(goReleaseVersion: ${goReleaseVersion}, repo: ${repo}, branch: ${branch}, overrideGoVersion: ${overrideGoVersion}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
   def message = """### What \n Bump go release version with the latest release. \n ### Further details \n See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo${goReleaseVersion}+label%3ACherryPickApproved) for ${goReleaseVersion}"""
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"


### PR DESCRIPTION
## What does this PR do?

`overrideGoVersion` didn't have the highest precedence therefore the `1.17` and `1.16` branches in the golang-crossbuild were not updated for the recent go1.17 and go1.16 releases

Additionally, I remove the support for the autobump in the apm-integration-testing@7.x since it relies on the APM Server to bump the version and therefore it cannot be consumed by this automation.

## Why is it important?

Keep updating the golang-crossbuild versions


## Test 

See this [build](https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/79/)

<img width="661" alt="image" src="https://user-images.githubusercontent.com/2871786/176206807-cde38208-31ad-4fa1-98b7-8d849a240218.png">

