### PR TITLE
feat: bump Python OpenTelemetry SDK to 1.15

### DIFF
--- a/resources/scripts/pytest_otel/CHANGELOG.md
+++ b/resources/scripts/pytest_otel/CHANGELOG.md
@@ -1,9 +1,9 @@
 # version 1.4.0
 
-* Remove support for Python 3.6 and 3.7
-* add support for Python 3.11
-* Bump OpenTelemetry SDK to 1.15.0
-* Update Elastic demo to 8.6.0
+* Remove support for Python 3.6 and 3.7 [2015](https://github.com/elastic/apm-pipeline-library/pull/2015)
+* add support for Python 3.11 [2015](https://github.com/elastic/apm-pipeline-library/pull/2015)
+* Bump OpenTelemetry SDK to 1.15.0 [2015](https://github.com/elastic/apm-pipeline-library/pull/2015)
+* Update Elastic demo to 8.6.0 [2015](https://github.com/elastic/apm-pipeline-library/pull/2015)
 
 # version 1.3.0
 

--- a/resources/scripts/pytest_otel/CHANGELOG.md
+++ b/resources/scripts/pytest_otel/CHANGELOG.md
@@ -1,3 +1,10 @@
+# version 1.4.0
+
+* Remove support for Python 3.6 and 3.7
+* add support for Python 3.11
+* Bump OpenTelemetry SDK to 1.15.0
+* Update Elastic demo to 8.6.0
+
 # version 1.3.0
 
 * Bump OpenTelemetry SDK to 1.13.0 [#1917](https://github.com/elastic/apm-pipeline-library/pull/1917)

--- a/resources/scripts/pytest_otel/README.md
+++ b/resources/scripts/pytest_otel/README.md
@@ -9,9 +9,9 @@ pytest-otel plugin for reporting APM traces of tests executed.
 Requirements
 ------------
 
-* opentelemetry-api == 1.13.0
-* opentelemetry-exporter-otlp == 1.13.0
-* opentelemetry-sdk == 1.13.0
+* opentelemetry-api == 1.15.0
+* opentelemetry-exporter-otlp == 1.15.0
+* opentelemetry-sdk == 1.15.0
 * pytest >= 7.1.3
 
 Installation

--- a/resources/scripts/pytest_otel/docs/demos/elastic/elastic-stack.yml
+++ b/resources/scripts/pytest_otel/docs/demos/elastic/elastic-stack.yml
@@ -20,7 +20,7 @@ services:
       - "xpack.security.authc.api_key.enabled=true"
       - "logger.org.elasticsearch=${ES_LOG_LEVEL:-error}"
       - "action.destructive_requires_name=false"
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_STACK_VERSION:-8.4.2}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_STACK_VERSION:-8.6.0}
     ports:
       - "9200"
     healthcheck:
@@ -43,7 +43,7 @@ services:
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-kibana_system_user}"
       ELASTICSEARCH_PASSWORD: "${KIBANA_ES_PASS:-changeme}"
       STATUS_ALLOWANONYMOUS: "true"
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_STACK_VERSION:-8.4.2}
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_STACK_VERSION:-8.6.0}
     ports:
       - "5601:5601"
     volumes:
@@ -58,7 +58,7 @@ services:
         ]
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:${ELASTIC_STACK_VERSION:-8.4.2}
+    image: docker.elastic.co/beats/elastic-agent:${ELASTIC_STACK_VERSION:-8.6.0}
     privileged: true
     entrypoint: "/bin/bash"
     command:

--- a/resources/scripts/pytest_otel/mypy.ini
+++ b/resources/scripts/pytest_otel/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 allow_untyped_defs = True
 allow_untyped_calls = True
 disallow_any_generics = True

--- a/resources/scripts/pytest_otel/pyproject.toml
+++ b/resources/scripts/pytest_otel/pyproject.toml
@@ -1,7 +1,7 @@
 dependencies = [
-    "opentelemetry-api==1.13.0",
-    "opentelemetry-exporter-otlp==1.13.0",
-    "opentelemetry-sdk==1.13.0",
+    "opentelemetry-api==1.15.0",
+    "opentelemetry-exporter-otlp==1.15.0",
+    "opentelemetry-sdk==1.15.0",
     "pytest==7.1.3",
 ]
 

--- a/resources/scripts/pytest_otel/requirements.txt
+++ b/resources/scripts/pytest_otel/requirements.txt
@@ -1,7 +1,7 @@
 coverage==6.5.0
-opentelemetry-api==1.13.0
-opentelemetry-exporter-otlp==1.13.0
-opentelemetry-sdk==1.13.0
+opentelemetry-api==1.15.0
+opentelemetry-exporter-otlp==1.15.0
+opentelemetry-sdk==1.15.0
 psutil==5.9.3
 pytest==7.1.3
 pre-commit==2.21.0

--- a/resources/scripts/pytest_otel/setup.cfg
+++ b/resources/scripts/pytest_otel/setup.cfg
@@ -5,7 +5,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/elastic/apm-pipeline-library/tree/main/resources/scripts/pytest_otel
 maintainer = Ivan Fernandez Calvo
-version = 1.3.0
+version = 1.4.0
 license = Apache-2.0
 license_file = LICENSE.txt
 platforms = any
@@ -33,9 +33,9 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    opentelemetry-api==1.13.0
-    opentelemetry-exporter-otlp==1.13.0
-    opentelemetry-sdk==1.13.0
+    opentelemetry-api==1.15.0
+    opentelemetry-exporter-otlp==1.15.0
+    opentelemetry-sdk==1.15.0
     pytest==7.1.3
 python_requires = >=3.6
 include_package_data = True

--- a/resources/scripts/pytest_otel/tox.ini
+++ b/resources/scripts/pytest_otel/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
+    py311
     py310
     py39
     py38
-    py37
-    py36
 
 [testenv]
 deps =


### PR DESCRIPTION
## What does this PR do?

* Remove support for Python 3.6 and 3.7
* add support for Python 3.11
* Bump OpenTelemetry SDK to 1.15.0
* Update Elastic demo to 8.6.0
