### PR TITLE
Add ability to add custom message to notify-build-status action

### DIFF
--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -52,9 +52,10 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name            | Type    | Required | Description                                             |
-|-----------------|---------|------|-------------------------------------------------------------|
-| `vaultRoleId`   | String  | yes  | The Vault role id.                                          |
-| `vaultSecretId` | String  | yes  | The Vault secret id.                                        |
-| `vaultUrl`      | String  | yes  | The Vault URL to connect to.                                |
-| `slackChannel`  | String  | no   | Slack channel id, channel name, or user id to post message. |
+| Name            | Type    | Required | Description                                                   |
+|-----------------|---------|------|-------------------------------------------------------------------|
+| `vaultRoleId`   | String  | yes  | The Vault role id.                                                |
+| `vaultSecretId` | String  | yes  | The Vault secret id.                                              |
+| `vaultUrl`      | String  | yes  | The Vault URL to connect to.                                      |
+| `slackChannel`  | String  | no   | Slack channel id, channel name, or user id to post message.       |
+| `message`       | String | no | Add additional message to the notification.                          |

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -52,10 +52,10 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name            | Type    | Required | Description                                                   |
-|-----------------|---------|------|-------------------------------------------------------------------|
-| `vaultRoleId`   | String  | yes  | The Vault role id.                                                |
-| `vaultSecretId` | String  | yes  | The Vault secret id.                                              |
-| `vaultUrl`      | String  | yes  | The Vault URL to connect to.                                      |
-| `slackChannel`  | String  | no   | Slack channel id, channel name, or user id to post message.       |
-| `message`       | String | no | Add additional message to the notification.                          |
+| Name            | Type     | Required | Description                                                   |
+|-----------------|----------|----------|---------------------------------------------------------------|
+| `vaultRoleId`   | String   | yes      | The Vault role id.                                            |
+| `vaultSecretId` | String   | yes      | The Vault secret id.                                          |
+| `vaultUrl`      | String   | yes      | The Vault URL to connect to.                                  |
+| `slackChannel`  | String   | no       | Slack channel id, channel name, or user id to post message.   |
+| `message`       | String   | no       | Add additional message to the notification.                   |

--- a/.github/actions/notify-build-status/action.yml
+++ b/.github/actions/notify-build-status/action.yml
@@ -14,6 +14,9 @@ inputs:
   slackChannel:
     description: Slack channel
     required: false
+  message:
+    description: Add additional message
+    required: false
 
 runs:
   using: composite
@@ -73,6 +76,7 @@ runs:
               {
                 "pretext": "Workflow <${{ steps.prepare.outputs.repo_url }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}> triggered by <${{ github.server_url }}/${{ github.actor }}|${{ github.actor }}>",
                 "color": "${{ steps.prepare.outputs.color }}",
+                "text": "${{ inputs.message }}",
                 "fields": [
                   {
                     "title": "Status",


### PR DESCRIPTION
## What does this PR do?

Add ability to add custom message to notify-build-status action

```
with:
  message: Hello, World!
```

![image](https://user-images.githubusercontent.com/16325797/220376412-fbb911bd-2e75-4c20-b20a-6c04391f9b62.png)

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

In some cases you wan't to add additional message to the notification.

## Related issues
Closes #ISSUE
