### PR TITLE
action: workflow event composite action

### DIFF
--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -12,8 +12,10 @@ GitHub Action to run a workflow event from another GitHub repository.
 
 ### Configuration
 
-Given the `PAT_TOKEN` GitHub secret when a merge happens in the `main` branch
-then trigger a `deploy-my-kibana` GitHub event workflow in the repository `my-org/acme`:
+Given the repository_dispatcher wokflow called `deploy my kibana`
+  And the `PAT_TOKEN` GitHub secret
+When a merge happens in the `main` branch
+Then it triggers a `deploy-my-kibana` GitHub event workflow in the repository `my-org/acme`:
 
 ```yaml
 ---
@@ -33,6 +35,24 @@ jobs:
           event: 'deploy-my-kibana'
           payload: ''
           token: ${{ secrets.PAT_TOKEN }}
+```
+
+```yaml
+---
+name: deploy my kibana
+
+on:
+  repository_dispatch:
+    types:
+      - deploy-my-kibana
+
+jobs:
+  dispatcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload..sha }}
 ```
 
 ## Customizing

--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -1,0 +1,49 @@
+## About
+
+GitHub Action to run a workflow event from another GitHub repository.
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+  * [outputs](#outputs)
+
+## Usage
+
+### Configuration
+
+Given the `PAT_TOKEN` GitHub secret when a merge happens in the `main` branch
+then trigger a `deploy-my-kibana` GitHub event workflow in the repository `my-org/acme`:
+
+```yaml
+---
+name: Run GitHub Event Workflow example
+on:
+  push:
+    branches:
+      - main
+jobs:
+  run-workflow:
+    name: Dispatch workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/workflow-run@current
+        with:
+          repository: "my-org/acme"
+          event: 'deploy-my-kibana'
+          payload: ''
+          token: ${{ secrets.PAT_TOKEN }}
+```
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `repository`      | String  |                             | The GitHub repository for the GitHub event type workflow to be triggered. Format: ORG/REPO . |
+| `event`           | String  |                             | The GitHub event type to be triggered. |
+| `payload`         | String  |                             | The GitHub event payload to be consumed by the GitHub workflow event type. Format: json |
+| `token`           | String  |                             | The GitHub token with permissions to trigger the GitHub workflow event type. |

--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -14,14 +14,14 @@ GitHub Action to run a workflow event from another GitHub repository.
 
 Given the repository_dispatcher wokflow called `deploy my kibana`
   And the `PAT_TOKEN` GitHub secret
-When a merge happens in the `main` branch
+When a Pull Request happens that targets the `main` branch
 Then it triggers a `deploy-my-kibana` GitHub event workflow in the repository `my-org/acme`:
 
 ```yaml
 ---
 name: Run GitHub Event Workflow example
 on:
-  push:
+  pull_request:
     branches:
       - main
 jobs:
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: "my-org/acme"
           event: 'deploy-my-kibana'
-          payload: ''
+          payload: '{ "sha": "${{ github.event.pull_request.head.sha }}", repository: "${{ github.repository }}" }'
           token: ${{ secrets.PAT_TOKEN }}
 ```
 
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.client_payload..sha }}
+          ref: ${{ github.event.client_payload.sha }}
 ```
 
 ## Customizing

--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -6,7 +6,6 @@ GitHub Action to run a workflow event from another GitHub repository.
   * [Configuration](#configuration)
 * [Customizing](#customizing)
   * [inputs](#inputs)
-  * [outputs](#outputs)
 
 ## Usage
 

--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: "my-org/acme"
           event: 'deploy-my-kibana'
-          payload: '{ "sha": "${{ github.event.pull_request.head.sha }}", repository: "${{ github.repository }}" }'
+          payload: '{ "ref": "${{ github.event.pull_request.head.sha }}", repository: "${{ github.repository }}" }'
           token: ${{ secrets.PAT_TOKEN }}
 ```
 
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.client_payload.sha }}
+          ref: ${{ github.event.client_payload.ref }}
 ```
 
 ## Customizing

--- a/.github/actions/workflow-run/README.md
+++ b/.github/actions/workflow-run/README.md
@@ -65,5 +65,5 @@ Following inputs can be used as `step.with` keys
 |-------------------|---------|-----------------------------|------------------------------------|
 | `repository`      | String  |                             | The GitHub repository for the GitHub event type workflow to be triggered. Format: ORG/REPO . |
 | `event`           | String  |                             | The GitHub event type to be triggered. |
-| `payload`         | String  |                             | The GitHub event payload to be consumed by the GitHub workflow event type. Format: json |
+| `payload`         | String  |                             | The GitHub event payload to be consumed by the GitHub workflow event type. Format: JSON ( { "my-key": "my-value", ... } ). |
 | `token`           | String  |                             | The GitHub token with permissions to trigger the GitHub workflow event type. |

--- a/.github/actions/workflow-run/action.yml
+++ b/.github/actions/workflow-run/action.yml
@@ -11,18 +11,32 @@ inputs:
     description: 'The GitHub event type.'
     required: true
   payload:
-    description: 'The workflow payload.'
+    description: 'The workflow payload in JSON format ( { "my-key": "my-value", ... } ).'
     required: false
 runs:
   using: "composite"
   steps:
+    - name: Prepare payload
+      run: |
+        if [ -n "${{ inputs.payload }}" ] ; then
+          {
+            echo '{'
+            echo '  "event_type": "${{ inputs.type }}",'
+            echo '  "client_payload": ${{ inputs.payload }}'
+            echo '}'
+          } | jq . > payload.json
+        else
+          echo '{ "event_type" : "${{ inputs.type }}" }' | jq . > payload.json
+        fi
+      shell: bash
+
     - name: Dispatch workflow
       run: |
         gh api \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           repos/${{ inputs.repository }}/dispatches \
           -X POST \
-          --input - <<< "{\"event_type\":\"${{ inputs.type }}\",\"client_payload\":{ \"ref\": \"foo\", \"repository\": \"${{ inputs.repository }}\"}}"
+          --input payload.json
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/workflow-run/action.yml
+++ b/.github/actions/workflow-run/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Prepare payload
       run: |
-        if [ -n "${{ inputs.payload }}" ] ; then
+        if [ -n '${{ inputs.payload }}' ] ; then
           {
             echo '{'
             echo '  "event_type": "${{ inputs.type }}",'

--- a/.github/actions/workflow-run/action.yml
+++ b/.github/actions/workflow-run/action.yml
@@ -20,10 +20,9 @@ runs:
       run: |
         gh api \
           -H 'Accept: application/vnd.github.everest-preview+json' \
-          -H "Authorization: Bearer ${{ inputs.token }}" \
           repos/${{ inputs.repository }}/dispatches \
           -X POST \
-          --input - <<< "{\"event_type\":\"${{ inputs.type }}\",\"client_payload\":{ \"ref\": \"${{ inputs.sha }}\", \"repository\": \"${{ inputs.repository }}\"}}"
-      shell: bash
+          --input - <<< "{\"event_type\":\"${{ inputs.type }}\",\"client_payload\":{ \"ref\": \"foo\", \"repository\": \"${{ inputs.repository }}\"}}"
       env:
         GH_TOKEN: ${{ inputs.token }}
+      shell: bash

--- a/.github/actions/workflow-run/action.yml
+++ b/.github/actions/workflow-run/action.yml
@@ -1,0 +1,29 @@
+name: 'Workflow run'
+description: 'Run GitHub workflow from a specific GitHub with some payload.'
+inputs:
+  repository:
+    description: 'The GitHub repository, format: ORG/REPO'
+    required: true
+  token:
+    description: 'The GitHub access token.'
+    required: true
+  type:
+    description: 'The GitHub event type.'
+    required: true
+  payload:
+    description: 'The workflow payload.'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Dispatch workflow
+      run: |
+        gh api \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H "Authorization: Bearer ${{ inputs.token }}" \
+          repos/${{ inputs.repository }}/dispatches \
+          -X POST \
+          --input - <<< "{\"event_type\":\"${{ inputs.type }}\",\"client_payload\":{ \"ref\": \"${{ inputs.sha }}\", \"repository\": \"${{ inputs.repository }}\"}}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -26,4 +26,4 @@ jobs:
           repository: "elastic/observability-robots-playground"
           type: my-event
           token: ${{ env.GITHUB_TOKEN }}
-          payload: '{ "sha": "${{ github.event.pull_request.head.sha }}", repository: "${{ github.repository }}" }'
+          payload: '{ "ref": "${{ github.event.pull_request.head.sha }}", "repository": "${{ github.repository }}" }'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  test-with-elastic-user:
+  dispatch-workflow:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,4 +26,4 @@ jobs:
           repository: "elastic/observability-robots-playground"
           type: my-event
           token: ${{ env.GITHUB_TOKEN }}
-          payload: '{ "sha": "${{ github.sha }}", repository: "${{ github.repository }}" }'
+          payload: '{ "sha": "${{ github.event.head.sha }}", repository: "${{ github.repository }}" }'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -26,4 +26,4 @@ jobs:
           repository: "elastic/observability-robots-playground"
           type: my-event
           token: ${{ env.GITHUB_TOKEN }}
-          payload: '{ "sha": "${{ github.event.head.sha }}", repository: "${{ github.repository }}" }'
+          payload: '{ "sha": "${{ github.event.pull_request.head.sha }}", repository: "${{ github.repository }}" }'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -1,0 +1,29 @@
+---
+name: test-workflow-run
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  test-with-elastic-user:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Dump GitHub context
+        run: echo '${{ toJSON(github) }}'
+
+      - uses: elastic/apm-pipeline-library/.github/actions/workflow-run@feature/github-workflow-run
+        with:
+          repository: "elastic/observability-robots-playground"
+          type: my-event
+          token: ${{ env.GITHUB_TOKEN }}
+          payload: '{ "sha": "${{ github.sha }}", repository: "${{ github.repository }}" }'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -2,7 +2,6 @@
 name: test-workflow-run
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

GitHub composite action to trigger workflows between GitHub repositories using the [repository_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch)

## Why is it important?

This will help us to interconnect different workflows with different even types, such as, a GitHub command will trigger a workflow in a different repository (even private repositories)

## Tasks

- [x] Define the payload format
- [x] Test this out


## Test

This [build](https://github.com/elastic/apm-pipeline-library/actions/runs/4224575367/jobs/7335706206), caused by  https://github.com/elastic/apm-pipeline-library/pull/2094/commits/0c4069e90f643ffaf45a397894024f0ddb19267a, triggered the build in one of our internal playground GitHub repositories:

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/2871786/220139449-bdf3908e-e053-48c7-b9df-9b8ac3804016.png">
