### PR TITLE
Use latest pre-commit & jitterbit/get-changed-files actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
-    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+    - uses: pre-commit/action@v3.0.0
       with: ## let's skip to run for all the files
         extra_args: --help
     - id: files
-      uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
+      uses: jitterbit/get-changed-files@v1
     - name: Configure PATH
       run: echo "${GITHUB_WORKSPACE}/.ci/scripts" >> $GITHUB_PATH
     - name: Precommit changes


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

## What does this PR do?

* Upgrade to the latest pre-commit action [v3.0.0](https://github.com/marketplace/actions/pre-commit).
* Upgrade to the latest jitterbit/get-changed-files action [v1](https://github.com/jitterbit/get-changed-files)

## Why is it important?

* Get the latest security and bug fix updates.
