### PR TITLE
Update codeowners to new CI group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /resources/approval-list/beats.yml @andresrc
 
 # Auto assign reviews
-* @elastic/observablt-robots @elastic/observablt-robots-contractors
+* @elastic/observablt-ci


### PR DESCRIPTION
## What does this PR do?

Updates CODEOWNERS to `observablt-ci`.

## Related issues
Refs https://github.com/elastic/observability-robots/issues/1280
