### PR TITLE
feat: enable dependabot for pytest-otel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,12 @@ updates:
       interval: "weekly"
     reviewers:
       - "elastic/observablt-robots-on-call"
+
+  # Enable version updates for Python
+  - package-ecosystem: "pip"
+    directory: "resources/scripts/pytest_otel"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/observablt-robots-on-call"


### PR DESCRIPTION
## What does this PR do?

Configures dependabot to track pytest-otel.

## Why is it important?

pytest-otel currently requires opentelemetry-python packages at version 1.11.0; however, 1.11.1 is available. By using dependabot we can keep the OTel deps updated, and catch any breaking changes.

## Related issues

None