### PR TITLE
cosmetic: github comment section to be collapsed

### DIFF
--- a/resources/commands-github-comment-markdown.template
+++ b/resources/commands-github-comment-markdown.template
@@ -1,6 +1,9 @@
 <%if (githubCommands?.size() > 0) {%>
 ## :robot: GitHub comments
 
+<details><summary>Expand to view the GitHub comments</summary>
+<p>
+
 To re-run your PR in the CI, just comment with:
 
 <% githubCommands?.each { githubCommand, description -> %>
@@ -9,3 +12,6 @@ To re-run your PR in the CI, just comment with:
 <%}%>
 
 <%}%>
+
+</p>
+</details>


### PR DESCRIPTION
## What does this PR do?

Collapse the GitHub comments sections by default

## Why is it important?

Less verbose details for the shake of usability

## Current

<img width="952" alt="image" src="https://user-images.githubusercontent.com/2871786/189681328-77605ff6-ba7a-49f1-ad2d-175a62e02b6d.png">


## This proposal


<img width="1169" alt="image" src="https://user-images.githubusercontent.com/2871786/189681115-bf811d76-01bc-4c8c-90c1-1c6d69b9c4e3.png">

