### PR TITLE
Fallback runE2E to main if a feature branch in Beats/ElasticAgent

### DIFF
--- a/vars/runE2E.txt
+++ b/vars/runE2E.txt
@@ -26,6 +26,8 @@ Trigger the end 2 end testing job. https://beats-ci.elastic.co/job/e2e-tests/job
 * *propagate*: the test suites to test. Optional (default false)
 * *wait*: the test suites to test. Optional (default false)
 
-**NOTE**: It works only in the `beats-ci` and `fleet-ci` controllers.
+**NOTE1**: Feature branches are not supported, so if Beats/ElasticAgent uses a
+           feature branch then it will run against the `e2e-testing@main`.
+**NOTE2**: It works only in the `beats-ci` and `fleet-ci` controllers.
 
 Parameters are defined in https://github.com/elastic/e2e-testing/blob/main/.ci/Jenkinsfile


### PR DESCRIPTION
## What does this PR do?

e2e-testing branch strategy follows the same branch strategy defined in `elastic/beats.git` and `elastic/elastic-agent`, aka, main and release branches. Hence feature branches are not supported.

Avoid feature branches by falling back to `main`

## Why is it important?

The existing branch strategy in the `e2e-testing` needs to be aligned with the consumers one. otherwise things won't work.

This is an alternative and might require some clarification with the teams about what to do and ownership.

Using this approach will make things work but there is a chance the target branch will not contain the expected implementation, if so, what do we do?