### PR TITLE
Allow agent projects to auto-upgrade to Go 1.18.

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -33,7 +33,6 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
     description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
@@ -47,7 +46,6 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
     description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
@@ -55,35 +53,30 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
   - repo: elastic-agent-inputs
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
   - repo: elastic-agent-libs
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
   - repo: elastic-agent-system-metrics
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency
   - repo: fleet-server
     script: .ci/bump-go-release-version.sh
     branches:
       - main
-    overrideGoVersion: "1.17"
     enabled: true
     labels: dependency,backport-skip
   - repo: golang-crossbuild


### PR DESCRIPTION
Part of https://github.com/elastic/beats/issues/32328

Allow the Go version bump automation to create PRs upgrading agent+beats repositories to Go 1.18.