### PR TITLE
fix empty list of 7 releases

### DIFF
--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -87,7 +87,7 @@ def fetchVersions() {
   def latestReleaseVersions = artifactsApi(action: 'latest-release-versions')
   // To store all the latest release versions
   def latestVersions = artifactsApi(action: 'latest-versions')
-  def current7 = latestReleaseVersions.findAll { it ==~ /7\.\d+\.\d+/ }.sort().last()
+  def current7 = getCurrent7(latestReleaseVersions)
   def latest8 = latestReleaseVersions.findAll { it ==~ /8\.\d+\.\d+/ }.sort().last()
   def current8 = getCurrent8(latestReleaseVersions)
   // NOTE: 6 major branch is now EOL (we keep this for backward compatibility)
@@ -99,6 +99,18 @@ def fetchVersions() {
   releaseVersions[bumpUtils.nextMinor8Key()] = latest8
   releaseVersions[bumpUtils.nextPatch8Key()] = increaseVersion(current8, 1)
   releaseVersions[bumpUtils.edge8Key()] = latestVersions.main.version.replaceAll('-SNAPSHOT','')
+}
+
+/*
+As long as the artifacts-api doesn't keep versions that have not built for over 30 days
+then return the previous value
+*/
+def getCurrent7(latestReleaseVersions) {
+  def latest7Versions = latestReleaseVersions?.findAll{ it ==~ /7\.\d+\.\d+/ }
+  if (latest7Versions) {
+    return latest7Versions.sort().last()
+  }
+  return bumpUtils.getCurrentMinorReleaseFor7()
 }
 
 def getCurrent8(latestReleaseVersions) {


### PR DESCRIPTION
## What does this PR do?

If the list of versions are empty then default to the previous value

## Why is it important?

Artifacts API might not provide what are the current releases as they are cleaned up after certain time...

## Test


I ran this [build](https://apm-ci.elastic.co/job/apm-shared/job/update-stack-release-version-pipeline/217/console) and it worked fine