### PR TITLE
automation: bump version for the apm-integration-testing@main

### DIFF
--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -16,6 +16,13 @@
 ##  The automation will resolve the correct version at runtime, so you don't need to change it.
 ##
 projects:
+  - repo: apm-integration-testing
+    script: .ci/bump-stack-version.sh
+    branches:
+      - main
+    enabled: true
+    labels: dependency
+    reusePullRequest: true
   - repo: apm-server
     script: .ci/bump-stack-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Enable the automation for bumping snapshots

## Why is it important?

No more downgrades such as https://github.com/elastic/apm-integration-testing/pull/1549

Although it will create two different PRs, the one that we are familiar with and the one related to the snapshot `major.minor.0` version, that happens not often though (every 2/3 months or so)

## Related issues

Uses https://github.com/elastic/apm-integration-testing/pull/1550
