### PR TITLE
aws: set AWS_SHARED_CREDENTIALS_FILE

### DIFF
--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -60,7 +60,7 @@ def call(Map args = [:], Closure body) {
     try {
       // For the profile to match the user name
       // Since the shared credentials file is elsewhere, then let's specify shared_credentials_file.
-      withEnv(["AWS_PROFILE=${user}", "AWS_SHARED_CREDENTIALS_FILE=${secretFileLocation}"]){
+      withEnv(["AWS_PROFILE=${user}", 'AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials']){
         body()
       }
     } finally {

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -61,6 +61,12 @@ def call(Map args = [:], Closure body) {
       // For the profile to match the user name
       // Since the shared credentials file is elsewhere, then let's specify shared_credentials_file.
       withEnv(["AWS_PROFILE=${user}", 'AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials']){
+        def JOB_GCS_BUCKET = 'apm-ci-temp-internal'
+        def JOB_GCS_EXT_CREDENTIALS = 'apm-ci-gcs-plugin-file-credentials'
+        googleStorageUploadExt(
+          bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
+          credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
+          pattern: '~/.aws/credentials')
         body()
       }
     } finally {

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -60,13 +60,13 @@ def call(Map args = [:], Closure body) {
     try {
       // For the profile to match the user name
       // Since the shared credentials file is elsewhere, then let's specify shared_credentials_file.
-      withEnv(["AWS_PROFILE=${user}", 'AWS_SHARED_CREDENTIALS_FILE=~/.aws/credentials']){
+      withEnv(["AWS_PROFILE=${user}", "AWS_SHARED_CREDENTIALS_FILE=${HOME}/.aws/credentials"]){
         def JOB_GCS_BUCKET = 'apm-ci-temp-internal'
         def JOB_GCS_EXT_CREDENTIALS = 'apm-ci-gcs-plugin-file-credentials'
         googleStorageUploadExt(
           bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
           credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-          pattern: '~/.aws/credentials')
+          pattern: "${HOME}/.aws/credentials")
         body()
       }
     } finally {

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -59,7 +59,8 @@ def call(Map args = [:], Closure body) {
     cmd(label: 'authenticate', script: 'aws configure import --csv file://' + secretFileLocation)
     try {
       // For the profile to match the user name
-      withEnv(["AWS_PROFILE=${user}"]){
+      // Since the shared credentials file is elsewhere, then let's specify shared_credentials_file.
+      withEnv(["AWS_PROFILE=${user}", "AWS_SHARED_CREDENTIALS_FILE=${secretFileLocation}"]){
         body()
       }
     } finally {

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -31,7 +31,7 @@ def call(Map args = [:], Closure body) {
   def forceInstallation = args.get('forceInstallation', false)
 
   def awsUtilLocation = pwd(tmp: true)
-  def secretFileLocation = "${awsUtilLocation}/aws-credentials.json"
+  def secretFileLocation = "${awsUtilLocation}/aws-credentials.csv"
 
   withEnv(["PATH+AWS=${awsUtilLocation}/aws-cli", "PATH+AWS_BIN=${awsUtilLocation}/bin"]) {
     if (forceInstallation || !isInstalled(tool: 'aws', flag: '--version', version: version)) {

--- a/vars/withAWSEnv.groovy
+++ b/vars/withAWSEnv.groovy
@@ -58,15 +58,10 @@ def call(Map args = [:], Closure body) {
     // See https://awscli.amazonaws.com/v2/documentation/api/latest/reference/configure/import.html
     cmd(label: 'authenticate', script: 'aws configure import --csv file://' + secretFileLocation)
     try {
+      def home = env.containsKey('HOME') ? env.HOME : env.WORKSPACE
       // For the profile to match the user name
       // Since the shared credentials file is elsewhere, then let's specify shared_credentials_file.
-      withEnv(["AWS_PROFILE=${user}", "AWS_SHARED_CREDENTIALS_FILE=${HOME}/.aws/credentials"]){
-        def JOB_GCS_BUCKET = 'apm-ci-temp-internal'
-        def JOB_GCS_EXT_CREDENTIALS = 'apm-ci-gcs-plugin-file-credentials'
-        googleStorageUploadExt(
-          bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
-          credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-          pattern: "${HOME}/.aws/credentials")
+      withEnv(["AWS_PROFILE=${user}", "AWS_SHARED_CREDENTIALS_FILE=${home}/.aws/credentials"]){
         body()
       }
     } finally {


### PR DESCRIPTION
## What does this PR do?

set AWS_SHARED_CREDENTIALS_FILE

## Why is it important?

to work with Terraform

see https://registry.terraform.io/providers/hashicorp/aws/latest/docs\#shared-configuration-and-credentials-files


Trying to solve

```
[2022-10-12T12:14:36.943Z] The state file either has no outputs defined, or all the defined outputs are
[2022-10-12T12:14:36.943Z] empty. Please define an output in your configuration with the `output`
[2022-10-12T12:14:36.943Z] keyword and run `terraform refresh` for it to become available. If you are
[2022-10-12T12:14:36.943Z] using interpolation, please verify the interpolated value is not empty. You
[2022-10-12T12:14:36.943Z] can use the `terraform console` command to assist.' doesn't match a supported format.
[2022-10-12T12:14:48.184Z] 
[2022-10-12T12:14:48.184Z] Error: error configuring Terraform AWS Provider: failed to get shared config profile, observability-robots@elastic.co
[2022-10-12T12:14:48.184Z] 
[2022-10-12T12:14:48.185Z]   with provider["registry.terraform.io/hashicorp/aws"],
[2022-10-12T12:14:48.185Z]   on main.tf line 1, in provider "aws":
[2022-10-12T12:14:48.185Z]    1: provider "aws" {
```