### PR TITLE
action: oblt-cli action

### DIFF
--- a/.github/actions/oblt-cli/README.md
+++ b/.github/actions/oblt-cli/README.md
@@ -41,3 +41,4 @@ Following inputs can be used as `step.with` keys
 | `command`         | String  |                             | The oblt-cli command to run, without the oblt-cli prefix. |
 | `slackChannel`    | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `token`           | String  |                             | The GitHub token with permissions fetch releases. |
+| `username`        | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/oblt-cli/README.md
+++ b/.github/actions/oblt-cli/README.md
@@ -1,0 +1,42 @@
+## About
+
+GitHub Action to run the oblt-cli wrapper
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```yaml
+---
+name: Create cluster using the oblt-cli
+on:
+  issues:
+    types: [opened]
+jobs:
+  run-oblt-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@current
+        with:
+          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix mycustomcluster'
+          token: ${{ secrets.PAT_TOKEN }}
+```
+
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `command`         | String  |                             | The oblt-cli command to run, without the oblt-cli prefix. |
+| `token`           | String  |                             | The GitHub token with permissions fetch releases. |

--- a/.github/actions/oblt-cli/README.md
+++ b/.github/actions/oblt-cli/README.md
@@ -39,4 +39,5 @@ Following inputs can be used as `step.with` keys
 | Name              | Type    | Default                     | Description                        |
 |-------------------|---------|-----------------------------|------------------------------------|
 | `command`         | String  |                             | The oblt-cli command to run, without the oblt-cli prefix. |
+| `slackChannel`    | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `token`           | String  |                             | The GitHub token with permissions fetch releases. |

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -28,9 +28,5 @@ runs:
 
     - name: run oblt-cli
       run: |
-        verboseFlag=''
-        if [ '${{ env.RUNNER_DEBUG }}' == "true" ] ; then
-          verboseFlag='--verbose'
-        fi
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} $verboseFlag
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose
       shell: bash

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -7,6 +7,10 @@ inputs:
   token:
     description: 'The GitHub access token.'
     required: true
+  slackChannel:
+    description: 'The slack channel to notify the status.'
+    default: '#observablt-bots'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -19,7 +23,7 @@ runs:
 
     - name: configure oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='#observablt-bots'
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='${{ inputs.slackChannel }}'
       shell: bash
 
     - name: run oblt-cli

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -19,10 +19,10 @@ runs:
 
     - name: configure oblt-cli
       run: |
-        GITHUB_TOKEN: ${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine
       shell: bash
 
     - name: run oblt-cli
       run: |
-        GITHUB_TOKEN: ${{ inputs.token }} ./oblt-cli ${{ inputs.command }}
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }}
       shell: bash

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: configure oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='#channelIsRequired'
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='#observablt-bots'
       shell: bash
 
     - name: run oblt-cli

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -1,0 +1,28 @@
+name: 'Oblt-cli wrapper'
+description: 'Run the oblt-cli wrapper.'
+inputs:
+  command:
+    description: 'The oblt-cli command to run'
+    required: true
+  token:
+    description: 'The GitHub access token.'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: download oblt-cli
+      run: |
+        gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+
+    - name: configure oblt-cli
+      run: |
+        GITHUB_TOKEN: ${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine
+      shell: bash
+
+    - name: run oblt-cli
+      run: |
+        GITHUB_TOKEN: ${{ inputs.token }} ./oblt-cli ${{ inputs.command }}
+      shell: bash

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: configure oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='#channelIsRequired'
       shell: bash
 
     - name: run oblt-cli

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'The slack channel to notify the status.'
     default: '#observablt-bots'
     required: false
+  username:
+    description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
+    default: 'apmmachine'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -23,7 +27,7 @@ runs:
 
     - name: configure oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username=apmmachine --slack-channel='${{ inputs.slackChannel }}'
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username='${{ inputs.username }}' --slack-channel='${{ inputs.slackChannel }}'
       shell: bash
 
     - name: run oblt-cli

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -28,5 +28,9 @@ runs:
 
     - name: run oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }}
+        verboseFlag=''
+        if [ '${{ env.RUNNER_DEBUG }}' == "true" ] ; then
+          verboseFlag='--verbose'
+        fi
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} $verboseFlag
       shell: bash

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -20,7 +20,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@feature/oblt-cli-action
+      - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@main
         with:
           token: ${{ env.GITHUB_TOKEN }}
           command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix testgithubaction'

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -1,0 +1,24 @@
+---
+name: test-oblt-cli
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  dispatch-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@feature/oblt-cli-action
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix mycustomcluster'

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  dispatch-workflow:
+  run-oblt-cli:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@feature/oblt-cli-action
         with:
           token: ${{ env.GITHUB_TOKEN }}
-          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix test-github-action'
+          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix testgithubaction'

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
         with:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@feature/oblt-cli-action
         with:
           token: ${{ env.GITHUB_TOKEN }}
-          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix mycustomcluster'
+          command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix test-github-action'


### PR DESCRIPTION
## What does this PR do?

Composite action to interact with the oblt-cli tool

## Why is it important?

Simplify consumers so they can directly use the CLI but without the need to download the binary

## Test

See this [build](https://github.com/elastic/apm-pipeline-library/actions/runs/4232636127/jobs/7352610773) that triggered the `oblt-cli`
