### PR TITLE
golang: autobump for fleet-server against 1.18

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -93,6 +93,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+    overrideGoVersion: "1.18"
     enabled: true
     labels: dependency,backport-skip
   - repo: golang-crossbuild
@@ -100,7 +101,6 @@ projects:
     branches:
       - main
       - "1.18"
-      - "1.17"
     enabled: true
     labels: dependency
   - repo: observability-robots


### PR DESCRIPTION
## What does this PR do?

Force `Fleet Server` to use 1.18 instead 1.19

## Why is it important?

Fleet Server uses `1.18` at the moment
