### PR TITLE
fix: install weel before to make a package

### DIFF
--- a/resources/scripts/pytest_otel/CHANGELOG.md
+++ b/resources/scripts/pytest_otel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # version 1.2.1
 
+* fix: pytest_otel: pytest.fail is not captured as an error [#1840](https://github.com/elastic/apm-pipeline-library/pull/1840) [#1843](https://github.com/elastic/apm-pipeline-library/pull/1843)
+* fix: update the pytest_otel demo [#1804](https://github.com/elastic/apm-pipeline-library/pull/1804)
+
 * chore(deps): bump mypy in /resources/scripts/pytest_otel [#1893](https://github.com/elastic/apm-pipeline-library/pull/1893)
 * chore(deps): bump pytest-docker in /resources/scripts/pytest_otel [#1894](https://github.com/elastic/apm-pipeline-library/pull/1894)
 * chore(deps): bump pre-commit in /resources/scripts/pytest_otel [#1877](https://github.com/elastic/apm-pipeline-library/pull/1877)
@@ -7,7 +10,6 @@
 * chore(deps): bump psutil in /resources/scripts/pytest_otel [#1879](https://github.com/elastic/apm-pipeline-library/pull/1879)
 * chore: bump Otel 1.12.0 [#1890](https://github.com/elastic/apm-pipeline-library/pull/1890)
 * pytest_otel: add hard dependencies [#1841](https://github.com/elastic/apm-pipeline-library/pull/1841)
-* fix: update the pytest_otel demo [#1804](https://github.com/elastic/apm-pipeline-library/pull/1804)
 
 # Version 1.1.1
 

--- a/resources/scripts/pytest_otel/Makefile
+++ b/resources/scripts/pytest_otel/Makefile
@@ -112,6 +112,7 @@ clean:
 package: virtualenv
 	source $(VENV)/bin/activate;\
 	set +xe; \
+	pip install wheel; \
 	$(PYTHON) setup.py sdist bdist_wheel
 
 ## @help:run-otel-collector:Run OpenTelemetry collector in debug mode.


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
We have to add the installation of wheel before to make the package if not the following error happens

```bash
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help
error: invalid command 'bdist_wheel'
```
