### PR TITLE
k8s: add gvm for the e2e-testing

### DIFF
--- a/.ci/docker/jenkins-agent/Dockerfile
+++ b/.ci/docker/jenkins-agent/Dockerfile
@@ -19,7 +19,10 @@ RUN wget https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64
 # Install gh
 RUN dnf -qy install 'dnf-command(config-manager)' \
   && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
-  && dnf install -qy gh \
+  && dnf install -qy gh
+
+# Install make
+RUN dnf install -qy make \
   && dnf -qy clean all
 
 # Install gvm

--- a/.ci/docker/jenkins-agent/Dockerfile
+++ b/.ci/docker/jenkins-agent/Dockerfile
@@ -22,5 +22,9 @@ RUN dnf -qy install 'dnf-command(config-manager)' \
   && dnf install -qy gh \
   && dnf -qy clean all
 
+# Install gvm
+RUN curl -L -o /usr/local/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-linux-amd64 \
+  && chmod 755 /usr/local/bin/gvm
+
 # Switch back to the `jenkins` user before
 USER jenkins


### PR DESCRIPTION
## What does this PR do?

Add `gvm` to the docker image

## Why is it important?

Run on k8s the e2e-testing -> https://github.com/elastic/e2e-testing/pull/2859