### PR TITLE
action: is-member-elastic-org composite action

### DIFF
--- a/.github/actions/is-member-elastic-org/README.md
+++ b/.github/actions/is-member-elastic-org/README.md
@@ -1,0 +1,52 @@
+## About
+
+GitHub Action to check if someone is member of the GitHub organization.
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+  * [outputs](#outputs)
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```yaml
+---
+name: Is Member Example
+on:
+  issues:
+    types: [opened]
+jobs:
+  run-if-member:
+    name: Welcome
+    runs-on: ubuntu-latest
+    steps:
+      - id: is_elastic_member
+        uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+        with:
+          username: ${{ github.event.issue.user.login }}
+          token: ${{ secrets.PAT_TOKEN }}
+      - if: steps.is_elastic_member.outputs.result == true
+        run: echo '${{ github.event.issue.user.login }} is member'
+```
+
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `username`            | String  |                             | The GitHub user name |
+
+### outputs
+
+| Name              | Type    | Description                 |
+|-------------------|---------| ----------------------------|
+| `result`          | Boolean | Whether the user is member. |

--- a/.github/actions/is-member-elastic-org/action.yml
+++ b/.github/actions/is-member-elastic-org/action.yml
@@ -22,6 +22,7 @@ runs:
           -H "Accept: application/vnd.github+json" \
           /orgs/elastic/members/${{ inputs.username }} ; then
           echo "result=true" >> $GITHUB_OUTPUT
+        else
+          echo "result=false" >> $GITHUB_OUTPUT
         fi
-        echo "result=false" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/is-member-elastic-org/action.yml
+++ b/.github/actions/is-member-elastic-org/action.yml
@@ -1,0 +1,27 @@
+name: 'Is Member of Elastic org'
+description: 'Check if someone is member of the GitHub organization.'
+inputs:
+  username:
+    description: 'The GitHub user'
+    required: true
+  token:
+    description: 'The GitHub access token.'
+    required: true
+outputs:
+  result:
+    description: 'The result in either true or false'
+    value: ${{ steps.gh-api-is-member.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - id: gh-api-is-member
+      name: Check if user is member of the Elastic org
+      run: |
+        if gh api \
+          -H "Authorization: Bearer ${{ inputs.token }}" \
+          -H "Accept: application/vnd.github+json" \
+          /orgs/elastic/members/${{ inputs.username }} ; then
+          echo "result=true" >> $GITHUB_OUTPUT
+        fi
+        echo "result=false" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -15,6 +15,7 @@ on:
       - publish-docker-images
       - pytest_otel-build-test
       - release-drafter
+      - test-is-member-elastic-org
     types: [completed]
 
 jobs:

--- a/.github/workflows/test-is-member-elastic-org.yml
+++ b/.github/workflows/test-is-member-elastic-org.yml
@@ -15,7 +15,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/alternative-is-mberm-elastic-org
+      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
         id: is_elastic_member
         with:
           username: mdelapenya
@@ -33,7 +33,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/alternative-is-mberm-elastic-org
+      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
         id: is_elastic_member
         with:
           username: apmmachine

--- a/.github/workflows/test-is-member-elastic-org.yml
+++ b/.github/workflows/test-is-member-elastic-org.yml
@@ -3,7 +3,6 @@ name: test-is-member-elastic-org
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   test-with-non-elastic-user:

--- a/.github/workflows/test-is-member-elastic-org.yml
+++ b/.github/workflows/test-is-member-elastic-org.yml
@@ -1,0 +1,44 @@
+---
+name: test-is-member-elastic-org
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test-with-non-elastic-user:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/alternative-is-mberm-elastic-org
+        id: is_elastic_member
+        with:
+          username: mdelapenya
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Assert is no member
+        run: test "${{steps.is_elastic_member.outputs.result}}" = "false"
+
+  test-with-elastic-user:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/alternative-is-mberm-elastic-org
+        id: is_elastic_member
+        with:
+          username: apmmachine
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Assert is member
+        run: test "${{steps.is_elastic_member.outputs.result}}" = "true"


### PR DESCRIPTION
## What does this PR do?

Support action to verify if the given GitHub user is member of the `elastic` org using 
https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user 

## Why is it important?

This will help us to move forward with the GitHub command ops to run specific actions based on specific GitHub commands

## Test

see [this workflow](https://github.com/elastic/apm-pipeline-library/actions/runs/4218017592/jobs/7322214514) that tested these changes

## Related issues

Supersedes https://github.com/elastic/apm-pipeline-library/pull/2087
