### PR TITLE
Update default vault secrets for sendBenchmarks

### DIFF
--- a/src/test/groovy/ApmBasePipelineTest.groovy
+++ b/src/test/groovy/ApmBasePipelineTest.groovy
@@ -39,7 +39,7 @@ class ApmBasePipelineTest extends DeclarativePipelineTest {
 
   enum VaultSecret{
     ALLOWED('secret/observability-team/ci/temp/allowed'),
-    BENCHMARK('secret/apm-team/ci/benchmark-cloud'),
+    BENCHMARK('secret/observability-team/ci/benchmark-cloud'),
     SECRET('secret'), SECRET_ALT_USERNAME('secret-alt-username'), SECRET_ALT_PASSKEY('secret-alt-passkey'),
     SECRET_APM('secret/observability-team/ci/jenkins-stats'),
     SECRET_APM_CUSTOMISED('secret/observability-team/ci/jenkins-stats/customised'),

--- a/vars/sendBenchmarks.groovy
+++ b/vars/sendBenchmarks.groovy
@@ -30,7 +30,7 @@ def call(Map args = [:]) {
   }
   def benchFile = args.containsKey('file') ? args.file : 'bench.out'
   def index = args.containsKey('index') ? args.index : 'benchmark-go'
-  def secret = args.containsKey('secret') ? args.secret : 'secret/apm-team/ci/benchmark-cloud'
+  def secret = args.containsKey('secret') ? args.secret : 'secret/observability-team/ci/benchmark-cloud'
   def archive = args.containsKey('archive') ? args.archive : true
 
   if(archive){


### PR DESCRIPTION
## What does this PR do?

Update vault secret so it can be used by some other teams within the observability org

## Why is it important?

Unblocks https://github.com/elastic/go-libaudit/pull/123