### PR TITLE
action: bump-aliases use docker login

### DIFF
--- a/.ci/bump-aliases.yml
+++ b/.ci/bump-aliases.yml
@@ -110,8 +110,6 @@ conditions:
     spec:
       image: docker.elastic.co/elasticsearch/elasticsearch
       tag: '{{ source "next7" }}-SNAPSHOT'
-      username: '{{ requiredEnv "DOCKER_USERNAME" }}'
-      password: '{{ requiredEnv "DOCKER_PASSWORD" }}'
     sourceid: next7
 
   docker_next8:
@@ -120,8 +118,6 @@ conditions:
     spec:
       image: docker.elastic.co/elasticsearch/elasticsearch
       tag: '{{ source "next8" }}-SNAPSHOT'
-      username: '{{ requiredEnv "DOCKER_USERNAME" }}'
-      password: '{{ requiredEnv "DOCKER_PASSWORD" }}'
     sourceid: next8
 
   docker_patch8:
@@ -130,8 +126,6 @@ conditions:
     spec:
       image: docker.elastic.co/elasticsearch/elasticsearch
       tag: '{{ source "patch8" }}-SNAPSHOT'
-      username: '{{ requiredEnv "DOCKER_USERNAME" }}'
-      password: '{{ requiredEnv "DOCKER_PASSWORD" }}'
     sourceid: patch8
 
   docker_edge8:
@@ -140,8 +134,6 @@ conditions:
     spec:
       image: docker.elastic.co/elasticsearch/elasticsearch
       tag: '{{ source "edge8" }}-SNAPSHOT'
-      username: '{{ requiredEnv "DOCKER_USERNAME" }}'
-      password: '{{ requiredEnv "DOCKER_PASSWORD" }}'
     sourceid: edge8
 
 targets:

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -38,7 +38,7 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
-    - name: Set environment
+    - name: Reset environment
       shell: bash
       run: |
           echo "DOCKER_USERNAME=" >> $GITHUB_ENV

--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -53,5 +53,3 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-        DOCKER_USERNAME: ${{ env.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ env.DOCKER_PASSWORD }}


### PR DESCRIPTION
## What does this PR do?

`bump-aliases` uses the environmental context that has already access to the prviate docker registry

## Why is it important?

Use docker-login and env variables are reseted after the login has happened, hence it's not accessible by env variables

## Test

I used the `.ci/bump-aliases.yml` locally with the username/password as I was already logged in and it worked.