### PR TITLE
Fix copyArtifacts for generateGoBenchmarkDiff to use the folder structure

### DIFF
--- a/vars/generateGoBenchmarkDiff.groovy
+++ b/vars/generateGoBenchmarkDiff.groovy
@@ -56,7 +56,7 @@ def getCompareWithFileIfPossible(Map args = [:]) {
     try {
       dir("${args.output}/${env.CHANGE_TARGET}") {
         projectName = env.JOB_NAME.replace(env.JOB_BASE_NAME, env.CHANGE_TARGET)
-        copyArtifacts(filter: "${args.file}", flatten: true, optional: true, projectName: projectName, selector: lastWithArtifacts())
+        copyArtifacts(filter: "${args.file}", flatten: false, optional: true, projectName: projectName, selector: lastWithArtifacts())
       }
     } catch(e) {
       log(level: 'INFO', text: 'generateGoBenchmarkDiff: it was not possible to copy the previous build.')


### PR DESCRIPTION
## What does this PR do?

Use nested folders

## Why is it important?

Otherwise the file cannot contain any nested folders and won't work as expected

https://github.com/elastic/apm-agent-go/pull/1264/files