### PR TITLE
ci: use the docker image with our toolchain

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -23,7 +23,8 @@ import groovy.transform.Field
 @Field def releaseVersions = [:]
 
 pipeline {
-  agent { label 'k8s' }
+  // let's use the gobld image that actually contains the software that we need
+  agent { label 'k8s && gobld/image:docker.elastic.co/observability-ci/jenkins-agent:latest' }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'


### PR DESCRIPTION
## What does this PR do?

Use the specific docker image that contains `jq` 

## Why is it important?

Otherwise, some pipelines will fail.

## Test

See https://apm-ci.elastic.co/job/apm-shared/job/update-stack-release-version-pipeline/205/

## Related issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1799

Although I published the docker image already
