### PR TITLE
actions: use hashicorp/vault-action to prepare the github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           email: ${{ env.GIT_EMAIL }}
           token: ${{ env.GITHUB_TOKEN }}
 
-      - name: configure git
+      - name: Configure git
         run: |
           git remote add origin-1 "${REMOTE_URL}"
           git fetch --force --tags
@@ -56,10 +56,10 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
 
-      - name: mvn release
+      - name: Mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
 
-      - name: update current tag
+      - name: Update current tag
         run: |
           git push origin-1 main
           git tag -f current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,20 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      - uses: hashicorp/vault-action@v2.4.2
         with:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: approle
+          secrets: |
+            secret/observability-team/ci/github-token username | GIT_USER ;
+            secret/observability-team/ci/github-token email | GIT_EMAIL ;
+            secret/observability-team/ci/github-token token | GITHUB_TOKEN_PAT
 
       - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
-          username: ${{ env.GIT_USER }}
-          email: ${{ env.GIT_EMAIL }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.GITHUB_TOKEN_PAT }}
 
       - name: Configure git
         run: |
@@ -58,6 +61,8 @@ jobs:
 
       - name: Mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
+        env:
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
       - name: Update current tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,14 +49,12 @@ jobs:
         env:
           REMOTE_URL: ${{ github.event.repository.html_url }}
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-            ${{ runner.os }}-maven-
+          java-version: '11'
+          distribution: 'adopt'
+          cache: 'maven'
 
       - name: mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"


### PR DESCRIPTION
## What does this PR do?

Set a new env variable to be populated for the releases.

## Why is it important?

Somehow it is not working with the PAT 