### PR TITLE
action: fix permissions in the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

Set write permissions

## Why is it important?

Otherwise:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project jenkins-library: Unable to commit files
Error:  Provider message:
Error:  The git-push command failed.
Error:  Command output:
Error:  remote: Permission to elastic/apm-pipeline-library.git denied to github-actions[bot].
Error:  fatal: unable to access 'https://github.com/elastic/apm-pipeline-library.git/': The requested URL returned error: 403
Error:  -> [Help 1]
```