### PR TITLE
pytest_otel: add hard dependencies

### DIFF
--- a/resources/scripts/pytest_otel/README.md
+++ b/resources/scripts/pytest_otel/README.md
@@ -12,7 +12,7 @@ Requirements
 * opentelemetry-api == 1.11.0
 * opentelemetry-exporter-otlp == 1.11.0
 * opentelemetry-sdk == 1.11.0
-
+* pytest >= 6.2.5
 
 Installation
 ------------

--- a/resources/scripts/pytest_otel/pyproject.toml
+++ b/resources/scripts/pytest_otel/pyproject.toml
@@ -2,7 +2,7 @@ dependencies = [
     "opentelemetry-api==1.11.0",
     "opentelemetry-exporter-otlp==1.11.0",
     "opentelemetry-sdk==1.11.0",
-    "pytest>=6",
+    "pytest>=6.2.5",
 ]
 
 [build-system]

--- a/resources/scripts/pytest_otel/pyproject.toml
+++ b/resources/scripts/pytest_otel/pyproject.toml
@@ -1,3 +1,10 @@
+dependencies = [
+    "opentelemetry-api==1.11.0",
+    "opentelemetry-exporter-otlp==1.11.0",
+    "opentelemetry-sdk==1.11.0",
+    "pytest>=6.2.5",
+]
+
 [build-system]
 requires = ["setuptools >= 44.0.0", "wheel >= 0.30"]
 build-backend = "setuptools.build_meta"

--- a/resources/scripts/pytest_otel/pyproject.toml
+++ b/resources/scripts/pytest_otel/pyproject.toml
@@ -2,7 +2,7 @@ dependencies = [
     "opentelemetry-api==1.11.0",
     "opentelemetry-exporter-otlp==1.11.0",
     "opentelemetry-sdk==1.11.0",
-    "pytest>=6.2.5",
+    "pytest>=6",
 ]
 
 [build-system]

--- a/resources/scripts/pytest_otel/setup.cfg
+++ b/resources/scripts/pytest_otel/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     opentelemetry-api==1.11.0
     opentelemetry-exporter-otlp==1.11.0
     opentelemetry-sdk==1.11.0
-    pytest>=5
+    pytest>=6
 python_requires = >=3.6
 include_package_data = True
 package_dir =

--- a/resources/scripts/pytest_otel/setup.cfg
+++ b/resources/scripts/pytest_otel/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     opentelemetry-api==1.11.0
     opentelemetry-exporter-otlp==1.11.0
     opentelemetry-sdk==1.11.0
-    pytest>=6
+    pytest>=6.2.5
 python_requires = >=3.6
 include_package_data = True
 package_dir =


### PR DESCRIPTION
## What does this PR do?

Add hard-requirements as [explained here](https://realpython.com/pypi-publish-python-package/#specify-your-package-dependencies)

Those dependencies are defined in https://github.com/elastic/apm-pipeline-library/blob/dcbf2c4c6026925b905ec1bdfe4ba2ba7a9469e1/resources/scripts/pytest_otel/requirements.txt#L6

## Why is it important?

Help consumers so they can use the library with the needed dependencies.

Closes https://github.com/elastic/apm-pipeline-library/issues/1839