### PR TITLE
action: fix missing run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
 
       - name: configure git
+        run: |
           git remote add origin-1 "${REMOTE_URL}"
           git checkout -b main
           git fetch --force --tags


### PR DESCRIPTION
## What does this PR do?

Fix a missing key in the GitHub action definition

## Why is it important?

Otherwise, it won't work