### PR TITLE
action: use PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      packages: write
 
     steps:
 
@@ -30,7 +26,11 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - name: configure git
         run: |
@@ -51,8 +51,6 @@ jobs:
 
       - name: mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: update current tag
         run: |


### PR DESCRIPTION
## What does this PR do?

Use PAT

## Why is it important?

as long as github actions cannot bypass the branch protection



Otherwise:


```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:50 min
[INFO] Finished at: 2023-01-24T15:15:18Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project jenkins-library: Unable to commit files
Error:  Provider message:
Error:  The git-push command failed.
Error:  Command output:
Error: [ERROR] remote: error: GH006: Protected branch update failed for refs/heads/main.        
Error: [ERROR] remote: error: You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information. At least 1 approving review is required by reviewers with write access. 4 of 4 required status checks are expected.        
Error:  To https://github.com/elastic/apm-pipeline-library.git
Error:   ! [remote rejected]   main -> main (protected branch hook declined)
Error: [ERROR] error: failed to push some refs to 'https://github.com/elastic/apm-pipeline-library.git'
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error: Process completed with exit code 1.
```

## Related issues
See https://github.com/orgs/community/discussions/13836

