### PR TITLE
ci: enable k8s workers

### DIFF
--- a/.ci/bumpGoReleaseVersion.groovy
+++ b/.ci/bumpGoReleaseVersion.groovy
@@ -18,7 +18,7 @@
 @Library('apm@main') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'k8s' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'

--- a/.ci/bumpStackReleaseVersion.groovy
+++ b/.ci/bumpStackReleaseVersion.groovy
@@ -18,7 +18,7 @@
 @Library('apm@main') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'k8s' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -23,7 +23,7 @@ import groovy.transform.Field
 @Field def latestVersions
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'k8s' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -23,7 +23,7 @@ import groovy.transform.Field
 @Field def latestVersions
 
 pipeline {
-  agent { label 'k8s' }
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'

--- a/.ci/chatops.groovy
+++ b/.ci/chatops.groovy
@@ -46,7 +46,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent any
+      agent { label 'k8s' }
       when {
         beforeAgent true
         expression {

--- a/.ci/fleet-ci-schedule-daily.groovy
+++ b/.ci/fleet-ci-schedule-daily.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent none
+  agent { label 'k8s' }
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'INFO'

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'master' }
+  agent { label 'k8s' }
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL='INFO'

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -18,7 +18,7 @@
 @Library('apm@main') _
 
 pipeline {
-  agent { label 'ubuntu && immutable' }
+  agent { label 'k8s' }
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'INFO'

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -23,7 +23,7 @@ import groovy.transform.Field
 @Field def releaseVersions = [:]
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'k8s' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'

--- a/.ci/validateWorkersBeatsCi.groovy
+++ b/.ci/validateWorkersBeatsCi.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'k8s' }
   environment {
     REPO = 'apm-pipeline-library'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"


### PR DESCRIPTION
## What does this PR do?

Initial attempt to use the `k8s` gobld workers in those pipelines which are not critical or likely platform specific.

## Why is it important?

Validate if we can start using it

## Test

I triggered manually some pipelines by forcing the `label` to `k8s`:

* https://apm-ci.elastic.co/job/apm-shared/job/apm-schedule-daily/812/console
* https://apm-ci.elastic.co/job/apm-shared/job/apm-schedule-weekly/187/console
```
15:21:45  [Pipeline] Start of Pipeline
15:21:45  [Pipeline] node
15:22:01  Running on [apm-ci-immutable-jenkins-swarm-1657290110773068510](https://apm-ci.elastic.co/computer/apm-ci-immutable-jenkins-swarm-1657290110773068510/) in /home/jenkins/workspace/apm-shared/apm-schedule-weekly
15:22:01  [Pipeline] {
```

* https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/84/console