### PR TITLE
Fix working directory in publish-docker-images workflow

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -48,6 +48,9 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.create-matrix.outputs.include )}}
+    defaults:
+      run:
+        working-directory: ${{ matrix.working_directory }}
     steps:
 
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
@@ -79,7 +82,6 @@ jobs:
       - name: Prepare
         if: ${{ matrix.prepare_script }}
         run: ${{ matrix.prepare_script }}
-        working-directory: ${{ matrix.working_directory }}
 
       - name: Generate Image Name
         id: generate-image-name
@@ -96,12 +98,10 @@ jobs:
           else
             bash -c "${{ matrix.build_script }}"
           fi
-        working-directory: ${{ matrix.working_directory }}
 
       - name: Test
         if: ${{ matrix.test_script }}
         run: ${{ matrix.test_script }}
-        working-directory: ${{ matrix.working_directory }}
 
       - name: Push
         if: ${{ env.PUSH != 'false' }}


### PR DESCRIPTION
## What does this PR do?

Sets the working directory for each step in publish-docker-images workflow using the `defaults` attribute.

## Why is it important?

I forgot to add the working directory for the push step and the workflow is failing for images with a custom `push_script`.
