### PR TITLE
delete branches which are not yet created

### DIFF
--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -41,6 +41,28 @@ jobs:
             echo "}"
           } > branches.json
 
+          ## Remove branches that have not been created yet, for such it queries the GitHub repositoreis
+          for branch in $(jq -r '.branches | .[]' branches.json); do
+            if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" ; then
+              echo $branch
+            else
+              ## fallback to kibana just in case
+              if git ls-remote --exit-code --heads https://github.com/elastic/kibana.git "$branch" ; then
+                echo $branch
+              else
+                echo "$branch does not exist"
+                {
+                  echo "{"
+                  echo "\"branches\":"
+                  jq ".branches - [\"$branch\"]" branches.json
+                  echo "}"
+                } > branches.json.tmp
+                mv branches.json.tmp branches.json
+                rm "$branch.json"
+              fi
+            fi
+          done
+
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.4.2
         with:


### PR DESCRIPTION
## What does this PR do?

Remove branches that have not been created yet

## Why is it important?

`artifacts-api` returns versions regardless of what branch is coming from. Then the `branches.json` contains a list of branches which might not exist. Then it's required to validate if the branch has been created in the relevant GitHub repositories.

Consumers use the `branches.json`, but `8.8` is not yet created but the one in `main`

<img width="463" alt="image" src="https://user-images.githubusercontent.com/2871786/219028402-6845231b-fd9c-491e-b258-31c5aef6dc31.png">

The artifacts-api is queried by current SNAPSHOTS and `8.8-SNAPSHOT` is there, but it's the one pointing to main rather than the `8.8` branch

<img width="501" alt="image" src="https://user-images.githubusercontent.com/2871786/219028573-88fe4481-7ca9-4331-9b59-7aeb8fdf1dd7.png">
