### PR TITLE
ci: use cloud workers

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -23,7 +23,12 @@ import groovy.transform.Field
 @Field def releaseVersions = [:]
 
 pipeline {
-  agent { label 'k8s' }
+  /*
+  As long as it requires docker we cannot use the k8s labels
+  bumpUtils.areStackVersionsAvailable uses docker to query if the given list of
+  versions are available. If push based event then we won't need this.
+  */
+  agent { label 'linux && immutable'  }
   environment {
     REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'


### PR DESCRIPTION
## What does this PR do?

Fix the pipeline for the bump versions

## Why is it important?

It requires docker and k8s workers don't provide that functionality yet