### PR TITLE
fix: use observability Vault namespace

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -141,7 +141,7 @@ pipeline {
           steps {
             deleteDir()
             unstash 'source'
-            dockerLogin(secret: "secret/apm-team/ci/docker-registry/prod",
+            dockerLogin(secret: "secret/observability-team/ci/docker-registry/prod",
               registry: "docker.elastic.co"
             )
             dir("${BASE_DIR}"){

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,8 +22,8 @@ pipeline {
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL='INFO'
-    DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
-    DOCKERELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKERHUB_SECRET = 'secret/observability-team/ci/elastic-observability-dockerhub'
+    DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -22,8 +22,8 @@ pipeline {
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'INFO'
-    DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
-    DOCKERELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKERHUB_SECRET = 'secret/observability-team/ci/elastic-observability-dockerhub'
+    DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     BEATS_MAILING_LIST = "${params.BEATS_MAILING_LIST}"
   }
   options {

--- a/resources/scripts/pytest_otel/Makefile
+++ b/resources/scripts/pytest_otel/Makefile
@@ -127,8 +127,8 @@ run-otel-collector:
 
 #https://upload.pypi.org/legacy/
 #https://test.pypi.org/legacy/
-#secret/apm-team/ci/apm-agent-python-pypi-test
-#secret/apm-team/ci/apm-agent-python-pypi-prod
+#secret/observability-team/ci/apm-agent-python-pypi-test
+#secret/observability-team/ci/apm-agent-python-pypi-prod
 ## @help:publish REPO_URL=${REPO_URL} TWINE_USER=${TWINE_USER} TWINE_PASSWORD=${TWINE_PASSWORD}:Publish the Python project in a PyPI repository.
 .PHONY: publish
 publish: package

--- a/resources/scripts/pytest_otel/tests/it/test_basic_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_basic_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_OK
 
 pytest_plugins = ["pytester"]
 
@@ -24,4 +24,4 @@ def test_basic():
     time.sleep(5)
     pass
 """)
-    assertTest(pytester, "test_basic", "passed", "STATUS_CODE_OK", "passed", "STATUS_CODE_OK")
+    assertTest(pytester, "test_basic", "passed", STATUS_CODE_OK, "passed", STATUS_CODE_OK)

--- a/resources/scripts/pytest_otel/tests/it/test_failure_code_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_failure_code_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_ERROR
 
 pytest_plugins = ["pytester"]
 
@@ -24,4 +24,4 @@ def test_failure_code():
     d = 1/0
     pass
 """)
-    assertTest(pytester, "test_failure_code", "failed", "STATUS_CODE_ERROR", "failed", "STATUS_CODE_ERROR")
+    assertTest(pytester, "test_failure_code", "failed", STATUS_CODE_ERROR, "failed", STATUS_CODE_ERROR)

--- a/resources/scripts/pytest_otel/tests/it/test_failure_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_failure_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_ERROR
 
 pytest_plugins = ["pytester"]
 
@@ -23,4 +23,4 @@ def test_failure_plugin(pytester, otel_service):
 def test_failure():
     assert 1 < 0
 """)
-    assertTest(pytester, "test_failure", "failed", "STATUS_CODE_ERROR", "failed", "STATUS_CODE_ERROR")
+    assertTest(pytester, "test_failure", "failed", STATUS_CODE_ERROR, "failed", STATUS_CODE_ERROR)

--- a/resources/scripts/pytest_otel/tests/it/test_skip_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_skip_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_OK
 
 pytest_plugins = ["pytester"]
 
@@ -24,4 +24,4 @@ def test_skip_plugin(pytester, otel_service):
 def test_skip():
     assert True
 """)
-    assertTest(pytester, None, "passed", "STATUS_CODE_OK", None, None)
+    assertTest(pytester, None, "passed", STATUS_CODE_OK, None, None)

--- a/resources/scripts/pytest_otel/tests/it/test_success_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_success_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_OK
 
 pytest_plugins = ["pytester"]
 
@@ -23,4 +23,4 @@ def test_success_plugin(pytester, otel_service):
 def test_success():
     assert True
 """)
-    assertTest(pytester, "test_success", "passed", "STATUS_CODE_OK", "passed", "STATUS_CODE_OK")
+    assertTest(pytester, "test_success", "passed", STATUS_CODE_OK, "passed", STATUS_CODE_OK)

--- a/resources/scripts/pytest_otel/tests/it/test_xfail_no_run_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_xfail_no_run_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_OK
 
 pytest_plugins = ["pytester"]
 
@@ -24,4 +24,4 @@ def test_xfail_no_run_plugin(pytester, otel_service):
 def test_xfail_no_run():
     assert False
 """)
-    assertTest(pytester, None, "passed", "STATUS_CODE_OK", None, None)
+    assertTest(pytester, None, "passed", STATUS_CODE_OK, None, None)

--- a/resources/scripts/pytest_otel/tests/it/test_xfail_plugin.py
+++ b/resources/scripts/pytest_otel/tests/it/test_xfail_plugin.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from utils import assertTest
+from utils import assertTest, STATUS_CODE_OK
 
 pytest_plugins = ["pytester"]
 
@@ -24,4 +24,4 @@ def test_xfail_plugin(pytester, otel_service):
 def test_xfail():
     assert False
 """)
-    assertTest(pytester, None, "passed", "STATUS_CODE_OK", None, None)
+    assertTest(pytester, None, "passed", STATUS_CODE_OK, None, None)

--- a/resources/scripts/pytest_otel/tests/it/utils/__init__.py
+++ b/resources/scripts/pytest_otel/tests/it/utils/__init__.py
@@ -5,6 +5,12 @@ import os
 import socket
 import subprocess
 
+SPAN_KIND_INTERNAL = 1
+SPAN_KIND_SERVER = 2
+
+STATUS_CODE_OK = 1
+STATUS_CODE_ERROR = 2
+
 
 def is_portListening(host, port):
     """Check a port in a host is liostening"""
@@ -30,7 +36,7 @@ def waitForFileContent(filename):
     """wait for a file has content"""
     while getSize(filename) < 1:
         time.sleep(5)
-        subprocess.check_output("docker cp $(docker ps -q --filter expose=4317):/tmp/tests.json {}".format(filename),
+        subprocess.check_output(f"docker cp $(docker ps -q --filter expose=4317):/tmp/tests.json {filename}",
                                 stderr=subprocess.STDOUT, shell=True)
     with open(filename, encoding='utf-8') as input:
         print(input.read())
@@ -42,27 +48,27 @@ def assertAttrKeyValue(attributes, key, value):
     for attr in attributes:
         if attr['key'] == key:
             realValue = attr["value"]["stringValue"]
-    assert realValue == value
+    assert realValue == value, f'attribute {key} is not {value}: {realValue}'
 
 
 def assertTestSuit(span, outcome, status):
     """check attributes of a test suit span"""
-    assert span["kind"] == "SPAN_KIND_SERVER"
-    assert span["status"]["code"] == status
+    assert span["kind"] == SPAN_KIND_SERVER, f'span kind is not server: {span["kind"]}'
+    assert span["status"]["code"] == status, f'status code is not {status}: {span["status"]["code"]}'
     if outcome is not None:
         assertAttrKeyValue(span["attributes"], 'tests.status', outcome)
-    assert len(span["parentSpanId"]) == 0
+    assert len(span["parentSpanId"]) == 0, f'parent span id is not empty: {span["parentSpanId"]}'
     return True
 
 
 def assertSpan(span, name, outcome, status):
     """check attributes of a span"""
-    assert span["kind"] == "SPAN_KIND_INTERNAL"
-    assert span["status"]["code"] == status
+    assert span["kind"] == SPAN_KIND_INTERNAL, f'span kind is not internal: {span["kind"]}'
+    assert span["status"]["code"] == status, f'status code is not {status}: {span["status"]["code"]}'
     assertAttrKeyValue(span["attributes"], 'tests.name', name)
     if outcome is not None:
         assertAttrKeyValue(span["attributes"], 'tests.status', outcome)
-    assert len(span["parentSpanId"]) > 0
+    assert len(span["parentSpanId"]) > 0, f'parent span id is empty: {span["parentSpanId"]}'
     return True
 
 
@@ -75,20 +81,17 @@ def assertTest(pytester, name, ts_outcome, ts_status, outcome, status):
     foundTestSuit = False
     with open(filename, encoding='utf-8') as input:
         spans_output = json.loads(input.readline())
-        print("""
-            spans_output {}
-            resourceSpans {}
-        """.format(
-            spans_output,
-            spans_output['resourceSpans'],
-        ))
+        print(f"""
+            spans_output {spans_output}
+            resourceSpans {spans_output['resourceSpans']}
+        """)
         for resourceSpan in spans_output['resourceSpans']:
             for instrumentationLibrarySpan in resourceSpan['scopeSpans']:
                 for span in instrumentationLibrarySpan['spans']:
-                    if span["name"] == "Running {}".format(name):
+                    if span["name"] == f"Running {name}":
                         foundTest = assertSpan(span, name, outcome, status)
                     if span["name"] == "Test Suite":
                         foundTestSuit = assertTestSuit(span, ts_outcome, ts_status)
-    assert foundTest or name is None
-    assert foundTestSuit
+    assert foundTest or name is None, f'test {name} not found'
+    assert foundTestSuit, 'test suit not found'
     os.remove(filename)

--- a/src/test/groovy/GetVaultSecretStepTests.groovy
+++ b/src/test/groovy/GetVaultSecretStepTests.groovy
@@ -32,6 +32,9 @@ class GetVaultSecretStepTests extends ApmBasePipelineTest {
       if(m?.url?.contains("v1/secret/observability-team/ci/secret")){
         return "{plaintext: '12345', encrypted: 'SECRET'}"
       }
+      if(m?.url?.contains("v1/secret/apm-team/ci/secret")){
+        return "{plaintext: '12345', encrypted: 'SECRET'}"
+      }
       if(m?.url?.contains("v1/auth/approle/login")){
         return "{auth: {client_token: 'TOKEN'}}"
       }

--- a/src/test/groovy/GetVaultSecretStepTests.groovy
+++ b/src/test/groovy/GetVaultSecretStepTests.groovy
@@ -29,7 +29,7 @@ class GetVaultSecretStepTests extends ApmBasePipelineTest {
     script = loadScript('vars/getVaultSecret.groovy')
 
     helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
-      if(m?.url?.contains("v1/secret/apm-team/ci/secret")){
+      if(m?.url?.contains("v1/secret/observability-team/ci/secret")){
         return "{plaintext: '12345', encrypted: 'SECRET'}"
       }
       if(m?.url?.contains("v1/auth/approle/login")){
@@ -48,7 +48,7 @@ class GetVaultSecretStepTests extends ApmBasePipelineTest {
 
   @Test
   void testMap() throws Exception {
-    def jsonValue = script.call(secret: "secret/apm-team/ci/secret")
+    def jsonValue = script.call(secret: "secret/observability-team/ci/secret")
     assertTrue(jsonValue.plaintext == '12345')
     printCallStack()
     assertJobStatusSuccess()
@@ -124,7 +124,7 @@ class GetVaultSecretStepTests extends ApmBasePipelineTest {
   @Test
   void test_in_internal_ci() throws Exception {
     helper.registerAllowedMethod('isInternalCI', { return true })
-    script.call(secret: "v1/secret/apm-team/ci/secret")
+    script.call(secret: "v1/secret/observability-team/ci/secret")
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=apm-vault-role-id'))
     assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=apm-vault-secret-id'))
@@ -134,7 +134,7 @@ class GetVaultSecretStepTests extends ApmBasePipelineTest {
   @Test
   void test_in_another_ci() throws Exception {
     helper.registerAllowedMethod('isInternalCI', { return false })
-    script.call(secret: "v1/secret/apm-team/ci/secret")
+    script.call(secret: "v1/secret/observability-team/ci/secret")
     printCallStack()
     assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=vault-role-id'))
     assertTrue(assertMethodCallContainsPattern('withCredentials', 'credentialsId=vault-secret-id'))

--- a/src/test/resources/jobs/dockerLogin.dsl
+++ b/src/test/resources/jobs/dockerLogin.dsl
@@ -3,7 +3,7 @@ DSL = '''pipeline {
   agent none
   environment {
     DOCKER_REGISTRY = 'docker.elastic.co'
-    DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
   }
   stages {
     stage('linux') {

--- a/vars/README.md
+++ b/vars/README.md
@@ -323,7 +323,7 @@ Parameters:
 Submits coverage information to codecov.io using their [bash script](https://codecov.io/bash")
 
 ```
-codecov(basedir: "${WORKSPACE}", repo: 'apm-agent-go', secret: 'secret/apm-team/ci/apm-agent-go-codecov')
+codecov(basedir: "${WORKSPACE}", repo: 'apm-agent-go', secret: 'secret/observability-team/ci/apm-agent-go-codecov')
 ```
 *repo*: The repository name (for example apm-agent-go), it is needed
 *basedir*: the folder to search into (the default value is '.').
@@ -2638,7 +2638,7 @@ preCommit(commit: 'abcdefg')
 
 preCommit(commit: 'abcdefg', credentialsId: 'ssh-credentials-xyz')
 
-preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/apm-team/ci/docker-registry/prod')
+preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/team/ci/docker-registry')
 ```
 
 * junit: whether to generate the JUnit report. Default: true. Optional
@@ -3995,6 +3995,18 @@ environment variables:
 
 **NOTE**: It requires the [OpenTelemetry plugin](https://plugins.jenkins.io/opentelemetry")
 
+## withPackerEnv
+Configure Packer context to run the given body closure
+
+```
+withPackerEnv(version: '1.8.4') {
+  // block
+}
+```
+
+* version: The packer CLI version to be installed. Optional (1.8.4)
+* forceInstallation: Whether to install packer regardless. Optional (false)
+
 ## withSecretVault
 Grab a secret from the vault, define the environment variables which have been
 passed as parameters and mask the secrets.
@@ -4088,7 +4100,7 @@ withVaultToken(path: '/foo', tokenFile: '.myfile') {
 Write the given data in vault for the given secret.
 
 ```
-writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secret': 'foo'] )
+writeVaultSecret(secret: 'secret/team/ci/temp/github-comment', data: ['secret': 'foo'] )
 ```
 
 * secret: Name of the secret on the the vault root path. Mandatory

--- a/vars/codecov.groovy
+++ b/vars/codecov.groovy
@@ -44,7 +44,7 @@ def call(Map args = [:]){
       token = getVaultSecret(secret: secret)?.data?.value
     } else {
       /** TODO remove it is only for APM projects */
-      token = getVaultSecret("${repo}-codecov")?.data?.value
+      token = getVaultSecret(secret: "secret/apm-team/ci/${repo}-codecov")?.data?.value
     }
     tokens["${repo}"] = token
   } else {

--- a/vars/codecov.txt
+++ b/vars/codecov.txt
@@ -1,7 +1,7 @@
 Submits coverage information to codecov.io using their [bash script](https://codecov.io/bash")
 
 ```
-codecov(basedir: "${WORKSPACE}", repo: 'apm-agent-go', secret: 'secret/apm-team/ci/apm-agent-go-codecov')
+codecov(basedir: "${WORKSPACE}", repo: 'apm-agent-go', secret: 'secret/observability-team/ci/apm-agent-go-codecov')
 ```
 *repo*: The repository name (for example apm-agent-go), it is needed
 *basedir*: the folder to search into (the default value is '.').

--- a/vars/opbeansPipeline.groovy
+++ b/vars/opbeansPipeline.groovy
@@ -31,11 +31,11 @@ def call(Map pipelineParams) {
       NOTIFY_TO = credentials('notify-to')
       JOB_GCS_BUCKET = credentials('gcs-bucket')
       JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
-      DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
+      DOCKERHUB_SECRET = 'secret/observability-team/ci/elastic-observability-dockerhub'
       PIPELINE_LOG_LEVEL = 'INFO'
       PATH = "${env.PATH}:${env.WORKSPACE}/bin"
       HOME = "${env.WORKSPACE}"
-      DOCKER_REGISTRY_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+      DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
       REGISTRY = 'docker.elastic.co'
       STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
     }

--- a/vars/preCommit.groovy
+++ b/vars/preCommit.groovy
@@ -25,7 +25,7 @@
 
   preCommit(commit: 'abcdefg', credentialsId: 'ssh-credentials-xyz')
 
-  preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/apm-team/ci/docker-registry/prod')
+  preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/team/ci/docker-registry')
 */
 def call(Map args = [:]) {
   def junitFlag = args.get('junit', true)

--- a/vars/preCommit.txt
+++ b/vars/preCommit.txt
@@ -8,7 +8,7 @@ preCommit(commit: 'abcdefg')
 
 preCommit(commit: 'abcdefg', credentialsId: 'ssh-credentials-xyz')
 
-preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/apm-team/ci/docker-registry/prod')
+preCommit(registry: 'docker.elastic.co', secretRegistry: 'secret/team/ci/docker-registry')
 ```
 
 * junit: whether to generate the JUnit report. Default: true. Optional

--- a/vars/writeVaultSecret.groovy
+++ b/vars/writeVaultSecret.groovy
@@ -18,7 +18,7 @@
 /**
   Write the given data in vault for the given secret.
 
-  writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secret': 'foo'] )
+  writeVaultSecret(secret: 'secret/team/ci/temp/github-comment', data: ['secret': 'foo'] )
 */
 import groovy.json.JsonOutput
 

--- a/vars/writeVaultSecret.txt
+++ b/vars/writeVaultSecret.txt
@@ -1,7 +1,7 @@
 Write the given data in vault for the given secret.
 
 ```
-writeVaultSecret(secret: 'secret/apm-team/ci/temp/github-comment', data: ['secret': 'foo'] )
+writeVaultSecret(secret: 'secret/team/ci/temp/github-comment', data: ['secret': 'foo'] )
 ```
 
 * secret: Name of the secret on the the vault root path. Mandatory


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes to use the `observability` namespace instead the `apm` namespace for grabbing vault secrets.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

We have to update only the `observability` secrets. The use of the `apm` should be deprecated.

