### PR TITLE
Fix docker-layer-caching action

### DIFF
--- a/.github/actions/docker-layer-caching/action.yml
+++ b/.github/actions/docker-layer-caching/action.yml
@@ -21,18 +21,12 @@ inputs:
     required: false
     default: 'false'
 
-  continue-on-error:
-    description: 'Continue on if the caching fails'
-    required: false
-    default: 'true'
-
 runs:
   using: 'composite'
   steps:
     - uses: satackey/action-docker-layer-caching@46d2c640b1d8ef50d185452ad6fb324e6bd1d052
       # This is set by default to true because it seems to be recommended always anyways.
-      # But it can be disabled if necessary.
-      continue-on-error: ${{ inputs.continue-on-error }}
+      continue-on-error: true
       with:
         key: ${{ inputs.key }}
         restore-keys: ${{ inputs.restore-keys }}


### PR DESCRIPTION
## What does this PR do?

On a different workflow the action can fail because of too many requests to the caching API (especially on matrix jobs). Which is why `continue-on-error` is recommended to be `true` always.

There is some complication for inputs that are not strings.

Instead of trying to fix the input, I'm removing the input and set `continue-on-error` to `true` always.

```
Error: Unexpected error: Error: Cache service responded with 429 during commit cache.
...
Error: The step failed and an error occurred when attempting to determine whether to continue on error.
Error: The template is not valid. elastic/apm-pipeline-library/current/.github/actions/docker-layer-caching/action.yml (Line: 35, Col: 26): Unexpected value 'true'
````
> Source: https://github.com/elastic/ecs-logging-ruby/actions/runs/3766344912/jobs/6402791690

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

https://github.com/elastic/ecs-logging-ruby/pull/28 is flaky and this would fix it.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues #ISSUE

Used in https://github.com/elastic/ecs-logging-ruby/pull/28
