### PR TITLE
automation: remove golang bump for obl-robots

### DIFF
--- a/.ci/.bump-go-release-version.yml
+++ b/.ci/.bump-go-release-version.yml
@@ -95,13 +95,6 @@ projects:
       - "1.18"
     enabled: true
     labels: dependency
-  - repo: observability-robots
-    script: .ci/bump-go-release-version.sh
-    branches:
-      - main
-    enabled: true
-    labels: dependency
-    reviewer: elastic/observablt-ci
   - repo: stream
     script: .ci/bump-go-release-version.sh
     branches:


### PR DESCRIPTION
## What does this PR do?

Avoid bumping versions for the oblt-robots in terms of new golang versions

## Why is it important?

Jenkins is not the CI for the future, so automation is not needed for that project for this particular regard