### PR TITLE
Freeze Go version at 1.18.

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -33,6 +33,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency,backport-skip
     description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
@@ -40,12 +41,14 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency,backport-skip
   - repo: elastic-agent
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency,backport-skip
     description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
@@ -53,24 +56,28 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency
   - repo: elastic-agent-inputs
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency
   - repo: elastic-agent-libs
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency
   - repo: elastic-agent-system-metrics
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency
   - repo: fleet-server


### PR DESCRIPTION
Prevents versions bumps to Go 1.19 until we are ready to update, we are
still working to support Go 1.18.
