### PR TITLE
shellcheck: use official pinned version 

### DIFF
--- a/.ci/docker/shellcheck/Dockerfile
+++ b/.ci/docker/shellcheck/Dockerfile
@@ -1,5 +1,5 @@
 # Build-only image
-FROM ubuntu:18.04 AS build
+FROM ubuntu:20.04 AS build
 USER root
 WORKDIR /opt/shellCheck
 

--- a/.ci/docker/shellcheck/Dockerfile
+++ b/.ci/docker/shellcheck/Dockerfile
@@ -1,27 +1,6 @@
-# Build-only image
-FROM ubuntu:20.04 AS build
-USER root
-WORKDIR /opt/shellCheck
-
-# Install OS deps
-RUN apt-get update -qq && apt-get install -qq -y ghc cabal-install git
-RUN git clone -n https://github.com/koalaman/shellcheck.git .\
-  && git checkout -B v0.6.0 cb57b4a74f490991e65ee8d0be1a6151a9819f91
-
-# Install Haskell deps
-RUN cabal update && cabal install --dependencies-only --ghc-options="-optlo-Os -split-sections"
-
-# Copy source and build it
-RUN cabal build Paths_ShellCheck && \
-  ghc -optl-static -optl-pthread -isrc -idist/build/autogen --make shellcheck -split-sections -optc-Wl,--gc-sections -optlo-Os && \
-  strip --strip-all shellcheck
-
-RUN mkdir -p /out/bin && \
-  cp shellcheck  /out/bin/
-
 # Resulting Alpine image
 FROM alpine:3.10.1
-COPY --from=build /out /
+COPY --from=koalaman/shellcheck:v0.9.0@sha256:a527e2077f11f28c1c1ad1dc784b5bc966baeb3e34ef304a0ffa72699b01ad9c /bin/shellcheck /bin
 RUN /bin/shellcheck -V
 WORKDIR /mnt
 


### PR DESCRIPTION
## What does this PR do?

Use the official docker pinned version with the latest `0.9.0` version

## Why is it important?

Fix the issue while compiling the project from the source code. I tried by bumping the OS version and went through the build system but somehow I could not make it work.

Since we don't use this often, I'd say to use this approach in favour of having something working. Otherwise we could remove it from the project since I don't see much benefit for buidlilng over and over from scratch for the same pinned version