### PR TITLE
fix: Remove "Integration Tests" stage from opbeansPipeline

### DIFF
--- a/src/test/groovy/OpbeansPipelineStepTests.groovy
+++ b/src/test/groovy/OpbeansPipelineStepTests.groovy
@@ -42,7 +42,6 @@ class OpbeansPipelineStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('stage', 'Build'))
     assertTrue(assertMethodCallContainsPattern('stage', 'Test'))
     assertTrue(assertMethodCallContainsPattern('stage', 'Release'))
-    assertTrue(assertMethodCallContainsPattern('build', 'job=apm-integration-tests-selector-mbp/main'))
     assertJobStatusSuccess()
   }
 
@@ -51,7 +50,6 @@ class OpbeansPipelineStepTests extends ApmBasePipelineTest {
     env.BRANCH_NAME = 'main'
     script.call(downstreamJobs: [])
     printCallStack()
-    assertTrue(assertMethodCallContainsPattern('build', 'job=apm-integration-tests-selector-mbp/main'))
     assertJobStatusSuccess()
   }
 

--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -38,8 +38,6 @@ def call(Map pipelineParams) {
       DOCKER_REGISTRY_SECRET = 'secret/apm-team/ci/docker-registry/prod'
       REGISTRY = 'docker.elastic.co'
       STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
-      GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-      ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
     }
     options {
       timeout(time: 1, unit: 'HOURS')
@@ -129,11 +127,6 @@ def call(Map pipelineParams) {
           }
         }
       }
-      stage('Integration Tests') {
-        steps {
-          runBuildITs("${env.REPO_NAME}", "${env.STAGING_IMAGE}/${env.REPO_NAME}")
-        }
-      }
       stage('Downstream') {
         when {
           allOf {
@@ -198,16 +191,6 @@ def call(Map pipelineParams) {
       }
     }
   }
-}
-
-def runBuildITs(String repo, String stagingDockerImage) {
-  build(job: env.ITS_PIPELINE, propagate: waitIfNotPR(), wait: waitIfNotPR(),
-        parameters: [string(name: 'INTEGRATION_TEST', value: 'Opbeans'),
-                     string(name: 'BUILD_OPTS', value: "${generateBuildOpts(repo, stagingDockerImage)}"),
-                     string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                     string(name: 'GITHUB_CHECK_REPO', value: repo),
-                     string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-  githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
 }
 
 def generateBuildOpts(String repo, String stagingDockerImage) {


### PR DESCRIPTION
opbeans-$lang Jenkins builds are currently failing on the "Integration Tests"
step with:
    Failed to trigger build of apm-integration-tests-selector-mbp/main
They all run the `opbeansPipeline()` that is defined here.

https://github.com/elastic/apm-integration-testing/pull/1524 removed
the integration tests from apm-integration-testing.git and its Jenkinsfile.

* * *

- node.js: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-nodejs%2Fopbeans-node-mbp/detail/main/124/pipeline
- python: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fopbeans-python-mbp/detail/main/150/pipeline
- go: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-go%2Fopbeans-go-mbp/detail/main/98/pipeline


I'm pretty sure this is the correct "fix", but to be honest I'm a little lost in all the various "Integration Tests" stages and Jenkinsfiles.