### PR TITLE
golang: 1.20

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -92,6 +92,7 @@ projects:
     script: .ci/bump-go-release-version.sh
     branches:
       - main
+      - "1.19"
       - "1.18"
     enabled: true
     labels: dependency


### PR DESCRIPTION
## What does this PR do?

Support minor-1 releases, aka 1.19

## Why is it important?

https://github.com/elastic/golang-crossbuild/pull/260 has been merged hence `main` does not use `1.19` anymore, so the automation requires to listen for `1.19` versions in the `1.19` branch

