### PR TITLE
Support for gobench transformation

### DIFF
--- a/src/test/groovy/SendBenchmarksStepTests.groovy
+++ b/src/test/groovy/SendBenchmarksStepTests.groovy
@@ -52,6 +52,7 @@ class SendBenchmarksStepTests extends ApmBasePipelineTest {
   void testParams() throws Exception {
     script.call(file: 'bench.out', index: 'index-name', url: 'https://vault.example.com', secret: VaultSecret.SECRET.toString(), archive: true)
     printCallStack()
+    assertFalse(assertMethodCallContainsPattern('withGoEnv', 'github.com/elastic/gobench'))
     assertJobStatusSuccess()
   }
 
@@ -196,5 +197,13 @@ class SendBenchmarksStepTests extends ApmBasePipelineTest {
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('error', 'Benchmarks: there was a response with an error. Review response'))
     assertJobStatusFailure()
+  }
+
+  @Test
+  void test_with_useGoBench() throws Exception {
+    script.call(file: 'bench.out', index: 'index-name', url: 'https://vault.example.com', secret: VaultSecret.SECRET.toString(), archive: true, useGoBench: true)
+    printCallStack()
+    assertTrue(assertMethodCallContainsPattern('withGoEnv', 'github.com/elastic/gobench'))
+    assertJobStatusSuccess()
   }
 }

--- a/vars/sendBenchmarks.groovy
+++ b/vars/sendBenchmarks.groovy
@@ -32,6 +32,7 @@ def call(Map args = [:]) {
   def index = args.containsKey('index') ? args.index : 'benchmark-go'
   def secret = args.containsKey('secret') ? args.secret : 'secret/observability-team/ci/benchmark-cloud'
   def archive = args.containsKey('archive') ? args.archive : true
+  def useGoBench = args.get('useGoBench', false)
 
   if(archive){
     archiveArtifacts(allowEmptyArchive: true,
@@ -55,7 +56,7 @@ def call(Map args = [:]) {
   def url = args.containsKey('url') ? args.url : data.url
 
   log(level: 'INFO', text: "Benchmarks: sending data...")
-  if(index.equals('benchmark-go') || index.equals('benchmark-server')){
+  if(index.equals('benchmark-go') || index.equals('benchmark-server') || useGoBench){
     def protocol = getProtocol(url)
     url = url - protocol
     gobench("${protocol}${user}:${password}@${url}", benchFile, index)

--- a/vars/sendBenchmarks.txt
+++ b/vars/sendBenchmarks.txt
@@ -17,6 +17,7 @@ sendBenchmarks(file: 'bench.out', index: 'index-name')
 * *index*: index name to store data.
 * *url*: ES url to store the data.
 * *secret*: Vault secret that contains the ES credentials.
+* *useGoBench*: Whether to use github.com/elastic/gobench. Default `false`.
 
 ### sendBenchmarks.prepareAndRun
 


### PR DESCRIPTION
## What does this PR do?

Add `useGoBench` parameter so it can use the `gobench` library

## Why is it important?

There is no need to approve the indices but use the flag instead
