### PR TITLE
pre-commit install always

### DIFF
--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -53,10 +53,7 @@ def call(Map args = [:]) {
           if command -v pip3 ; then
             PIP_COMMAND=pip3
           fi
-          # if pre-commit was already installed then do nothing
-          if ! command -v pre-commit ; then
-            ${PIP_COMMAND} install pre-commit
-          fi
+          ${PIP_COMMAND} install pre-commit
         ''')
       }
       retryWithSleep(retries: 2, seconds: 5, backoff: true) {


### PR DESCRIPTION
## What does this PR do?

install pre-commit regardless of the exiting installation in the CI workers

## Why is it important?

Cannot trust the CI workers since the pre-commit can be corrupted