### PR TITLE
pre-commit: remove jjbb and jenkinsfile linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: current
     hooks:
     -   id: check-bash-syntax
-    -   id: check-abstract-classes-and-traits   # TODO: this hook won't be needed once the CI migration is completed
+    -   id: check-abstract-classes-and-trait   # TODO: this hook won't be needed once the CI migration is completed
     -   id: check-jsonslurper-class   # TODO: this hook won't be needed once the CI migration is completed
     -   id: check-unicode-non-breaking-spaces
     -   id: remove-unicode-non-breaking-spaces

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,17 +45,14 @@ repos:
     rev: current
     hooks:
     -   id: check-bash-syntax
-    -   id: check-abstract-classes-and-trait
-    -   id: check-jsonslurper-class
-    -   id: check-jenkins-pipelines   # TODO: this hook won't be needed once the CI migration is completed
-        files: ^(.ci/(.*\.groovy|Jenkinsfile)|Jenkinsfile|resources/JenkinsfileTemplate.groovy)$
+    -   id: check-abstract-classes-and-traits   # TODO: this hook won't be needed once the CI migration is completed
+    -   id: check-jsonslurper-class   # TODO: this hook won't be needed once the CI migration is completed
     -   id: check-unicode-non-breaking-spaces
     -   id: remove-unicode-non-breaking-spaces
     -   id: check-en-dashes
         exclude: ^src/test/resources/mappings/
     -   id: remove-en-dashes
         exclude: ^src/test/resources/mappings/
-    -   id: check-jjbb                # TODO: this hook won't be needed once the CI migration is completed
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.1.0


### PR DESCRIPTION
## What does this PR do?

Remove linters for unexisting type of files (jjbb and pipelines)

## Why is it important?

Remove legacy code since this project doesn't run in Jenkins anymore 