### PR TITLE
go 1.18 for apm pipeline

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -19,6 +19,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency
     reviewer: elastic/observablt-ci

--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -38,5 +38,5 @@ def isGoVersionEnvVarSet(){
 }
 
 def defaultVersion(){
-  return '1.19.1'
+  return '1.18.5'
 }


### PR DESCRIPTION
## What does this PR do?

Go Version is normally being driven by Beats and similar projects. So let's use the same versioning

## Why is it important?

Avoid weird surprises regarding the version used in the pipeline:
- https://github.com/elastic/elastic-agent/pull/1204