### PR TITLE
action: export traces with the OTEL GH action

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -3,7 +3,6 @@ name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows: [Java CI, job-dsl]
     types: [completed]
 
 jobs:
@@ -12,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Export Workflow Trace
-        uses: v1v/otel-export-trace-action@v2
+        uses: inception-health/otel-export-trace-action@v1
         with:
           otlpEndpoint: "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}"
           otlpHeaders: "${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"


### PR DESCRIPTION
use the original action rather than the forked one and enable to all the workflows