### PR TITLE
action: list active branches with snapshots in the Unified Release

### DIFF
--- a/.github/actions/elastic-stack-snapshot-branches/README.md
+++ b/.github/actions/elastic-stack-snapshot-branches/README.md
@@ -1,0 +1,37 @@
+
+## About
+
+GitHub Action to fetch the current list of active branches in Elastic (the ones based
+on the Unified Release process)
+
+___
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+
+## Usage
+
+### Configuration
+
+```yaml
+---
+...
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - id: generator
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@current
+
+  bump-elastic-stack:
+    runs-on: ubuntu-latest
+    needs: [filter]
+    strategy:
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
+...
+
+```

--- a/.github/actions/elastic-stack-snapshot-branches/action.yml
+++ b/.github/actions/elastic-stack-snapshot-branches/action.yml
@@ -1,0 +1,27 @@
+---
+name: 'Elastic Stack Snapshot branches'
+description: 'Fetch the current list of active branches with snapshots in Elastic'
+outputs:
+  matrix:
+    description: "Processed matrix with the required tuples of version and framework"
+    value: ${{ steps.generator.outputs.matrix }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - id: generator
+      shell: python
+      run: |
+        import json
+        import os
+        import requests
+        r = requests.get(url='https://storage.googleapis.com/artifacts-api/snapshots/branches.json')
+        matrix = {'include': []}
+        for branch in r.json()['branches']:
+          matrix['include'].append({"branch": branch})
+        with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
+          f.write("matrix={}\n".format(json.dumps(matrix)))
+    - id: debug
+      shell: bash
+      run: |
+        echo 'Matrix: ${{ steps.generator.outputs.matrix }}'


### PR DESCRIPTION
## What does this PR do?

GitHub composite action to fetch the current list of active branches with snapshots in the Unified Release.

## Why is it important?

so consumers don't need to reimplement anything but use this.

## Related issues

Requires https://github.com/elastic/apm-pipeline-library/pull/2069
Notifies https://github.com/elastic/apm-server/pull/10222