### PR TITLE
Fix azure-vm-tool docker image

### DIFF
--- a/.ci/.docker-images.schema.json
+++ b/.ci/.docker-images.schema.json
@@ -15,6 +15,10 @@
             "type": "string",
             "description": "The name of the image <name>:<tag>."
           },
+          "branch": {
+            "type": "string",
+            "description": "The branch to checkout."
+          },
           "repository": {
             "type": "string",
             "pattern": "^(\\w+[-_.]?)+\/(\\w+[-_.]?)+$",
@@ -57,7 +61,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "repository"
         ],
         "additionalProperties": false,
         "dependencies": {

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -43,11 +43,12 @@ images:
     build_script: "docker build --force-rm -t ${REGISTRY}/${PREFIX}/${NAME}:${TAG} ${NAME}"
     push_script: "docker push ${REGISTRY}/${PREFIX}/${NAME}:${TAG}"
 
-## This is also failing in Jenkins
-##  https://apm-ci.elastic.co/job/apm-shared/job/docker-images/job/oracle-instant-client/
-#  - name: "azure-vm-tools"
-#    repository: "elastic/azure-vm-extension"
-#    working_directory: ".ci/docker/azure-vm-tools"
+  - name: "azure-vm-tools"
+    repository: "elastic/azure-vm-extension"
+    build_script: "make prepare"
+    # The full image name is defined here: https://github.com/elastic/azure-vm-extension/blob/82862124bbbc9bc7ab50184375d3b9743c42b2b7/.ci/Makefile#L5
+    push_script: "docker push ${REGISTRY}/${PREFIX}/${NAME}:${TAG}"
+    working_directory: ".ci"
 
   # observability-robots Docker Images
 

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -60,10 +60,10 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - uses: actions/checkout@v3
-        if: ${{ matrix.repository }}
         with:
           repository: ${{ matrix.repository }}
           token: ${{ env.GITHUB_TOKEN }}
+          ref: ${{ matrix.branch }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:
@@ -103,11 +103,11 @@ jobs:
         if: ${{ matrix.test_script }}
         run: ${{ matrix.test_script }}
 
-      - name: Push
-        if: ${{ env.PUSH != 'false' }}
-        run: |
-          if [ -z "${{ matrix.push_script }}" ]; then
-            docker push ${{ steps.generate-image-name.outputs.image_name }}
-          else
-            bash -c "${{ matrix.push_script }}"
-          fi
+#      - name: Push
+#        if: ${{ env.PUSH != 'false' }}
+#        run: |
+#          if [ -z "${{ matrix.push_script }}" ]; then
+#            docker push ${{ steps.generate-image-name.outputs.image_name }}
+#          else
+#            bash -c "${{ matrix.push_script }}"
+#          fi

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -103,11 +103,11 @@ jobs:
         if: ${{ matrix.test_script }}
         run: ${{ matrix.test_script }}
 
-#      - name: Push
-#        if: ${{ env.PUSH != 'false' }}
-#        run: |
-#          if [ -z "${{ matrix.push_script }}" ]; then
-#            docker push ${{ steps.generate-image-name.outputs.image_name }}
-#          else
-#            bash -c "${{ matrix.push_script }}"
-#          fi
+      - name: Push
+        if: ${{ env.PUSH != 'false' }}
+        run: |
+          if [ -z "${{ matrix.push_script }}" ]; then
+            docker push ${{ steps.generate-image-name.outputs.image_name }}
+          else
+            bash -c "${{ matrix.push_script }}"
+          fi


### PR DESCRIPTION
## What does this PR do?

- Fixes the `azure-vm-tools` image build
- Adds ability to specify a branch for debugging.


Verified to be working here: https://github.com/elastic/apm-pipeline-library/actions/runs/3932458276/jobs/6725049141

## Why is it important?

During the migration there were images that failed already on Jenkins. This is a follow-up PR.

## Related issues
- https://github.com/elastic/apm-pipeline-library/issues/1992