### PR TITLE
actions: cache maven dependencies

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
       - uses: v1v/otel-upload-test-artifact-action@v2


### PR DESCRIPTION
See https://github.com/actions/setup-java\#caching-packages-dependencies

## What does this PR do?

Cache maven build dependencies

## Why is it important?

Faster builds