### PR TITLE
fix: remove branches jobs creation

### DIFF
--- a/.ci/jobs/apm-pipeline-library-mbp.yml
+++ b/.ci/jobs/apm-pipeline-library-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          head-filter-regex: '^(?!update-.*-version).*$'
+          head-filter-regex: '(main|PR-.*)'
           notification-context: 'apm-ci'
           repo: apm-pipeline-library
           repo-owner: elastic


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
* filter all branches except main and PRs in the main Jenkins pipeline
## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

There is about 30 branches that should not have job for this pipeline.