### PR TITLE
Re-enable test-plans docker image

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -59,10 +59,11 @@ images:
     working_directory: "apps/pickles"
 
   - name: "test-plans"
-    repository: "elastic/observability-robots"
+    repository: "reakaleek/observability-robots"
     build_script: "make build"
     push_script: "make push"
     working_directory: "apps/test-plans"
+    branch: feature/fix-test-plans-web-build
 
   - name: "obs-jenkins-heartbeat"
     repository: "elastic/observability-robots"

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -59,11 +59,10 @@ images:
     working_directory: "apps/pickles"
 
   - name: "test-plans"
-    repository: "reakaleek/observability-robots"
+    repository: "elastic/observability-robots"
     build_script: "make build"
     push_script: "make push"
     working_directory: "apps/test-plans"
-    branch: feature/fix-test-plans-web-build
 
   - name: "obs-jenkins-heartbeat"
     repository: "elastic/observability-robots"

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -58,13 +58,11 @@ images:
     push_script: "make push"
     working_directory: "apps/pickles"
 
-## This is also failing on Jenkins
-## https://apm-ci.elastic.co/job/apm-shared/job/docker-images/job/test-plans/
-#  - name: "test-plans"
-#    repository: "elastic/observability-robots"
-#    build_script: "make build"
-#    push_script: "make push"
-#    working_directory: "apps/test-plans"
+  - name: "test-plans"
+    repository: "elastic/observability-robots"
+    build_script: "make build"
+    push_script: "make push"
+    working_directory: "apps/test-plans"
 
   - name: "obs-jenkins-heartbeat"
     repository: "elastic/observability-robots"


### PR DESCRIPTION
## What does this PR do?

- Re-enables the `test-plans` image build

Verified to be working here: https://github.com/elastic/apm-pipeline-library/actions/runs/3938527741/jobs/6737329340

## Why is it important?

During the migration there were images that failed already on Jenkins. This is a follow-up PR.

## Related issues
- https://github.com/elastic/apm-pipeline-library/issues/1992