### PR TITLE
Prepare jenkins-agent with the required tools

### DIFF
--- a/.ci/docker/Makefile
+++ b/.ci/docker/Makefile
@@ -42,7 +42,11 @@ convert-tests-results: ## convert TAP test results to JUnit
 					sh -c 'npm install tap-xunit -g && cat target/results.tap | tap-xunit --package="co.elastic.pipeline.$${APP}" > target/junit-$${APP}-results.xml'
 
 test-%: prepare-test ## Run the tests for the specific app
-	@DOCKERFILE=$* bats-core/bin/bats --tap tests | tee target/results.tap
+	@DOCKERFILE=$* bats-core/bin/bats --tap tests/tests.bats | tee target/results.tap
+	@$(MAKE) -s convert-tests-results
+
+simple-test-%: prepare-test ## Run the specific tests for the specific app
+	@DOCKERFILE=$* bats-core/bin/bats --tap tests/tests_without_run.bats | tee target/results.tap
 	@$(MAKE) -s convert-tests-results
 
 push-%: prepare-test ## Push the Docker image to the docker.elastic.co repository

--- a/.ci/docker/jenkins-agent/Dockerfile
+++ b/.ci/docker/jenkins-agent/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.elastic.co/infra/jenkins-swarm:latest
+
+# Need to switch to the `root` user, as the default is `jenkins`.
+USER root
+
+# As long it uses centos:8 there is a need to change the mirrors
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+
+# Install jq
+RUN dnf install -qy jq && dnf -qy clean all
+
+# Switch back to the `jenkins` user before
+USER jenkins

--- a/.ci/docker/tests/tests_without_run.bats
+++ b/.ci/docker/tests/tests_without_run.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load test_helpers
+
+IMAGE="docker.elastic.co/observability-ci/${DOCKERFILE//\//-}"
+CONTAINER="${DOCKERFILE//\//-}"
+
+@test "${DOCKERFILE} - build image" {
+	cd $BATS_TEST_DIRNAME/..
+	# Simplify the makefile as it does fail with '/bin/sh: 1: Bad substitution' in the CI
+	if [ ! -e ${DOCKERFILE} ] ; then
+		DOCKERFILE="${DOCKERFILE//-//}"
+	fi
+	run docker build --rm -t ${IMAGE} ${DOCKERFILE}
+	assert_success
+}
+
+@test "${DOCKERFILE} - clean test containers" {
+	cleanup $CONTAINER
+}

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
@@ -266,6 +266,34 @@ apmPipelineLibraryDockerImages.each{ name ->
   ])
 }
 
+
+/*
+  APM Pipeline library Docker images with simple tests
+  simple tests don't run the container since the container might require some
+  specific configuration to work (i.e: jenkins agents will require the jenkins controller
+  to connect to)
+*/
+def apmPipelineLibraryDockerImages = [
+  "jenkins-agent"
+]
+
+apmPipelineLibraryDockerImages.each{ name ->
+  def tag = 'latest'
+  def dockerImage = "${registry}/${prefix}/${name}:${tag}"
+  dockerImages.add([
+    name: "${name}",
+    repo: 'git@github.com:elastic/apm-pipeline-library.git',
+    branch_docker: 'main',
+    tag: "${tag}",
+    folder: '.ci/docker',
+    build_script: "docker build --force-rm -t ${dockerImage} ${name}",
+    push_script: "docker push ${dockerImage}",
+    test_script: "make simple-test-${name}",
+    push: true
+  ])
+}
+
+
 /*
   APM Agent Python Docker images
 */

--- a/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
+++ b/.ci/jobDSL/jobs/apm-ci/apm-shared/docker-images/build_docker_images.groovy
@@ -273,11 +273,11 @@ apmPipelineLibraryDockerImages.each{ name ->
   specific configuration to work (i.e: jenkins agents will require the jenkins controller
   to connect to)
 */
-def apmPipelineLibraryDockerImages = [
+def apmPipelineLibraryExtraDockerImages = [
   "jenkins-agent"
 ]
 
-apmPipelineLibraryDockerImages.each{ name ->
+apmPipelineLibraryExtraDockerImages.each{ name ->
   def tag = 'latest'
   def dockerImage = "${registry}/${prefix}/${name}:${tag}"
   dockerImages.add([


### PR DESCRIPTION
## What does this PR do?

Host the jenkins-agent docker image

## Why is it important?

Then we can add the required toolchain and use it when running Jenkins `k8s` workers with `Gobld`. For instance https://github.com/elastic/apm-pipeline-library/pull/1800 is a way to use this particular image

## Important

As long as the existing docker image uses centos we are forced to use the hack with the mirrors, already reported to the CI Systems team.

the jenkins-agent container requires some env variables, so the TAP UTs will fail, so `simple-test` contains a subset of tests to be executed

## Related issues

Caused by https://github.com/elastic/apm-pipeline-library/commits/main
