### PR TITLE
update owner for the auto-bump in the e2e-testing

### DIFF
--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -46,7 +46,7 @@ projects:
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip
-    reviewer: elastic/observablt-ci
+    reviewer: elastic/observablt-dx
   - repo: elastic-agent
     script: .ci/bump-stack-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Change the owner for those auto-bumps

For instance https://github.com/elastic/e2e-testing/pull/3069 only notifies the `ci` team