### PR TITLE
action: opentelemetry exporter

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,26 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots package
+      - uses: v1v/otel-upload-test-artifact-action@v2
+        if: always()
+        continue-on-error: true
+        with:
+          jobName: "build"
+          stepName: "Build with Maven"
+          path: "target/surefire-reports/*.xml"
+          type: "junit"
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,19 @@
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows: ["victor-junit check"]
+    types: [completed]
+
+jobs:
+  otel-export-trace:
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export Workflow Trace
+        uses: v1v/otel-export-trace-action@v2
+        with:
+          otlpEndpoint: "${{ secrets.APM_SERVER }}"
+          otlpHeaders: "Authorization=Bearer ${{ secrets.APM_TOKEN }}"
+          githubToken: ${{ secrets.MY_GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -2,7 +2,7 @@ name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows: ["victor-junit check"]
+    workflows: [Java CI]
     types: [completed]
 
 jobs:
@@ -13,7 +13,8 @@ jobs:
       - name: Export Workflow Trace
         uses: v1v/otel-export-trace-action@v2
         with:
-          otlpEndpoint: "${{ secrets.APM_SERVER }}"
-          otlpHeaders: "Authorization=Bearer ${{ secrets.APM_TOKEN }}"
-          githubToken: ${{ secrets.MY_GITHUB_TOKEN }}
+          otlpEndpoint: "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}"
+          otlpHeaders: "${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"
+          otelServiceName: ${{ github.repository }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## What does this PR do?

Enable the OpenTelemetry exporter for GitHub actions with JUnit support

## Why is it important?

Keep iterating on this so we can gather further insights and see how the existing integration with https://github.com/jenkinsci/opentelemetry-plugin could be also reused (attributes, dashboards) if possible.

## Important

For some reason, I cannot test the GitHub actions on this PR but only when it's merged, I don't know whether this will work, since we run some docker containers as part of the UTs.

