### PR TITLE
Remove mention of "/hey-apm" from apm-server

### DIFF
--- a/src/co/elastic/NotificationManager.groovy
+++ b/src/co/elastic/NotificationManager.groovy
@@ -496,7 +496,6 @@ def getSupportedGithubCommands() {
   }
 
   if (isProjectSupported('apm-server')) {
-    comments['/hey-apm'] = 'Run the hey-apm benchmark.'
     comments['/package'] = 'Generate and publish the docker images.'
     comments['/test windows'] = 'Build & tests on Windows.'
   }


### PR DESCRIPTION
## What does this PR do?

Remove mention of the `/hey-apm` command in the apm-server repo bot comments.

## Why is it important?

I'm going to remove the command.

## Related issues

None