### PR TITLE
golang: enable 1.18 and 1.17

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -90,8 +90,8 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+      - "1.18"
       - "1.17"
-      - "1.16"
     enabled: true
     labels: dependency
   - repo: observability-robots


### PR DESCRIPTION
1.16 is not anymore supported and main points to 1.19 now

## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
