### PR TITLE
Fix push condition in publish-docker-images wokrflow

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: ${{ matrix.working_directory }}
 
       - name: Push
-        if: ${{ matrix.push }}
+        if: ${{ matrix.push != false }}
         run: |
           if [ -z "${{ matrix.push_script }}" ]; then
             docker push ${{ steps.generate-image-name.outputs.image_name }}


### PR DESCRIPTION
## What does this PR do?

After merging https://github.com/elastic/apm-pipeline-library/pull/1986, I tried to verify the final behaviour of `publish-docker-images` with `workflow_dispatch`. Unfortunately, the push condition is wrong, which I consciously commented out during development.

The `push` property is defined as `default: true` in the schema and therefore left out.

This change should make the expression true if the `push` property is empty or `true`.

## Why is it important?

The workflow is already merged and running on a schedule, but nothing is pushed because the condition is wrong.

## Related issues
- https://github.com/elastic/apm-pipeline-library/pull/1986
