### PR TITLE
Fix publish-docker-images workflow v2

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           echo "NAME=${{ matrix.name }}" >> $GITHUB_ENV
           echo "TAG=${{ matrix.tag || 'latest' }}" >> $GITHUB_ENV
+          echo "PUSH=${{ matrix.push }}" >> $GITHUB_ENV
 
       - name: Prepare
         if: ${{ matrix.prepare_script }}
@@ -103,7 +104,7 @@ jobs:
         working-directory: ${{ matrix.working_directory }}
 
       - name: Push
-        if: ${{ matrix.push != false }}
+        if: ${{ env.PUSH != 'false' }}
         run: |
           if [ -z "${{ matrix.push_script }}" ]; then
             docker push ${{ steps.generate-image-name.outputs.image_name }}


### PR DESCRIPTION
## What does this PR do?

The fix in https://github.com/elastic/apm-pipeline-library/pull/1995 did not work as expected.

The culprit is that in GH Actions Expressions, they do loose comparisons, which causes unexpected behaviour:

```javascript
${{ '' != false }} // false
${{ '' == false }} // true
${{ null != false }} // false
${{ null == false }} // true

// when used to evaluate matrix.push, which can be true, false or undefined
// ${{ matrix.push != false }}
```

By putting the `matrix.push` into a environment variable, the expression will be evaluated using string comparison and therefore gives the expected result.

## Why is it important?

The publish-docker-images workflow is already merged and the old build-docker-images Jenkinsfile is already removed. Hence, it's not working ATM.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- https://github.com/elastic/apm-pipeline-library/pull/1995
- https://github.com/elastic/apm-pipeline-library/pull/1986