### PR TITLE
dependabot: remove maven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 ---
 version: 2
 updates:
-  # Enable version updates for maven
-  - package-ecosystem: "maven"
-    # Look for `pom.xml` file in the `root` directory
-    directory: "/"
-    # Check for updates once a month
-    schedule:
-      interval: "monthly"
-    reviewers:
-      - "elastic/observablt-ci"
-
   # Enable version updates for Docker
   - package-ecosystem: "docker"
     directory: "/local"


### PR DESCRIPTION
## What does this PR do?

Remove maven dependabot since it's not production ready this code, as we don't use those dependencies at runtime but consume them from the CI controllers.

## Why is it important?

Jenkins ecosystem at Elastic is deprecated, hence the Jenkins shared library won't need any updates on that regard eventually.

Reduce the PR review overhead that won't be needed in the near future

## Related issues
Closes #ISSUE
