### PR TITLE
Revert "chore(deps-dev): bump workflow-job from 1203.v7b_7023424efe to 1232.v5a_4c994312f1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>1232.v5a_4c994312f1</version>
+      <version>1203.v7b_7023424efe</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts elastic/apm-pipeline-library#1818


https://github-redirect.dependabot.com/jenkinsci/workflow-job-plugin/issues/279 is the one causing issues in our CI when running the release

```

[2022-08-30T12:15:33.563Z] [INFO] [INFO] BUILD FAILURE

[2022-08-30T12:15:33.563Z] [INFO] [INFO] ------------------------------------------------------------------------

[2022-08-30T12:15:33.563Z] [INFO] [INFO] Total time:  13.996 s

[2022-08-30T12:15:33.563Z] [INFO] [INFO] Finished at: 2022-08-30T12:15:33Z

[2022-08-30T12:15:33.563Z] [INFO] [INFO] ------------------------------------------------------------------------

[2022-08-30T12:15:33.563Z] [INFO] [ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:1.13.1:compileTests (default) on project jenkins-library: Error occurred while calling a method on a Groovy class from classpath. InvocationTargetException: org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0 -> [Help 1]

```