### PR TITLE
automation: enable extended description for the Golang autobump

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -12,6 +12,7 @@
 ##  assign: A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request. Optional.
 ##  reviewer: A comma-separated list (no spaces around the comma) of GitHub handles to request a review from. Optional.
 ##  overrideGoVersion: The major.minor version to be used since some projects do not use the latest major.minor version but the previous one. Optional.
+##  description: Extended description to be added to the existing one in the PR. Optional.
 ##
 projects:
   - repo: apm-pipeline-library
@@ -35,6 +36,7 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
+    description: It requires the version to be bumped first in the https://github.com/elastic/golang-crossbuild. Otherwise it will fail until the docker images are available.
   - repo: elastic-agent-shipper
     script: .ci/bump-go-release-version.sh
     branches:
@@ -48,6 +50,7 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
+    description: It requires the version to be bumped first in the https://github.com/elastic/golang-crossbuild. Otherwise it will fail until the docker images are available.
   - repo: elastic-agent-autodiscover
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -36,7 +36,7 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
-    description: It requires the version to be bumped first in the https://github.com/elastic/golang-crossbuild. Otherwise it will fail until the docker images are available.
+    description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
   - repo: elastic-agent-shipper
     script: .ci/bump-go-release-version.sh
     branches:
@@ -50,7 +50,7 @@ projects:
     overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
-    description: It requires the version to be bumped first in the https://github.com/elastic/golang-crossbuild. Otherwise it will fail until the docker images are available.
+    description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
   - repo: elastic-agent-autodiscover
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -86,7 +86,8 @@ def generateSteps(Map args = [:]) {
                        title: project.get('title', ''),
                        assign: project.get('assign', ''),
                        overrideGoVersion: project.get('overrideGoVersion'),
-                       reviewer: project.get('reviewer', ''))
+                       reviewer: project.get('reviewer', ''),
+                       extendedDescription: project.get('description', ''))
     }
   }
 }
@@ -108,6 +109,7 @@ def prepareArguments(Map args = [:]){
   def reviewer = args.get('reviewer', '')
   def state = args.get('state', 'all')
   def overrideGoVersion = args.get('overrideGoVersion', '')
+  def extendedDescription = args.get('extendedDescription', '')
 
   // Default to the branch.
   if (!overrideGoVersion?.trim()) {
@@ -118,7 +120,7 @@ def prepareArguments(Map args = [:]){
   def goReleaseVersion = getGoReleaseVersion(branch: branch, overrideGoVersion: overrideGoVersion)
 
   log(level: 'INFO', text: "prepareArguments(goReleaseVersion: ${goReleaseVersion}, repo: ${repo}, branch: ${branch}, overrideGoVersion: ${overrideGoVersion}, scriptFile: ${scriptFile}, labels: '${labels}', title: '${title}', assign: '${assign}', reviewer: '${reviewer}')")
-  def message = """### What \n Bump go release version with the latest release. \n ### Further details \n See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo${goReleaseVersion}+label%3ACherryPickApproved) for ${goReleaseVersion}"""
+  def message = getDescription(goReleaseVersion, extendedDescription)
   if (labels.trim() && !labels.contains('automation')) {
     labels = "automation,${labels}"
   }
@@ -181,4 +183,14 @@ def getGoReleaseVersion(Map args = [:]){
   }
 
   return env.GO_RELEASE_VERSION
+}
+
+def getDescription(goReleaseVersion, extendedDescription) {
+  return """### What \n
+Bump go release version with the latest release. \n
+### Further details \n
+See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo${goReleaseVersion}+label%3ACherryPickApproved) for ${goReleaseVersion}\n
+${extendedDescription} \n\n
+_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_
+"""
 }


### PR DESCRIPTION
## What does this PR do?

Enable to customise the PR description for the `golang` autobump.

## Why is it important?

@cmacknz asked about a particular PR that was failing -> https://github.com/elastic/beats/pull/31827#issuecomment-1168846705

This proposal could help with adding further context regarding the `golang-crossbuild` dependencies with Beats and Elastic Agent.

Currently

<img width="668" alt="image" src="https://user-images.githubusercontent.com/2871786/176688992-970d958a-6dbd-40af-9052-20985808cee4.png">

Proposal

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/2871786/176689070-2a98edc6-3534-423a-aae1-09f3ea565543.png">

The existing automation is stateless so, it does not look after cross-project dependencies, so by adding the description with more semantic, I'd expect to answer those questions, what do you think?
