### PR TITLE
Customise wget/curl flags and support for noCheckCertificate in the Terraform

### DIFF
--- a/src/test/groovy/DownloadStepTests.groovy
+++ b/src/test/groovy/DownloadStepTests.groovy
@@ -73,4 +73,28 @@ class DownloadStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallOccurrences('downloadWithCurl', 1))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void test_with_wget_and_flags() throws Exception {
+    script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz', curlFlags: '--foo', wgetFlags: '--bar')
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', 'curl'))
+    assertFalse(assertMethodCallContainsPattern('sh', '--foo'))
+    assertTrue(assertMethodCallContainsPattern('sh', '--bar'))
+    assertTrue(assertMethodCallOccurrences('downloadWithWget', 1))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_curl_and_flags() throws Exception {
+    helper.registerAllowedMethod('downloadWithWget', [Map.class], { return false })
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m -> return m.tool.equals('curl') })
+    script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz', curlFlags: '--foo', wgetFlags: '--bar')
+    printCallStack()
+    assertFalse(assertMethodCallContainsPattern('sh', 'wget'))
+    assertFalse(assertMethodCallContainsPattern('sh', '--bar'))
+    assertTrue(assertMethodCallContainsPattern('sh', '--foo'))
+    assertTrue(assertMethodCallOccurrences('downloadWithCurl', 1))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/groovy/DownloadWithCurlStepTests.groovy
+++ b/src/test/groovy/DownloadWithCurlStepTests.groovy
@@ -66,6 +66,17 @@ class DownloadWithCurlStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void test_with_flags() throws Exception {
+    def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz', flags: '--parallel')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', 'curl -sSLo gsutil.tar.gz'))
+    assertTrue(assertMethodCallContainsPattern('sh', '--parallel'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'https://example.acme.org'))
+    assertTrue(result)
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void test_windows() throws Exception {
     helper.registerAllowedMethod('isUnix', [], { false })
     def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz')

--- a/src/test/groovy/DownloadWithWgetStepTests.groovy
+++ b/src/test/groovy/DownloadWithWgetStepTests.groovy
@@ -50,7 +50,7 @@ class DownloadWithWgetStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('isInstalled', [Map.class], { return false })
     def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz')
     printCallStack()
-    assertFalse(assertMethodCallContainsPattern('sh', 'wget -q -O'))
+    assertFalse(assertMethodCallContainsPattern('sh', '-q -O'))
     assertFalse(result)
     assertJobStatusSuccess()
   }
@@ -59,7 +59,16 @@ class DownloadWithWgetStepTests extends ApmBasePipelineTest {
   void test() throws Exception {
     def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('sh', 'wget -q -O gsutil.tar.gz https://example.acme.org'))
+    assertTrue(assertMethodCallContainsPattern('sh', '-q -O gsutil.tar.gz https://example.acme.org'))
+    assertTrue(result)
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void test_with_flags() throws Exception {
+    def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz', flags: '--no-check-certificate')
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('sh', '--no-check-certificate -q -O gsutil.tar.gz https://example.acme.org'))
     assertTrue(result)
     assertJobStatusSuccess()
   }
@@ -69,7 +78,7 @@ class DownloadWithWgetStepTests extends ApmBasePipelineTest {
     helper.registerAllowedMethod('isUnix', [], { false })
     def result = script.call(url: 'https://example.acme.org', output: 'gsutil.tar.gz')
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('bat', 'wget -q -O gsutil.tar.gz https://example.acme.org'))
+    assertTrue(assertMethodCallContainsPattern('bat', '-q -O gsutil.tar.gz https://example.acme.org'))
     assertTrue(result)
     assertJobStatusSuccess()
   }

--- a/src/test/groovy/WithTerraformEnvStepTests.groovy
+++ b/src/test/groovy/WithTerraformEnvStepTests.groovy
@@ -46,6 +46,19 @@ class WithTerraformEnvStepTests extends ApmBasePipelineTest {
     assertJobStatusSuccess()
   }
 
+  @Test
+  void test_with_noCheckCertificate() throws Exception {
+    helper.registerAllowedMethod('isInstalled', [Map.class], { m -> return m.tool.equals('wget') })
+    def ret = false
+    script.call(version: "2.0.0", noCheckCertificate: true) {
+      ret = true
+    }
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('download', '--no-check-certificate'))
+    assertTrue(assertMethodCallContainsPattern('withEnv', 'PATH+TERRAFORM'))
+    assertTrue(ret)
+    assertJobStatusSuccess()
+  }
 
   @Test
   void test_with_force_installation_and_version_already_installed() throws Exception {
@@ -56,6 +69,7 @@ class WithTerraformEnvStepTests extends ApmBasePipelineTest {
     }
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('download', '2.0.0'))
+    assertFalse(assertMethodCallContainsPattern('download', '--no-check-certificate'))
     assertTrue(ret)
     assertJobStatusSuccess()
   }

