### PR TITLE
ci: use github commit status

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     SLACK_CHANNEL = '#observablt-bots'
     JOB_GCS_BUCKET = 'apm-ci-temp'
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin-file-credentials'
-    GITHUB_CHECK = 'true'
+    GITHUB_CHECK = 'false'
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
As long as the mask-pass is still 3.3 based
