### PR TITLE
Set default working directory for publish-docker-images workflow

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -50,7 +50,7 @@ jobs:
         include: ${{ fromJson(needs.create-matrix.outputs.include )}}
     defaults:
       run:
-        working-directory: ${{ matrix.working_directory }}
+        working-directory: ${{ matrix.working_directory || '.' }}
     steps:
 
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@current


### PR DESCRIPTION
## What does this PR do?

The `push_script` was failing because I forgot to set the working directory for it in case it's undefined.
This change sets the default working directory for the whole job.

I was able to verify it with a manually dispatched workflow here: https://github.com/elastic/apm-pipeline-library/actions/runs/3849476101

## Why is it important?

The publish-docker-images workflow is failing.
