### PR TITLE
action: reusable action for the OTEL export

### DIFF
--- a/.github/actions/opentelemetry/README.md
+++ b/.github/actions/opentelemetry/README.md
@@ -1,0 +1,76 @@
+
+## About
+
+GitHub Action to export GitHub actions as OpenTelemetry traces.
+
+___
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```
+---
+name: ci
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      ...
+
+```
+
+Then, let's create a new workflow to export the data
+
+```yaml
+---
+name: OpenTelemetry
+on:
+  workflow_run:
+    workflows: [ ci ]
+    types: [ completed ]
+
+jobs:
+  publish_results:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      actions: read
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+```
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `vaultUrl`        | String  |                             | The Vault URL to connect to. |
+| `vaultRoleId`     | String  |                             | The Vault role id. |
+| `vaultSecretId`   | String  |                             | The Vault secret id. |
+| `githubToken`     | String  |                             | The GitHub token used to comment out the URL with the report. |

--- a/.github/actions/opentelemetry/README.md
+++ b/.github/actions/opentelemetry/README.md
@@ -55,10 +55,10 @@ jobs:
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
 
 ```
 
@@ -70,7 +70,8 @@ Following inputs can be used as `step.with` keys
 
 | Name              | Type    | Default                     | Description                        |
 |-------------------|---------|-----------------------------|------------------------------------|
-| `vaultUrl`        | String  | `secrets.VAULT_ADDR`        | The Vault URL to connect to. |
+| `githubToken`     | String  | `github.token`              | The GitHub token used to comment out the URL with the report. |
 | `vaultRoleId`     | String  | `secrets.VAULT_ROLE_ID`     | The Vault role id. |
 | `vaultSecretId`   | String  | `secrets.VAULT_SECRET_ID`   | The Vault secret id. |
-| `githubToken`     | String  | `github.token`              | The GitHub token used to comment out the URL with the report. |
+| `vaultUrl`        | String  | `secrets.VAULT_ADDR`        | The Vault URL to connect to. |
+| `secret`          | String  | `secret/observability-team/ci/jenkins-logs-robots` | The Vault secret. |

--- a/.github/actions/opentelemetry/README.md
+++ b/.github/actions/opentelemetry/README.md
@@ -70,7 +70,7 @@ Following inputs can be used as `step.with` keys
 
 | Name              | Type    | Default                     | Description                        |
 |-------------------|---------|-----------------------------|------------------------------------|
-| `vaultUrl`        | String  |                             | The Vault URL to connect to. |
-| `vaultRoleId`     | String  |                             | The Vault role id. |
-| `vaultSecretId`   | String  |                             | The Vault secret id. |
-| `githubToken`     | String  |                             | The GitHub token used to comment out the URL with the report. |
+| `vaultUrl`        | String  | `secrets.VAULT_ADDR`        | The Vault URL to connect to. |
+| `vaultRoleId`     | String  | `secrets.VAULT_ROLE_ID`     | The Vault role id. |
+| `vaultSecretId`   | String  | `secrets.VAULT_SECRET_ID`   | The Vault secret id. |
+| `githubToken`     | String  | `github.token`              | The GitHub token used to comment out the URL with the report. |

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -13,7 +13,8 @@ inputs:
     required: true
   githubToken:
     description: 'GitHub token.'
-    required: true
+    default: ${{ github.token }}
+    required: false
 runs:
   using: "composite"
   steps:

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Vault secret ID (it uses secrets.VAULT_SECRET_ID by default)'
     default: ${{ secrets.VAULT_SECRET_ID }}
     required: false
+  secret:
+    description: 'Vault secret with the apmServerOtel and apmServerToken fields.'
+    default: secret/observability-team/ci/jenkins-logs-robots
+    required: false
   githubToken:
     description: 'GitHub token (it uses github.token by default)'
     default: ${{ github.token }}
@@ -28,8 +32,8 @@ runs:
         secretId: ${{ inputs.vaultSecretId }}
         method: approle
         secrets: |
-          secret/observability-team/ci/jenkins-logs-robots apmServerOtel | OTLP_ENDPOINT ;
-          secret/observability-team/ci/jenkins-logs-robots apmServerToken | OTLP_TOKEN
+          ${{ inputs.secret }} apmServerOtel | OTLP_ENDPOINT ;
+          ${{ inputs.secret }} apmServerToken | OTLP_TOKEN
 
     - name: Export Workflow Trace
       uses: inception-health/otel-export-trace-action@v1

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -1,0 +1,36 @@
+---
+name: OpenTelemetry report
+description: Export GitHub actions as OpenTelemetry traces
+inputs:
+  vaultUrl:
+    description: 'Vault URL'
+    required: true
+  vaultRoleId:
+    description: 'Vault role ID'
+    required: true
+  vaultSecretId:
+    description: 'Vault secret ID'
+    required: true
+  githubToken:
+    description: 'GitHub token.'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: hashicorp/vault-action@v2.4.2
+      with:
+        url: ${{ inputs.vaultUrl }}
+        roleId: ${{ inputs.vaultRoleId }}
+        secretId: ${{ inputs.vaultSecretId }}
+        method: approle
+        secrets: |
+          secret/observability-team/ci/jenkins-logs-robots apmServerOtel | OTLP_ENDPOINT ;
+          secret/observability-team/ci/jenkins-logs-robots apmServerToken | OTLP_TOKEN
+    - name: Export Workflow Trace
+      uses: inception-health/otel-export-trace-action@v1
+      with:
+        otlpEndpoint: "${{ env.OTLP_ENDPOINT }}"
+        otlpHeaders: "Authorization=Bearer ${{ env.OTLP_TOKEN }}"
+        otelServiceName: ${{ github.repository }}
+        githubToken: ${{ inputs.githubToken }}
+        runId: ${{ github.event.workflow_run.id }}

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -3,16 +3,19 @@ name: OpenTelemetry report
 description: Export GitHub actions as OpenTelemetry traces
 inputs:
   vaultUrl:
-    description: 'Vault URL'
-    required: true
+    description: 'Vault URL (it uses secrets.VAULT_ADDR by default)'
+    default: ${{ secrets.VAULT_ADDR }}
+    required: false
   vaultRoleId:
-    description: 'Vault role ID'
-    required: true
+    description: 'Vault role ID (it uses secrets.VAULT_ROLE_ID by default)'
+    default: ${{ secrets.VAULT_ROLE_ID }}
+    required: false
   vaultSecretId:
-    description: 'Vault secret ID'
-    required: true
+    description: 'Vault secret ID (it uses secrets.VAULT_SECRET_ID by default)'
+    default: ${{ secrets.VAULT_SECRET_ID }}
+    required: false
   githubToken:
-    description: 'GitHub token.'
+    description: 'GitHub token (it uses github.token by default)'
     default: ${{ github.token }}
     required: false
 runs:
@@ -27,6 +30,7 @@ runs:
         secrets: |
           secret/observability-team/ci/jenkins-logs-robots apmServerOtel | OTLP_ENDPOINT ;
           secret/observability-team/ci/jenkins-logs-robots apmServerToken | OTLP_TOKEN
+
     - name: Export Workflow Trace
       uses: inception-health/otel-export-trace-action@v1
       with:


### PR DESCRIPTION
## What does this PR do?

Create a reusable action and hide all the credentials by using Vault

## Why is it important?

Consumers don't need to worry about the internals and it uses Vault so much protected approach


@kuisathaverat made a good point regarding abstracting the secrets by using Vault, see https://github.com/elastic/apm-pipeline-library/pull/2007#issuecomment-1384004736
