### PR TITLE
docker: enable apm-integration-testing-all

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -112,12 +112,10 @@ images:
     repository: "elastic/apm-integration-testing"
     tag: "daily"
 
-## This is also failing in Jenkins
-## https://apm-ci.elastic.co/job/apm-shared/job/docker-images/job/apm-integration-testing-all
-#  - name: "apm-integration-testing-all"
-#    repository: "elastic/apm-integration-testing"
-#    build_script: "make -C docker all-tests"
-#    push_script: "make -C docker all-push"
+  - name: "apm-integration-testing-all"
+    repository: "elastic/apm-integration-testing"
+    build_script: "make -C docker all-tests"
+    push_script: "make -C docker all-push"
 
   # Opbeans Docker Images
 


### PR DESCRIPTION
After fixing the upstream issues in https://github.com/elastic/apm-integration-testing/pull/1554

## What does this PR do?

Enable building the docker images for the apm-integration-testing-all

```
➜  apm-integration-testing git:(fix/apm-server-docker-image) make -C docker all-tests
HEAD is now at c706d14 Bats 1.1.0
12-alpine: Pulling from library/node
Digest: sha256:d4b15b3d48f42059a15bd659be60afe21762aae9d6cbea6f124440895c27db68
Status: Image is up to date for node:12-alpine
docker.io/library/node:12-alpine
Synchronizing submodule url for 'tests/test_helper/bats-assert'
Synchronizing submodule url for 'tests/test_helper/bats-support'
1..5
ok 1 apm-server - build image
ok 2 apm-server - clean test containers
ok 3 apm-server - create test container
ok 4 apm-server - test container with 0 as exitcode
ok 5 apm-server - clean test containers afterwards
```


### Issues

Part of https://github.com/elastic/apm-pipeline-library/issues/1992
Requires https://github.com/elastic/apm-integration-testing/issues/1555