### PR TITLE
Remove spurious quote when looking for .go-version

### DIFF
--- a/vars/goDefaultVersion.groovy
+++ b/vars/goDefaultVersion.groovy
@@ -25,7 +25,7 @@ def call(Map args = [:]) {
   if(isGoVersionEnvVarSet()) {
     goDefaultVersion = "${env.GO_VERSION}"
   } else {
-    def found = ['.go-version', "${env.BASE_DIR}/.go-version'"].find { fileExists(it) }
+    def found = ['.go-version', "${env.BASE_DIR}/.go-version"].find { fileExists(it) }
     if (found) {
       goDefaultVersion = readFile(file: found)?.trim()
     }


### PR DESCRIPTION
## What does this PR do?

Remove a spurious quote that is producing an unexpected string.

## Why is it important?

This prevents `goDefaultVersion` to find the Go version in  `env.BASE_DIR`, as it tries to find `.go-version'`.

## Related issues

Found in https://github.com/elastic/integrations/pull/4717, where the default version of Go is being unexpectedly installed.
