### PR TITLE
Support release7 alias

### DIFF
--- a/src/test/groovy/StackVersionsStepTests.groovy
+++ b/src/test/groovy/StackVersionsStepTests.groovy
@@ -23,7 +23,8 @@ class StackVersionsStepTests extends ApmBasePipelineTest {
 
   class BumpUtilsMock {
     String getNextMinorReleaseFor8(){ "8.2.0" }
-    String getNextPatchReleaseFor8(){ "8.1.0" }
+    String getNextPatchReleaseFor8(){ "8.1.1" }
+    String getCurrentMinorReleaseFor8(){ "8.1.0" }
     String getCurrentMinorReleaseFor7(){ "7.17.1" }
   }
 
@@ -62,6 +63,14 @@ class StackVersionsStepTests extends ApmBasePipelineTest {
   @Test
   void testRelease() throws Exception {
     def versions = script.release()
+    printCallStack()
+    assertTrue(versions != "")
+    assertJobStatusSuccess()
+  }
+
+  @Test
+  void testRelease7() throws Exception {
+    def versions = script.release7()
     printCallStack()
     assertTrue(versions != "")
     assertJobStatusSuccess()

--- a/vars/stackVersions.groovy
+++ b/vars/stackVersions.groovy
@@ -52,6 +52,10 @@ def dev(Map args = [:]){
 }
 
 def release(Map args = [:]){
+  return version(bumpUtils.getCurrentMinorReleaseFor8(), args)
+}
+
+def release7(Map args = [:]){
   return version(bumpUtils.getCurrentMinorReleaseFor7(), args)
 }
 

--- a/vars/stackVersions.txt
+++ b/vars/stackVersions.txt
@@ -2,12 +2,13 @@
   Return the version currently used for testing.
 
 ```
-  stackVersions() // [ '8.0.0', '7.11.0', '7.10.2' ]
-  stackVersions(snapshot: true) // [ '8.0.0-SNAPSHOT', '7.11.0-SNAPSHOT', '7.10.2-SNAPSHOT' ]
+  stackVersions() // [ '8.1.0', '8.0.0', '7.11.0', '7.10.2' ]
+  stackVersions(snapshot: true) // [ '8.1.0-SNAPSHOT', '8.0.0-SNAPSHOT', '7.11.0-SNAPSHOT', '7.10.2-SNAPSHOT' ]
 
-  stackVersions.edge() // '8.0.0'
+  stackVersions.edge() // '8.1.0'
   stackVersions.dev() // '7.11.0'
-  stackVersions.release() // '7.10.2'
+  stackVersions.release() // '8.0.0'
+  stackVersions.release7() // '7.10.2'
   stackVersions.snapshot('7.11.1') // '7.11.1-SNAPSHOT'
-  stackVersions.edge(snapshot: true) // '8.0.0-SNAPSHOT'
+  stackVersions.edge(snapshot: true) // '8.1.0-SNAPSHOT'
 ```


### PR DESCRIPTION
## What does this PR do?

Move `release` to the 8 series while `release7` is added for the 7 series.

## Why is it important?

Reflect what's the latest major release