### PR TITLE
Add GIT_USER and GIT_EMAIL to GITHUB_ENV

### DIFF
--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -30,6 +30,10 @@ runs:
         git config --global user.name "${GIT_USER}"
         git config --global user.email "${GIT_EMAIL}"
         gh auth setup-git
+
+        echo "GIT_USER=${GIT_USER}" >> $GITHUB_ENV
+        echo "GIT_EMAIL=${GIT_EMAIL}" >> $GITHUB_ENV
+
       env:
         GIT_USER: "${{ inputs.username }}"
         GIT_EMAIL: "${{ inputs.email }}"

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -20,6 +20,7 @@ inputs:
     default: 'false'
   token:
     description: 'GitHub token.'
+    default: ${{ github.token }}
     required: false
 runs:
   using: "composite"
@@ -38,4 +39,4 @@ runs:
         GIT_USER: "${{ inputs.username }}"
         GIT_EMAIL: "${{ inputs.email }}"
         GIT_TRACE: "${{ inputs.trace }}"
-        GITHUB_TOKEN: ${{ inputs.token || github.token }}
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: 'false'
   token:
     description: 'GitHub token.'
-    required: true
+    required: false
 runs:
   using: "composite"
   steps:
@@ -38,4 +38,4 @@ runs:
         GIT_USER: "${{ inputs.username }}"
         GIT_EMAIL: "${{ inputs.email }}"
         GIT_TRACE: "${{ inputs.trace }}"
-        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ inputs.token || github.token }}

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -30,13 +30,23 @@ jobs:
         # Random Dockerfile from .ci/docker
       - run: docker build -t yamllint -f .ci/docker/yamllint/Dockerfile .
 
-  setup-git:
+  setup-git-with-token:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-git
         with:
           token: ${{ github.token }}
+      - name: Check GIT_USER
+        run: test "$GIT_USER" = "apmmachine"
+      - name: Check GIT_EMAIL
+        run: test "$GIT_EMAIL" = "apmmachine@users.noreply.github.com"
+
+  setup-git-without-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-git
       - name: Check GIT_USER
         run: test "$GIT_USER" = "apmmachine"
       - name: Check GIT_EMAIL

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-git
+        with:
+          token: ${{ github.token }}
       - name: Check GIT_USER
         run: test "$GIT_USER" -eq "apmmachine"
       - name: Check GIT_EMAIL

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           token: ${{ github.token }}
       - name: Check GIT_USER
-        run: test "$GIT_USER" -eq "apmmachine"
+        run: test "$GIT_USER" = "apmmachine"
       - name: Check GIT_EMAIL
-        run: test "$GIT_EMAIL" -eq "apmmachine@users.noreply.github.com"
+        run: test "$GIT_EMAIL" = "apmmachine@users.noreply.github.com"

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -29,3 +29,13 @@ jobs:
             custom-docker-cache-key-${{ github.workflow }}-
         # Random Dockerfile from .ci/docker
       - run: docker build -t yamllint -f .ci/docker/yamllint/Dockerfile .
+
+  setup-git:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-git
+      - name: Check GIT_USER
+        run: test "$GIT_USER" -eq "apmmachine"
+      - name: Check GIT_EMAIL
+        run: test "$GIT_EMAIL" -eq "apmmachine@users.noreply.github.com"


### PR DESCRIPTION
## What does this PR do?

Add `GIT_USER` and `GIT_EMAIL` to `GITHUB_ENV` when using the `setup-git` action so it is available in subsequent steps

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
