### PR TITLE
action: use explicit workflow names

### DIFF
--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -1,6 +1,6 @@
 ---
 ## Test custom actions in .github/actions/
-name: actions
+name: actions-test
 
 on:
   push:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: build-test
 
 on:
   push:

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -3,6 +3,14 @@ name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
+    workflows:
+      - actions-test
+      - build-test
+      - job-dsl
+      - licenses
+      - publish-docker-images
+      - pytest_otel-build-test
+      - release-drafter
     types: [completed]
 
 jobs:

--- a/.github/workflows/pytest_otel.yml
+++ b/.github/workflows/pytest_otel.yml
@@ -1,5 +1,5 @@
 ---
-name: pytest_otel build and tests
+name: pytest_otel-build-test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -4,7 +4,7 @@ name: Test Report
 
 on:
   workflow_run:
-    workflows: [Java CI, job-dsl]
+    workflows: [build-test, job-dsl, pytest_otel-build-test]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
* rename workflows with some IDs rather than meaningful names
* user explicit workflow names otherwise the workflow won't run as it's required
