### PR TITLE
actions: enable releases with the default behaviour

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,22 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      - uses: hashicorp/vault-action@v2.4.2
         with:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: approle
+          secrets: |
+            secret/observability-team/ci/github-token username | GIT_USER ;
+            secret/observability-team/ci/github-token email | GIT_EMAIL ;
+            secret/observability-team/ci/github-token token | GITHUB_TOKEN_PAT
 
       - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
-          username: ${{ env.GIT_USER }}
-          email: ${{ env.GIT_EMAIL }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.GITHUB_TOKEN_PAT }}
 
-      - name: configure git
+      - name: Configure git
         run: |
           git remote add origin-1 "${REMOTE_URL}"
           git fetch --force --tags
@@ -50,19 +53,19 @@ jobs:
         env:
           REMOTE_URL: ${{ github.event.repository.html_url }}
 
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-            ${{ runner.os }}-maven-
+          java-version: '11'
+          distribution: 'adopt'
+          cache: 'maven'
 
-      - name: mvn release
+      - name: Mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
+        env:
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
-      - name: update current tag
+      - name: Update current tag
         run: |
           git push origin-1 main
           git tag -f current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           git remote add origin-1 "${REMOTE_URL}"
           git fetch --force --tags
-          exit 0
           git checkout main
         env:
           REMOTE_URL: ${{ github.event.repository.html_url }}
@@ -76,7 +75,6 @@ jobs:
 
       - name: Update current tag
         run: |
-          exit 0
           git push origin-1 main
           git tag -f current
           git push origin-1 current -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
 
       - uses: actions/checkout@v3
@@ -30,20 +27,17 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: hashicorp/vault-action@v2.4.2
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
         with:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          method: approle
-          secrets: |
-            secret/observability-team/ci/github-token username | GIT_USER ;
-            secret/observability-team/ci/github-token email | GIT_EMAIL ;
-            secret/observability-team/ci/github-token token | GITHUB_TOKEN_PAT
 
       - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
-          token: ${{ env.GITHUB_TOKEN_PAT }}
+          username: ${{ env.GIT_USER }}
+          email: ${{ env.GIT_EMAIL }}
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
@@ -62,8 +56,6 @@ jobs:
 
       - name: Mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
       - name: Update current tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
-      - name: Debug git environment
-        if: success() || failure()
-        continue-on-error: true
-        run: |
-          git --no-pager log -n2
-          git config user.email
-          git config user.name
-
       - name: Update current tag
         run: |
           git push origin-1 main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,22 +30,19 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: hashicorp/vault-action@v2.4.2
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
         with:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          method: approle
-          secrets: |
-            secret/observability-team/ci/github-token username | GIT_USER ;
-            secret/observability-team/ci/github-token email | GIT_EMAIL ;
-            secret/observability-team/ci/github-token token | GITHUB_TOKEN_PAT
 
       - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
-          token: ${{ env.GITHUB_TOKEN_PAT }}
+          username: ${{ env.GIT_USER }}
+          email: ${{ env.GIT_EMAIL }}
+          token: ${{ env.GITHUB_TOKEN }}
 
-      - name: Configure git
+      - name: configure git
         run: |
           git remote add origin-1 "${REMOTE_URL}"
           git fetch --force --tags
@@ -53,19 +50,19 @@ jobs:
         env:
           REMOTE_URL: ${{ github.event.repository.html_url }}
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
-          cache: 'maven'
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-maven-
 
-      - name: Mvn release
+      - name: mvn release
         run: ./mvnw -B -V release:prepare release:perform --batch-mode -Darguments="-DskipTests=true --batch-mode"
-        env:
-          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
-      - name: Update current tag
+      - name: update current tag
         run: |
           git push origin-1 main
           git tag -f current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN_PAT }}
 
+      - name: Debug git environment
+        if: success() || failure()
+        continue-on-error: true
+        run: |
+          git --no-pager log -n2
+          git config user.email
+          git config user.name
+
       - name: Update current tag
         run: |
           git push origin-1 main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           git remote add origin-1 "${REMOTE_URL}"
           git fetch --force --tags
+          exit 0
           git checkout main
         env:
           REMOTE_URL: ${{ github.event.repository.html_url }}
@@ -74,6 +75,7 @@ jobs:
 
       - name: Update current tag
         run: |
+          exit 0
           git push origin-1 main
           git tag -f current
           git push origin-1 current -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>co.elastic</groupId>
   <artifactId>jenkins-library</artifactId>
-  <version>1.1.366-SNAPSHOT</version>
+  <version>1.1.366</version>
   <name>APM Pipeline Shared Library</name>
   <description>Pipeline Shared Library containing utility steps.</description>
   <url>https://github.com/elastic/apm-pipeline-library</url>
@@ -12,7 +12,7 @@
     <connection>scm:git:https://github.com/elastic/apm-pipeline-library.git</connection>
     <developerConnection>scm:git:https://github.com/elastic/apm-pipeline-library.git</developerConnection>
     <url>https://github.com/elastic/apm-pipeline-library</url>
-    <tag>HEAD</tag>
+    <tag>v1.1.366</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <connection>scm:git:https://github.com/elastic/apm-pipeline-library.git</connection>
     <developerConnection>scm:git:https://github.com/elastic/apm-pipeline-library.git</developerConnection>
     <url>https://github.com/elastic/apm-pipeline-library</url>
-    <tag>v1.1.366</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
## What does this PR do?

Use default behaviour

## Why is it important?

> The auth token is persisted in the local git config. This enables your scripts to run authenticated git commands. The token is removed during post-job cleanup. Set persist-credentials: false to opt-out.

That's the way to force the push coming from the PAT rather than `github-actions[bot]`

