### PR TITLE
action: report back test results

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,14 +7,18 @@ on:
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:
-  checks: write
-  pull-requests: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Upload event
+        uses: actions/upload-artifact@v3
+        with:
+          name: EventFile
+          path: ${{ github.event_path }}
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -23,12 +27,12 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@f00bb47e1d89c6d98071d1b69e16a2b63c7fbfc1
+      - name: Upload Test Results
         if: always()
-        continue-on-error: true
+        uses: actions/upload-artifact@v3
         with:
-          files: "target/surefire-reports/*.xml"
+          name: Test Results
+          path: target/surefire-reports/*.xml
       - uses: v1v/otel-upload-test-artifact-action@v2
         if: always()
         continue-on-error: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,8 @@ on:
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:
-  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build:
@@ -22,6 +23,12 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@f00bb47e1d89c6d98071d1b69e16a2b63c7fbfc1
+        if: always()
+        continue-on-error: true
+        with:
+          files: "target/surefire-reports/*.xml"
       - uses: v1v/otel-upload-test-artifact-action@v2
         if: always()
         continue-on-error: true

--- a/.github/workflows/job-dsl.yml
+++ b/.github/workflows/job-dsl.yml
@@ -11,13 +11,17 @@ on:
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:
-  checks: write
-  pull-requests: write
+  contents: read
 
 jobs:
   job-dsl:
     runs-on: ubuntu-latest
     steps:
+      - name: Upload event
+        uses: actions/upload-artifact@v3
+        with:
+          name: EventFile
+          path: ${{ github.event_path }}
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -29,12 +33,12 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean test --stacktrace
         working-directory: .ci/jobDSL
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@f00bb47e1d89c6d98071d1b69e16a2b63c7fbfc1
+      - name: Upload Test Results
         if: always()
-        continue-on-error: true
+        uses: actions/upload-artifact@v3
         with:
-          files: ".ci/jobDSL/build/test-results/test/TEST-*.xml"
+          name: Test Results
+          path: .ci/jobDSL/build/test-results/test/TEST-*.xml
       - uses: v1v/otel-upload-test-artifact-action@v2
         if: always()
         continue-on-error: true

--- a/.github/workflows/job-dsl.yml
+++ b/.github/workflows/job-dsl.yml
@@ -11,7 +11,8 @@ on:
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:
-  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   job-dsl:
@@ -28,6 +29,12 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean test --stacktrace
         working-directory: .ci/jobDSL
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@f00bb47e1d89c6d98071d1b69e16a2b63c7fbfc1
+        if: always()
+        continue-on-error: true
+        with:
+          files: ".ci/jobDSL/build/test-results/test/TEST-*.xml"
       - uses: v1v/otel-upload-test-artifact-action@v2
         if: always()
         continue-on-error: true

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,41 @@
+name: Unit Test Results
+
+on:
+  workflow_run:
+    workflows: [Java CI, job-dsl]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@f00bb47e1d89c6d98071d1b69e16a2b63c7fbfc1
+        if: always()
+        continue-on-error: true
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/EventFile/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: |
+            .ci/jobDSL/build/test-results/test/TEST-*.xml
+            target/surefire-reports/*.xml


### PR DESCRIPTION
## What does this PR do?

Report back the test results as GitHub comments

## Why is it important?

Keep reporting what's the status so people don't need to go to the logs

## Question

- This approach requires to change the permissions.
- There is an alternative approach to create another [GitHub workflow](https://github.com/EnricoMi/publish-unit-test-result-action/blob/master/.github/workflows/test-results.yml) that consumes the artifacts which were [uploaded](https://github.com/EnricoMi/publish-unit-test-result-action/blob/8b03530a086aaacbc2e00a9743670685273623a0/.github/workflows/ci-cd.yml#L112-L119) . This can help with the permissions for the GitHub token

## Further details

```
Warning: This action is running on a pull_request event for a fork repository. It cannot do anything useful like creating check runs or pull request comments. To run the action on fork repository pull requests, see https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#support-fork-repositories-and-dependabot-branches
```

for the first commit