### PR TITLE
go-bump-automation: enable for cloudbeat

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -44,6 +44,7 @@ projects:
     enabled: true
     labels: dependency
     reviewer: elastic/cloudbeat
+    overrideGoVersion: "1.18"
   - repo: elastic-agent-shipper
     script: .ci/bump-go-release-version.sh
     branches:

--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -37,6 +37,13 @@ projects:
     enabled: true
     labels: dependency,backport-skip
     description: It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to https://github.com/elastic/golang-crossbuild/releases. Otherwise it will fail until the docker images are available.
+  - repo: cloudbeat
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency
+    reviewer: elastic/cloudbeat
   - repo: elastic-agent-shipper
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Enable golang auto-bump for https://github.com/elastic/cloudbeat

## Why is it important?

Use same automation as done for other projects, hence https://github.com/elastic/cloudbeat/pull/304 won't be manually created anymore

## Issue

Requires https://github.com/elastic/cloudbeat/pull/368