### PR TITLE
action: setup-git required for the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+      - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        with:
+          username: ${{ env.GIT_USER }}
+          email: ${{ env.GIT_EMAIL }}
+          token: ${{ env.GITHUB_TOKEN }}
+
       - name: configure git
         run: |
           git remote add origin-1 "${REMOTE_URL}"


### PR DESCRIPTION
## What does this PR do?

Enable `setup-git`

## Why is it important?

Otherwise:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project jenkins-library: Unable to commit files
Error:  Provider message:
Error:  The git-commit command failed.
Error:  Command output:
Error:  Author identity unknown
Error:  
Error:  *** Please tell me who you are.
Error:  
Error:  Run
Error:  
Error:    git config --global user.email "you@example.com"
Error:    git config --global user.name "Your Name"
Error:  
Error:  to set your account's default identity.
Error:  Omit --global to set the identity only in this repository.
```
