### PR TITLE
feat: add Generic Webhook trigger configuration

### DIFF
--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/edge_lite.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/edge_lite.groovy
@@ -72,16 +72,32 @@ pipelineJob("apm-shared/oblt-test-env/edge-lite-oblt-cluster") {
               key("GT_FILES_REMOVED")
               value("\$.commits[*].['removed'][*]")
             }
+            genericVariable {
+              key("GT_TITLE")
+              value('$.pull_request.title')
+            }
+            genericVariable {
+              key("GT_PR_HEAD_REF")
+              value('$.pull_request.head.ref')
+            }
+            genericVariable {
+              key("GT_PR_HEAD_SHA")
+              value('$.pull_request.head.sha')
+            }
+            genericVariable {
+              key("GT_ACTION")
+              value('$.action')
+            }
           }
           genericHeaderVariables {
             genericHeaderVariable {
               key("x-github-event")
-              regexpFilter("push")
+              regexpFilter("pull_request")
             }
           }
-          regexpFilterText('$GT_REPO/$GT_REF$GT_FILES_ADDED$GT_FILES_MODIFIED$GT_FILES_REMOVED')
-          regexpFilterExpression("^elastic/observability-test-environments/refs/heads/main.*environments/edge-lite/.*")
-          causeString("Triggered on Update PR")
+          regexpFilterText('$GT_REPO/$GT_PR_HEAD_REF/$GT_TITLE/$GT_ACTION')
+          regexpFilterExpression("^elastic/observability-test-environments/updatecli_.*/\\[updatecli\\]\\[edge-lite\\] Update Elastic Stack/opened")
+          causeString("Triggered on create PR")
           silentResponse(true)
         }
       }

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/manage_user_oblt_clusters.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/oblt-test-env/manage_user_oblt_clusters.groovy
@@ -22,11 +22,81 @@ pipelineJob("apm-shared/oblt-test-env/manage-user-oblt-clusters") {
     stringParam("branch_specifier", "main", "the Git branch specifier to build.")
   }
   disabled(false)
-  logRotator {
-    numToKeep(10)
-    daysToKeep(7)
-    artifactNumToKeep(10)
-    artifactDaysToKeep(-1)
+  quietPeriod(10)
+  properties {
+    buildDiscarder {
+      strategy {
+        logRotator {
+          numToKeepStr("10")
+          daysToKeepStr("7")
+          artifactNumToKeepStr("10")
+          artifactDaysToKeepStr("-1")
+        }
+      }
+    }
+    disableConcurrentBuilds()
+    durabilityHint {
+      hint("PERFORMANCE_OPTIMIZED")
+    }
+    disableResume()
+    pipelineTriggers {
+      triggers {
+        GenericTrigger {
+          genericVariables {
+            genericVariable {
+              key("GT_REPO")
+              value('$.repository.full_name')
+            }
+            genericVariable {
+              key("GT_REF")
+              value('$.ref')
+            }
+            genericVariable {
+              key("GT_BEFORE")
+              value('$.before')
+            }
+            genericVariable {
+              key("GT_AFTER")
+              value('$.after')
+            }
+            genericVariable {
+              key("GT_FILES_ADDED")
+              value("\$.commits[*].['added'][*]")
+            }
+            genericVariable {
+              key("GT_FILES_MODIFIED")
+              value("\$.commits[*].['modified'][*]")
+            }
+            genericVariable {
+              key("GT_FILES_REMOVED")
+              value("\$.commits[*].['removed'][*]")
+            }
+            genericVariable {
+              key("GT_TITLE")
+              value('$.pull_request.title')
+            }
+            genericVariable {
+              key("GT_PR_HEAD_REF")
+              value('$.pull_request.head.ref')
+            }
+            genericVariable {
+              key("GT_PR_HEAD_SHA")
+              value('$.pull_request.head.sha')
+            }
+          }
+          genericHeaderVariables {
+            genericHeaderVariable {
+              key("x-github-event")
+              regexpFilter("push")
+            }
+          }
+          regexpFilterText('$GT_REPO/$GT_REF$GT_FILES_ADDED$GT_FILES_MODIFIED$GT_FILES_REMOVED')
+          regexpFilterExpression("^elastic/observability-test-environments/refs/heads/main.*environments/users/.*")
+          causeString("Triggered on push")
+          silentResponse(true)
+        }
+      }
+    }
   }
   definition {
     cpsScm {


### PR DESCRIPTION
## What does this PR do?

Configure the Generic Webhook Trigger on the jobDSL definition.

## Why is it important?

This defines the trigger at creation time is not needed to run the job one time to configure the triggerts.
