### PR TITLE
dependabot: less often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
   # Enable version updates for Gradle
   - package-ecosystem: "gradle"
     directory: ".ci/jobDSL"
-    # Check for updates once a week
+    # Check for updates once a month
     schedule:
       interval: "monthly"
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     # Check for updates once a week
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "elastic/observablt-ci"
 
@@ -25,6 +25,6 @@ updates:
     directory: ".ci/jobDSL"
     # Check for updates once a week
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "elastic/observablt-ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "maven"
     # Look for `pom.xml` file in the `root` directory
     directory: "/"
-    # Check for updates once a week
+    # Check for updates once a month
     schedule:
       interval: "monthly"
     reviewers:


### PR DESCRIPTION
## What does this PR do?

Run less often the dependabot bumps

## Why is it important?

There is no need to be up-to-date immediately, so we can reduce the code review overhead/notifications a bit