### PR TITLE
populate: elastic stack manifests

### DIFF
--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -33,10 +33,10 @@ jobs:
 
           ## generate a manifest with the current active snapshot branches (it also includes main).
           ## Aka those with artifacts that have been generated in the last 30 days.
-          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g)
+          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g')
           {
             echo "{"
-            echo "\"$branches\":"
+            echo "\"branches\":"
             echo "${BRANCHES}"
             echo "}"
           } > branches.json
@@ -65,7 +65,6 @@ jobs:
           destination: "artifacts-api"
           headers: |-
             content-type: application/json
-            x-goog-meta-generator: generate-elastic-stack-snapshots.yml
             x-goog-meta-generator: generate-elastic-stack-snapshots.yml
 
       - name: debug

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -1,0 +1,54 @@
+---
+name: generate-elastic-stack-snapshots
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fetch snapshots
+        run: |-
+          URL="https://artifacts-api.elastic.co/v1"
+          NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
+
+          QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+          for version in ${QUERY_OUTPUT}; do
+            LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
+            BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
+            echo "${LATEST_OUTPUT}" | tee "$BRANCH.json"
+
+            "versions": [12, 14, 16]
+          done
+          ## support main branch
+          cp master.json main.json || true
+          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | sed 's#-SNAPSHOT##g')
+          echo "\"branches\": ${BRANCHES}" > branches.json
+
+      - name: 'Get service account'
+        uses: hashicorp/vault-action@v2.4.2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: approle
+          secrets: |
+            secret/observability-team/ci/artifacts-api-bucket service-account | SERVICE_ACCOUNT ;
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ env.SERVICE_ACCOUNT }}'
+
+      - uses: 'google-github-actions/upload-cloud-storage@v0'
+        with:
+          path: '.'
+          glob: "*.json"
+          destination: "artifacts-api/snapshots"

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -33,7 +33,7 @@ jobs:
           ## generate a manifest with the current active snapshot branches.
           ## Aka those with artifacts that have been generated in the last 30 days.
           BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | sed 's#-SNAPSHOT##g')
-          echo "\"branches\": ${BRANCHES}" > branches.json
+          echo "{\"branches\": ${BRANCHES}}" > branches.json
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.4.2

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1-5'
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -55,4 +55,4 @@ jobs:
         with:
           path: 'snapshots'
           glob: "*.json"
-          destination: "artifacts-api/snapshots"
+          destination: "artifacts-api"

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: fetch snapshots
-        working-directory: ./snapshots  ## we avoid surprises by uploading the unexpected credentials json file
         run: |-
+          ## we avoid surprises by uploading the unexpected credentials json file
+          mkdir snapshots
+          cd snapshots
           URL="https://artifacts-api.elastic.co/v1"
           NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -30,10 +30,16 @@ jobs:
           done
           ## support main branch
           cp master.json main.json || true
-          ## generate a manifest with the current active snapshot branches.
+
+          ## generate a manifest with the current active snapshot branches (it also includes main).
           ## Aka those with artifacts that have been generated in the last 30 days.
-          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | sed 's#-SNAPSHOT##g')
-          echo "{\"branches\": ${BRANCHES}}" > branches.json
+          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g)
+          {
+            echo "{"
+            echo "\"$branches\":"
+            echo "${BRANCHES}"
+            echo "}"
+          } > branches.json
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.4.2
@@ -59,6 +65,7 @@ jobs:
           destination: "artifacts-api"
           headers: |-
             content-type: application/json
+            x-goog-meta-generator: generate-elastic-stack-snapshots.yml
             x-goog-meta-generator: generate-elastic-stack-snapshots.yml
 
       - name: debug

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -51,8 +51,16 @@ jobs:
         with:
           credentials_json: '${{ env.SERVICE_ACCOUNT }}'
 
-      - uses: 'google-github-actions/upload-cloud-storage@v0'
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v0'
         with:
-          path: 'snapshots'
+          path: snapshots
           glob: "*.json"
           destination: "artifacts-api"
+          headers: |-
+            content-type: application/json
+            x-goog-meta-generator: generate-elastic-stack-snapshots.yml
+          predefinedAcl: publicRead
+
+      - name: debug
+        run: echo "${{ steps.upload-file.outputs.uploaded }}"

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -24,11 +24,11 @@ jobs:
             LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
             BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
             echo "${LATEST_OUTPUT}" | tee "$BRANCH.json"
-
-            "versions": [12, 14, 16]
           done
           ## support main branch
           cp master.json main.json || true
+          ## generate a manifest with the current active snapshot branches.
+          ## Aka those with artifacts that have been generated in the last 30 days.
           BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | sed 's#-SNAPSHOT##g')
           echo "\"branches\": ${BRANCHES}" > branches.json
 

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -60,7 +60,6 @@ jobs:
           headers: |-
             content-type: application/json
             x-goog-meta-generator: generate-elastic-stack-snapshots.yml
-          predefinedAcl: publicRead
 
       - name: debug
         run: echo "${{ steps.upload-file.outputs.uploaded }}"

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: fetch snapshots
+        working-directory: ./snapshots  ## we avoid surprises by uploading the unexpected credentials json file
         run: |-
           URL="https://artifacts-api.elastic.co/v1"
           NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
@@ -50,6 +51,6 @@ jobs:
 
       - uses: 'google-github-actions/upload-cloud-storage@v0'
         with:
-          path: '.'
+          path: 'snapshots'
           glob: "*.json"
           destination: "artifacts-api/snapshots"


### PR DESCRIPTION
## What does this PR do?

Upload the elastic stack manifests to a google bucket

## Why is it important?

Automate the bump with `updatecli` so there is no need to parse or run specific shell scripts but pretty much query the google bucket for the given branch


<img width="346" alt="image" src="https://user-images.githubusercontent.com/2871786/217880190-a842b6a2-8977-4fd1-a674-887727c7159e.png">