--- a/vars/download.groovy
+++ b/vars/download.groovy
@@ -24,7 +24,9 @@
 def call(Map args = [:]) {
   def url = args.containsKey('url') ? args.url : error('download: url parameter is required')
   def output = args.containsKey('output') ? args.output : error('download: output parameter is required')
-  if (!downloadWithWget(url: url, output: output)) {
-    downloadWithCurl(url: url, output: output)
+  def curlFlags = args.get('curlFlags', '')
+  def wgetFlags = args.get('wgetFlags', '')
+  if (!downloadWithWget(url: url, output: output, flags: wgetFlags)) {
+    downloadWithCurl(url: url, output: output, flags: curlFlags)
   }
 }

--- a/vars/download.txt
+++ b/vars/download.txt
@@ -6,3 +6,5 @@ download(url: 'https://....', output: 'gsutil.tar.gz')
 
 * url: The URL to be downloaded. Mandatory
 * output: The file where the output will be written to. Mandatory.
+* curlClags: curl flags to be used. Optional.
+* wgetFlags: wget flags to be used. Optional.

--- a/vars/downloadWithCurl.groovy
+++ b/vars/downloadWithCurl.groovy
@@ -24,8 +24,9 @@
 def call(Map args = [:]) {
   def url = args.containsKey('url') ? args.url : error('downloadWithCurl: url parameter is required')
   def output = args.containsKey('output') ? args.output : error('downloadWithCurl: output parameter is required')
+  def flags = args.get('flags', '')
   if(isInstalled(tool: 'curl', flag: '--version')) {
-    cmd(label: 'download tool', script: "curl -sSLo ${output} --retry 3 --retry-delay 2 --max-time 10 ${url}")
+    cmd(label: 'download tool', script: "curl -sSLo ${output} --retry 3 --retry-delay 2 --max-time 10 ${flags} ${url}")
     return true
   } else {
     log(level: 'WARN', text: 'withGCPEnv: downloadWithCurl is not available.')

--- a/vars/downloadWithCurl.groovy
+++ b/vars/downloadWithCurl.groovy
@@ -29,7 +29,7 @@ def call(Map args = [:]) {
     cmd(label: 'download tool', script: "curl -sSLo ${output} --retry 3 --retry-delay 2 --max-time 10 ${flags} ${url}")
     return true
   } else {
-    log(level: 'WARN', text: 'withGCPEnv: downloadWithCurl is not available.')
+    log(level: 'WARN', text: 'downloadWithCurl: downloadWithCurl is not available.')
   }
   return false
 }

--- a/vars/downloadWithCurl.txt
+++ b/vars/downloadWithCurl.txt
@@ -6,3 +6,4 @@ downloadWithCurl(url: 'https://....', output: 'gsutil.tar.gz')
 
 * url: The URL to be downloaded. Mandatory
 * output: The file where the CUrl output will be written to. Mandatory.
+* flags: curl flags to be used. Optional.

--- a/vars/downloadWithWget.groovy
+++ b/vars/downloadWithWget.groovy
@@ -24,9 +24,10 @@
 def call(Map args = [:]) {
   def url = args.containsKey('url') ? args.url : error('downloadWithWget: url parameter is required')
   def output = args.containsKey('output') ? args.output : error('downloadWithWget: output parameter is required')
+  def flags = args.get('flags', '')
   if(isInstalled(tool: 'wget', flag: '--version')) {
     retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-      cmd(label: 'download tool', script: "wget -q -O ${output} ${url}")
+      cmd(label: 'download tool', script: "wget ${flags} -q -O ${output} ${url}")
     }
     return true
   } else {

--- a/vars/downloadWithWget.txt
+++ b/vars/downloadWithWget.txt
@@ -6,3 +6,4 @@ downloadWithWget(url: 'https://....', output: 'gsutil.tar.gz')
 
 * url: The URL to be downloaded. Mandatory
 * output: The file where the wget output will be written to. Mandatory.
+* flags: WGet flags to be used. Optional.

--- a/vars/withTerraformEnv.groovy
+++ b/vars/withTerraformEnv.groovy
@@ -25,23 +25,25 @@ withTerraformEnv(version: '0.15.1') {
 def call(Map args = [:], Closure body) {
   def version = args.get('version', '1.1.9')
   def forceInstallation = args.get('forceInstallation', false)
+  def noCheckCertificate = args.get('noCheckCertificate', false)
 
   def location = pwd(tmp: true)
 
   withEnv(["PATH+TERRAFORM=${location}"]) {
     if (forceInstallation || !isInstalled(tool: 'terraform', flag: '--version', version: version)) {
-      downloadAndInstall(location, version)
+      downloadAndInstall(location, version, noCheckCertificate)
     }
     body()
   }
 }
 
-def downloadAndInstall(where, version) {
+def downloadAndInstall(where, version, noCheckCertificate) {
   def url = terraformURL(version)
   def zipfile = 'terraform.zip'
+  def wgetFlags = noCheckCertificate ? '--no-check-certificate' : ''
   dir(where) {
     retryWithSleep(retries: 5, seconds: 10, backoff: true) {
-      download(url: url, output: zipfile)
+      download(url: url, output: zipfile, wgetFlags: wgetFlags)
     }
     unzip(quiet: true, zipFile: zipfile)
     if (isUnix()) {

--- a/vars/withTerraformEnv.txt
+++ b/vars/withTerraformEnv.txt
@@ -8,3 +8,4 @@ withTerraformEnv(version: '0.15.1') {
 
 * version: The terraform CLI version to be installed. Optional (1.1.9)
 * forceInstallation: Whether to install terraform regardless. Optional (false)
+* noCheckCertificate: Whether to check the certificate. Optional (false)


### PR DESCRIPTION
## What does this PR do?

- Allow to customise `wget`, `curl` and `download` steps with what flags to be used
- Allow to noCheckCertificate for the `withTerraformEnv` since old versions of Windows have got some issues.

## Why is it important?

Simplify the logic in the pipeline by adding the complexity in the pipeline, unfortunately, the packer-cache doesn't work for EOL OSes

Otherwise, if the logic is added to the pipeline then https://github.com/elastic/beats/pull/32221/commits/1b778b1c9309cde2374f9b3c433cf43cb5b3b4ef is the proposal... unfortunately it's a bit to hacky so the shared library could be the more sustainable approach

## Related issues
Notifies https://github.com/elastic/beats/pull/32221/
