### PR TITLE
action: centralise the updatecli execution

### DIFF
--- a/.github/actions/updatecli/README.md
+++ b/.github/actions/updatecli/README.md
@@ -1,0 +1,61 @@
+
+## About
+
+GitHub Action to run the updatecli with vault access.
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+
+```yaml
+---
+name: update-specs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/update-specs.yml
+
+
+```
+
+___
+
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `pipeline`        | String  |                             | Path to pipeline file. |
+| `vaultRoleId`     | String  |                             | The Vault role id. |
+| `vaultSecretId`   | String  |                             | The Vault secret id. |
+| `vaultUrl`        | String  |                             | The Vault URL to connect to. |

--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -1,0 +1,36 @@
+name: 'Updatecli'
+description: 'Run the declarative dependency manager.'
+inputs:
+  pipeline:
+    description: 'The updatecli pipeline to run'
+    required: true
+  vaultUrl:
+    description: 'Vault URL'
+    required: true
+  vaultRoleId:
+    description: 'Vault role ID'
+    required: true
+  vaultSecretId:
+    description: 'Vault secret ID'
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Git
+      uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
+    - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      with:
+        url: ${{ inputs.vaultUrl }}
+        roleId: ${{ inputs.vaultRoleId }}
+        secretId: ${{ inputs.vaultSecretId }}
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+
+    - name: Run Updatecli
+      run: updatecli apply --config ${{ inputs.pipeline }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Composite action to centralise the updatecli settings

## Why is it important?

Avoid duplicated code and being able to bypass the existing issue with PRs created on behalf of `github actions[bot]`

## Related issues

See https://github.com/orgs/community/discussions/25602#issuecomment-536184102
