### PR TITLE
Validate yq is installed on beats-ci

### DIFF
--- a/test-infra/beats-ci/test_beats_installed_tools.py
+++ b/test-infra/beats-ci/test_beats_installed_tools.py
@@ -72,3 +72,7 @@ def test_tar_installed(host):
 def test_vault_installed(host):
   cmd = host.run("vault --version")
   assert cmd.rc == 0, "it is required for all the Beats projects"
+
+def test_yq_is_installed(host):
+  cmd = host.run("yq --version")
+  assert cmd.rc == 0, "it is required for ingest-dev project"


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

## What does this PR do?

Check `yq` is installed on beats-ci.

## Why is it important?

`yq` is needed for the `ingest-dev` project.
