### PR TITLE
action: generate matrix output for the given list of versions, frameworks and exclusions

### DIFF
--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -40,4 +40,5 @@ runs:
           f.write("matrix={}\n".format(json.dumps(matrix)))
     - id: debug
       shell: bash
-      run: echo ${{ steps.generator.outputs.matrix }}
+      run: |
+        echo 'Matrix to test: ${{ steps.generator.outputs.matrix }}'

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -38,3 +38,6 @@ runs:
               matrix['include'].append({"version": version, "framework": framework})
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("matrix={}\n".format(json.dumps(matrix)))
+    - id: debug
+      shell: shell
+      run: echo ${{ steps.generator.outputs.matrix }}

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -30,7 +30,6 @@ runs:
         frameworks = yaml.safe_load(Path('${{ inputs.frameworksFile }}').read_text())
         versions = yaml.safe_load(Path('${{ inputs.versionsFile }}').read_text())
         matrix = {'include': []}
-        print(excludes['exclude'])
         for version in versions['VERSION']:
           for framework in frameworks['FRAMEWORK']:
             if len(list(filter(lambda item: item['VERSION'] == version and item["FRAMEWORK"] == framework, excludes['exclude']))) > 0:

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -39,5 +39,3 @@ runs:
               matrix['include'].append({"version": version, "framework": framework})
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("matrix={}\n".format(json.dumps(matrix)))
-    - run: |
-        echo "Matrix to test: ${{ steps.generator.outputs.matrix }}"

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -18,28 +18,26 @@ outputs:
 runs:
   using: "composite"
   steps:
-    steps:
-      - uses: actions/checkout@v3
-      - name: Generate matrix support
-        id: generator
-        shell: python
-        run: |
-          import json
-          import os
-          import yaml
-          from pathlib import Path
-          excludes = yaml.safe_load(Path('${{ inputs.excludedFile }}').read_text())
-          frameworks = yaml.safe_load(Path('${{ inputs.frameworksFile }}').read_text())
-          versions = yaml.safe_load(Path('${{ inputs.versionsFile }}').read_text())
-          matrix = {'include': []}
-          print(excludes['exclude'])
-          for version in versions['VERSION']:
-            for framework in frameworks['FRAMEWORK']:
-              if len(list(filter(lambda item: item['VERSION'] == version and item["FRAMEWORK"] == framework, excludes['exclude']))) > 0:
-                print('excluded ' + version + ' with ' + framework)
-              else:
-                matrix['include'].append({"version": version, "framework": framework})
-          with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
-            f.write("matrix={}\n".format(json.dumps(matrix)))
-      - run: |
-          echo "Matrix to test: ${{ steps.generator.outputs.matrix }}"
+    - uses: actions/checkout@v3
+    - id: generator
+      shell: python
+      run: |
+        import json
+        import os
+        import yaml
+        from pathlib import Path
+        excludes = yaml.safe_load(Path('${{ inputs.excludedFile }}').read_text())
+        frameworks = yaml.safe_load(Path('${{ inputs.frameworksFile }}').read_text())
+        versions = yaml.safe_load(Path('${{ inputs.versionsFile }}').read_text())
+        matrix = {'include': []}
+        print(excludes['exclude'])
+        for version in versions['VERSION']:
+          for framework in frameworks['FRAMEWORK']:
+            if len(list(filter(lambda item: item['VERSION'] == version and item["FRAMEWORK"] == framework, excludes['exclude']))) > 0:
+              print('excluded ' + version + ' with ' + framework)
+            else:
+              matrix['include'].append({"version": version, "framework": framework})
+        with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
+          f.write("matrix={}\n".format(json.dumps(matrix)))
+    - run: |
+        echo "Matrix to test: ${{ steps.generator.outputs.matrix }}"

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
 outputs:
   matrix:
-    description: "GitHub token"
+    description: "Processed matrix with the required tuples of version and framework"
     value: ${{ steps.generator.outputs.matrix }}
 runs:
   using: "composite"

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -1,0 +1,47 @@
+---
+name: 'Matrix Version Framework'
+description: 'Create matrix for the supported versions and frameworks'
+inputs:
+  versionsFile:
+    description: 'The YAML file with the versions. Being VERSION the key for the list'
+    required: true
+  frameworksFile:
+    description: 'The YAML file with the frameworks. Being FRAMEWORK the key for the list'
+    required: true
+  excludedFile:
+    ddescription: 'The YAML file with the excluded tuples. Being exclude the key for the list of tuples (VERSION, FRAMEWORK)'
+    required: true
+outputs:
+  matrix:
+    description: "GitHub token"
+    value: ${{ steps.generator.outputs.matrix }}
+runs:
+  using: "composite"
+  steps:
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate matrix support
+        id: generator
+        shell: python
+        run: |
+          import json
+          import os
+          import yaml
+          from pathlib import Path
+          excludes = yaml.safe_load(Path('${{ inputs.excludedFile }}').read_text())
+          frameworks = yaml.safe_load(Path('${{ inputs.frameworksFile }}').read_text())
+          versions = yaml.safe_load(Path('${{ inputs.versionsFile }}').read_text())
+          matrix = {'include': []}
+          print(excludes['exclude'])
+          for version in versions['VERSION']:
+            for framework in frameworks['FRAMEWORK']:
+              if len(list(filter(lambda item: item['VERSION'] == version and item["FRAMEWORK"] == framework, excludes['exclude']))) > 0:
+                print('excluded ' + version + ' with ' + framework)
+              else:
+                matrix['include'].append({"version": version, "framework": framework})
+          with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
+            f.write("matrix={}\n".format(json.dumps(matrix)))
+      - run: |
+          echo "Matrix to test: ${{ steps.generator.outputs.matrix }}"

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -39,5 +39,5 @@ runs:
         with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
           f.write("matrix={}\n".format(json.dumps(matrix)))
     - id: debug
-      shell: shell
+      shell: bash
       run: echo ${{ steps.generator.outputs.matrix }}

--- a/.github/actions/version-framework/action.yml
+++ b/.github/actions/version-framework/action.yml
@@ -18,8 +18,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    outputs:
-      matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
       - name: Generate matrix support


### PR DESCRIPTION
## What does this PR do?

Generate the `include` list to be consumed by the GitHub matrix workflows

## Why is it important?

Reuse the component so the APM Agents could potentially use this action


## Test


<img width="1263" alt="image" src="https://user-images.githubusercontent.com/2871786/201160631-ff6cc997-0053-46b2-a4fd-bcc09861bc5c.png">


## Issue

Requires by https://github.com/elastic/apm-agent-ruby/pull/1320

