### PR TITLE
test-infra: java for arm is not required

### DIFF
--- a/test-infra/apm-ci/test_installed_tools.py
+++ b/test-infra/apm-ci/test_installed_tools.py
@@ -41,7 +41,7 @@ def test_vault_installed(host):
   assert cmd.rc == 0, "it is required for all the APM projects"
 
 def test_java11_is_installed(host):
-  if host.system_info.type == 'darwin' or host.system_info.arch != 'x86_64':
+  if host.system_info.type == 'darwin' or host.check_output("uname -m") != "x86_64":
     pytest.skip("unsupported configuration")
   else:
     hudson_home = host.environment().get('HUDSON_HOME')

--- a/test-infra/apm-ci/test_installed_tools.py
+++ b/test-infra/apm-ci/test_installed_tools.py
@@ -41,7 +41,7 @@ def test_vault_installed(host):
   assert cmd.rc == 0, "it is required for all the APM projects"
 
 def test_java11_is_installed(host):
-  if host.system_info.type == 'darwin' :
+  if host.system_info.type == 'darwin' or host.system_info.arch != 'x86_64':
     pytest.skip("unsupported configuration")
   else:
     hudson_home = host.environment().get('HUDSON_HOME')


### PR DESCRIPTION
## What does this PR do?

Skip test-infra for arm , using https://testinfra.readthedocs.io/en/latest/modules.html#testinfra.modules.systeminfo.SystemInfo.arch

## Why is it important?

Java Agent doesn't use ARM anymore

