### PR TITLE
action: composite cannot access to secrets

### DIFF
--- a/.github/actions/opentelemetry/README.md
+++ b/.github/actions/opentelemetry/README.md
@@ -71,7 +71,7 @@ Following inputs can be used as `step.with` keys
 | Name              | Type    | Default                     | Description                        |
 |-------------------|---------|-----------------------------|------------------------------------|
 | `githubToken`     | String  | `github.token`              | The GitHub token used to comment out the URL with the report. |
-| `vaultRoleId`     | String  | `secrets.VAULT_ROLE_ID`     | The Vault role id. |
-| `vaultSecretId`   | String  | `secrets.VAULT_SECRET_ID`   | The Vault secret id. |
-| `vaultUrl`        | String  | `secrets.VAULT_ADDR`        | The Vault URL to connect to. |
+| `vaultRoleId`     | String  |                             | The Vault role id. |
+| `vaultSecretId`   | String  |                             | The Vault secret id. |
+| `vaultUrl`        | String  |                             | The Vault URL to connect to. |
 | `secret`          | String  | `secret/observability-team/ci/jenkins-logs-robots` | The Vault secret. |

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -3,17 +3,14 @@ name: OpenTelemetry report
 description: Export GitHub actions as OpenTelemetry traces
 inputs:
   vaultUrl:
-    description: 'Vault URL (it uses secrets.VAULT_ADDR by default)'
-    default: ${{ secrets.VAULT_ADDR }}
-    required: false
+    description: 'Vault URL'
+    required: true
   vaultRoleId:
-    description: 'Vault role ID (it uses secrets.VAULT_ROLE_ID by default)'
-    default: ${{ secrets.VAULT_ROLE_ID }}
-    required: false
+    description: 'Vault role ID'
+    required: true
   vaultSecretId:
-    description: 'Vault secret ID (it uses secrets.VAULT_SECRET_ID by default)'
-    default: ${{ secrets.VAULT_SECRET_ID }}
-    required: false
+    description: 'Vault secret ID'
+    required: true
   secret:
     description: 'Vault secret with the apmServerOtel and apmServerToken fields.'
     default: secret/observability-team/ci/jenkins-logs-robots


### PR DESCRIPTION
## What does this PR do?

Restore the secrets since:


## Why is it important?


> The secrets context contains the names and values of secrets that are available to a workflow run. The secrets context is not available for composite actions due to security reasons.

See https://docs.github.com/en/actions/learn-github-actions/contexts#secrets-context