### PR TITLE
Honour archiveOnlyOnFail in metricbeat

### DIFF
--- a/src/test/groovy/MetricbeatStepTests.groovy
+++ b/src/test/groovy/MetricbeatStepTests.groovy
@@ -210,4 +210,30 @@ class MetricbeatStepTests extends ApmBasePipelineTest {
     assertTrue(assertMethodCallContainsPattern('log', "There is no configuration file to stop metricbeat."))
     assertJobStatusSuccess()
   }
+
+  @Test
+  void testStop_ArchiveOnlyOnFailTrue_SuccessBuild() throws Exception {
+    def id = "fooID"
+    def output = "foo.log"
+    def workdir = "metricbeatTest_2"
+    helper.registerAllowedMethod('isBuildFailure', [], { false })
+    printCallStack(){
+      script.stop(workdir: workdir)
+    }
+    assertFalse(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testStop_ArchiveOnlyOnFailTrue_FailureBuild() throws Exception {
+    def id = "fooID"
+    def output = "foo.log"
+    def workdir = "metricbeatTest_2"
+    helper.registerAllowedMethod('isBuildFailure', [], { true })
+    printCallStack(){
+      script.stop(workdir: workdir)
+    }
+    assertTrue(assertMethodCallContainsPattern('archiveArtifacts', "artifacts=**/${output}*"))
+    assertJobStatusSuccess()
+  }
 }

--- a/src/test/resources/metricbeatTest_2/metricbeat_container_worker-0676d01d9601f8191.json
+++ b/src/test/resources/metricbeatTest_2/metricbeat_container_worker-0676d01d9601f8191.json
@@ -2,6 +2,7 @@
   "id": "fooID",
   "config": "bar.xml",
   "image": "foo: latest",
+  "output": "foo.log",
   "workdir": "fooDir",
   "timeout": "30",
   "archiveOnlyOnFail": "true"

--- a/vars/metricbeat.txt
+++ b/vars/metricbeat.txt
@@ -21,6 +21,7 @@
 * *image:* metricbeat Docker image to use (docker.elastic.co/beats/metricbeat:7.10.1).
 * *timeout:* Time to wait before kill the metricbeat Docker container on the stop operation.
 * *workdir:* Directory to use as root folder to read and write files (current folder).
+* *archiveOnlyOnFail:* if true only archive the files in case of failure.
 
 ```
   metricbeat(


### PR DESCRIPTION
## What does this PR do?

Support `archiveOnlyOnFail` in the `metricbeat` step

## Why is it important?

`archiveOnlyOnFail` was added to the consumer `dockerContext` but it was not implemented in `metricbeat`.