### PR TITLE
Less precedence for isMemberOfOrg

### DIFF
--- a/vars/githubPrCheckApproved.groovy
+++ b/vars/githubPrCheckApproved.groovy
@@ -42,17 +42,21 @@ def call(Map args = [:]){
   log(level: 'INFO', text: "githubPrCheckApproved: Title: ${pr?.title} - User: ${user} - Author Association: ${pr?.author_association}")
 
   // The PR is approved to be executed in the CI for the below reasons:
-  // - An user with write permissions raised the PR.
-  // - IsMemberOf the Elastic Org.
-  // - An authorized bot created the PR.
   // - If it has already been approved by a member or collaborator.
+  // - An user with write permissions raised the PR.
+  // - An authorized bot created the PR.
   // - A trusted user for that particular repo.
+  // - IsMemberOf the Elastic Org.
   //
+  // NOTE: isMemberOfOrg can throw a controlled error if it's not member of the elastic org
+  //       so the digested report with notifyBuildResult reports it. Therefore
+  //       let's validate isMemberOfOrg at the very end instead to avoid reporting those
+  //       errors.
   approved = user != null && (isPrApproved(reviews) ||
                               hasWritePermission(token, repoName, user) ||
-                              isMemberOfOrg(user: user, org: 'elastic') ||
                               isAuthorizedBot(user, userType) ||
-                              isAuthorizedUser(repoName, user))
+                              isAuthorizedUser(repoName, user) ||
+                              isMemberOfOrg(user: user, org: 'elastic'))
 
   if(!approved){
     def message = 'The PR is not allowed to run in the CI yet'


### PR DESCRIPTION
## What does this PR do?

Higher precedence for all the different cases if they can run in the CI but the `isMemberOfOrg`.

## Why is it important?

Since `isMemberOfOrg` throws a [controlled error](https://github.com/elastic/apm-pipeline-library/blob/bf86ffc303a9d5a8fe84122d11b1e72bb0987220/vars/isMemberOfOrg.groovy#L40-L50) and then the reporting digested comment in GitHub mislead with the error.


Currently:

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/2871786/176676863-944162be-78f1-4db0-a26d-3439f642b5bd.png">

Then the `error` message about the GitHub API call won't be reflected anymore with this proposal.


Thanks @aspacca for reporting this