### PR TITLE
Fix isBranch to filter out tags

### DIFF
--- a/src/test/groovy/IsBranchStepTests.groovy
+++ b/src/test/groovy/IsBranchStepTests.groovy
@@ -41,6 +41,15 @@ class IsBranchStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_isBranch_cornercase() throws Exception {
+    addEnvVar('BRANCH_NAME', '')
+    def ret = script.call()
+    printCallStack()
+    assertFalse(ret)
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_isBranch_in_pr() throws Exception {
     addEnvVar('BRANCH_NAME', 'PR-1')
     addEnvVar('CHANGE_ID', '1')

--- a/src/test/groovy/IsBranchStepTests.groovy
+++ b/src/test/groovy/IsBranchStepTests.groovy
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertFalse
 
 class IsBranchStepTests extends ApmBasePipelineTest {
 
-
   @Override
   @Before
   void setUp() throws Exception {
@@ -34,7 +33,7 @@ class IsBranchStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_isBranch() throws Exception {
-    env.BRANCH_NAME = 'master'
+    addEnvVar('BRANCH_NAME', 'my-branch')
     def ret = script.call()
     printCallStack()
     assertTrue(ret)
@@ -43,8 +42,8 @@ class IsBranchStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_isBranch_in_pr() throws Exception {
-    env.BRANCH_NAME = 'PR-1'
-    env.CHANGE_ID = '1'
+    addEnvVar('BRANCH_NAME', 'PR-1')
+    addEnvVar('CHANGE_ID', '1')
     def ret = script.call()
     printCallStack()
     assertFalse(ret)
@@ -53,8 +52,8 @@ class IsBranchStepTests extends ApmBasePipelineTest {
 
   @Test
   void test_isBranch_in_tag() throws Exception {
-    env.TAG_NAME = 'my-tag'
-    env.remove('BRANCH_NAME')
+    addEnvVar('BRANCH_NAME', 'my-tag')
+    addEnvVar('TAG_NAME', 'my-tag')
     env.remove('CHANGE_ID')
     def ret = script.call()
     printCallStack()

--- a/vars/isBranch.groovy
+++ b/vars/isBranch.groovy
@@ -23,5 +23,9 @@
   }
 */
 def call(){
+  // It should not happen but if the BRANCH_NAME is empty then it's not a branch
+  if (!env.BRANCH_NAME?.trim()) {
+    return false
+  }
   return !(isPR() || isTag())
 }

--- a/vars/isBranch.groovy
+++ b/vars/isBranch.groovy
@@ -23,5 +23,5 @@
   }
 */
 def call(){
-  return (!isPR() && env.BRANCH_NAME?.trim()) ? true : false
+  return !(isPR() || isTag())
 }


### PR DESCRIPTION
## What does this PR do?

`isBranch` returned true for git tags since `BRANCH_NAME` was evaluated

## Why is it important?

Fix the misbehaviour since there are some GitHub issues created for tag releases https://github.com/elastic/beats/issues/32140 while the condition is only about `isBranch()` -> https://github.com/elastic/beats/blob/e85d8b9a77d79be3f7defdaa7d99bfa93aae0e11/Jenkinsfile#L207

