### PR TITLE
golang: automate bump for elastic/stream.git

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -110,3 +110,9 @@ projects:
     enabled: true
     labels: dependency
     reviewer: elastic/observablt-ci
+  - repo: stream
+    script: .ci/bump-go-release-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency


### PR DESCRIPTION
## What does this PR do?

Enrol the `elastic/stream.git` project for the golang autobump.

## Why is it important?

Team won't need to monitor if a new version is out but use our existing automation

## Related issues
Requires https://github.com/elastic/stream/pull/42
