### PR TITLE
bump: tweak conditions for current releases and upcoming patches

### DIFF
--- a/.ci/bump-aliases.yml
+++ b/.ci/bump-aliases.yml
@@ -120,14 +120,6 @@ conditions:
       tag: '{{ source "next8" }}-SNAPSHOT'
     sourceid: next8
 
-  docker_patch8:
-    name: Is docker image elasticsearch:{{ source "patch8" }}-SNAPSHOT available
-    kind: dockerimage
-    spec:
-      image: docker.elastic.co/elasticsearch/elasticsearch
-      tag: '{{ source "patch8" }}-SNAPSHOT'
-    sourceid: patch8
-
   docker_edge8:
     name: Is docker image elasticsearch:{{ source "edge8" }}-SNAPSHOT available
     kind: dockerimage

--- a/.ci/bump-aliases.yml
+++ b/.ci/bump-aliases.yml
@@ -88,22 +88,6 @@ sources:
           pattern: "[0-9].[0-9].[0-9]"
 
 conditions:
-  docker_current7:
-    name: Is docker image elasticsearch:{{ source "current7" }} published
-    kind: dockerimage
-    spec:
-      image: elasticsearch
-      tag: '{{ source "current7" }}'
-    sourceid: current7
-
-  docker_current_8:
-    name: Is docker image elasticsearch:{{ source "current8" }} published
-    kind: dockerimage
-    spec:
-      image: elasticsearch
-      tag: '{{ source "current8" }}'
-    sourceid: current8
-
   docker_next7:
     name: Is docker image elasticsearch:{{ source "next7" }}-SNAPSHOT available
     kind: dockerimage

--- a/.ci/bump-elastic-stack.yml
+++ b/.ci/bump-elastic-stack.yml
@@ -37,15 +37,6 @@ sources:
         kind: regex
         pattern: ^v8\.(\d+)\.(\d+)$
 
-conditions:
-  dockerTag:
-    name: Is docker image elasticsearch:{{ source "latestRelease" }} published
-    kind: dockerimage
-    spec:
-      image: elasticsearch
-      tag: '{{ source "latestRelease" }}'
-    sourceid: latestRelease
-
 targets:
   update-filebeat:
     name: 'Update elastic stack version to {{ source "latestRelease" }}'


### PR DESCRIPTION
## What does this PR do?

When a new minor will happen then the patch for the 8 line will not point to an existing version.
Current releases are already supported with the GitHub releases

## Why is it important?

Those conditions are not required