### PR TITLE
Add support for go packages with explicit versions

### DIFF
--- a/src/test/groovy/WithGoEnvUnixStepTests.groovy
+++ b/src/test/groovy/WithGoEnvUnixStepTests.groovy
@@ -172,6 +172,20 @@ class WithGoEnvUnixStepTests extends ApmBasePipelineTest {
   }
 
   @Test
+  void testPkgs_with_version() throws Exception {
+    helper.registerAllowedMethod('nodeOS', [], { "linux" })
+    def isOK = false
+    script.call(version: "1.16.1", pkgs: [ "P1@1", "P2@2" ]){
+      isOK = true
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('sh', 'go install P1@1'))
+    assertTrue(assertMethodCallContainsPattern('sh', 'go install P2@2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "linux" })
     def version = "1.15.1"

--- a/src/test/groovy/WithGoEnvWindowsStepTests.groovy
+++ b/src/test/groovy/WithGoEnvWindowsStepTests.groovy
@@ -120,6 +120,19 @@ void testOSArg() throws Exception {
   }
 
   @Test
+  void testPkgs_with_version() throws Exception {
+    def isOK = false
+    script.call(version: "1.16.1", pkgs: [ "P1@1", "P2@2" ]){
+      isOK = definedVariables('1.16.1', 'windows')
+    }
+    printCallStack()
+    assertTrue(isOK)
+    assertTrue(assertMethodCallContainsPattern('bat', 'go install P1@1'))
+    assertTrue(assertMethodCallContainsPattern('bat', 'go install P2@2'))
+    assertJobStatusSuccess()
+  }
+
+  @Test
   void testDefaultGoVersion() throws Exception {
     helper.registerAllowedMethod('nodeOS', [], { "windows" })
     def version = "1.15.1"

--- a/vars/withGoEnvUnix.groovy
+++ b/vars/withGoEnvUnix.groovy
@@ -73,8 +73,13 @@ def installPackages(Map args = [:]) {
   def atVersion = isBeforeGo1_16(version: version) ? '' : "@latest"
   withEnv(["GOARCH=${arch}"]){
     args.pkgs?.each{ p ->
+      // If the package is already with the given version then use it
+      def packageWithVersion = "${p}${atVersion}"
+      if (p.contains('@')) {
+        packageWithVersion = "${p}"
+      }
       retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        sh(label: "Installing ${p}", script: "go ${method} ${p}${atVersion}")
+        sh(label: "Installing ${packageWithVersion}", script: "go ${method} ${packageWithVersion}")
       }
     }
   }

--- a/vars/withGoEnvWindows.groovy
+++ b/vars/withGoEnvWindows.groovy
@@ -63,8 +63,13 @@ def call(Map args = [:], Closure body) {
       bat(label: "Installing Go ${version}", script: content)
     }
     pkgs?.each{ p ->
+      // If the package is already with the given version then use it
+      def packageWithVersion = "${p}${atVersion}"
+      if (p.contains('@')) {
+        packageWithVersion = "${p}"
+      }
       retryWithSleep(retries: 3, seconds: 5, backoff: true){
-        bat(label: "Installing ${p}", script: "go ${method} ${p}${atVersion}")
+        bat(label: "Installing ${packageWithVersion}", script: "go ${method} ${packageWithVersion}")
       }
     }
     body()


### PR DESCRIPTION
## What does this PR do?

Support to install specific version of any Golang packages.

## Why is it important?

Otherwise, with golang > 1.15 then it always uses `@latest`

## Related issues

Notifies https://github.com/elastic/elastic-agent-shipper/pull/73
