### PR TITLE
Move from observablt-robots-on-call to observablt-robots

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -21,14 +21,14 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: apm-integration-testing
     script: .ci/bump-go-release-version.sh
     branches:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: beats
     script: .ci/bump-go-release-version.sh
     branches:
@@ -93,4 +93,4 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -21,14 +21,14 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-go-release-version.sh
     branches:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: beats
     script: .ci/bump-go-release-version.sh
     branches:
@@ -93,4 +93,4 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -19,7 +19,7 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: apm-integration-testing
     script: .ci/bump-stack-release-version.sh
     branches:
@@ -27,14 +27,14 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: observability-test-environments
     script: .ci/bump-stack-release-version.sh
     branches:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh
     branches:

--- a/.ci/.bump-stack-release-version.yml
+++ b/.ci/.bump-stack-release-version.yml
@@ -19,7 +19,7 @@ projects:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: apm-integration-testing
     script: .ci/bump-stack-release-version.sh
     branches:
@@ -27,14 +27,14 @@ projects:
       - 7.x
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: observability-test-environments
     script: .ci/bump-stack-release-version.sh
     branches:
       - main
     enabled: true
     labels: dependency
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: azure-vm-extension
     script: .ci/bump-stack-release-version.sh
     branches:

--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -46,7 +46,7 @@ projects:
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
-    reviewer: elastic/observablt-robots-on-call
+    reviewer: elastic/observablt-robots
   - repo: elastic-agent
     script: .ci/bump-stack-version.sh
     branches:

--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -46,7 +46,7 @@ projects:
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
-    reviewer: elastic/observablt-robots
+    reviewer: elastic/observablt-ci
   - repo: elastic-agent
     script: .ci/bump-stack-version.sh
     branches:

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -69,7 +69,7 @@ pipeline {
                           branchName: 'main',
                           labels: 'automation',
                           message: """### What \n Bump stack version with the latest one. \n ### Further details \n ${releaseVersions} \n The release might not be available yet, if the CI failed please verify if the release is public available in https://www.elastic.co/downloads/past-releases#elasticsearch.""",
-                          reviewer: 'elastic/observablt-robots',
+                          reviewer: 'elastic/observablt-ci',
                           stackVersions: releaseVersions,
                           title: '[automation] Update Elastic stack release version source of truth')
       }

--- a/.ci/updateStackReleaseVersion.groovy
+++ b/.ci/updateStackReleaseVersion.groovy
@@ -69,7 +69,7 @@ pipeline {
                           branchName: 'main',
                           labels: 'automation',
                           message: """### What \n Bump stack version with the latest one. \n ### Further details \n ${releaseVersions} \n The release might not be available yet, if the CI failed please verify if the release is public available in https://www.elastic.co/downloads/past-releases#elasticsearch.""",
-                          reviewer: 'elastic/observablt-robots-on-call',
+                          reviewer: 'elastic/observablt-robots',
                           stackVersions: releaseVersions,
                           title: '[automation] Update Elastic stack release version source of truth')
       }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots-on-call"
+      - "elastic/observablt-robots"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots-on-call"
+      - "elastic/observablt-robots"
 
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
@@ -27,4 +27,4 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots-on-call"
+      - "elastic/observablt-robots"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots"
+      - "elastic/observablt-ci"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots"
+      - "elastic/observablt-ci"
 
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
@@ -27,4 +27,4 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "elastic/observablt-robots"
+      - "elastic/observablt-ci"


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

## What does this PR do?

Use `elastic/observablt-robots` group instead of `elastic/observablt-robots-on-call`.

## Why is it important?

There is no rotation anymore for on-call.
