### PR TITLE
actions: support gitops for oblt-cli-create-ccs

### DIFF
--- a/.github/actions/oblt-cli-create-ccs/README.md
+++ b/.github/actions/oblt-cli-create-ccs/README.md
@@ -45,3 +45,4 @@ Following inputs can be used as `step.with` keys
 | `slackChannel`              | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `token`                     | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
 | `username`                  | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |
+| `gitops`                    | Boolean | `false`                     | Whether to provide the GitOps metadata to the oblt-cli. |

--- a/.github/actions/oblt-cli-create-ccs/action.yml
+++ b/.github/actions/oblt-cli-create-ccs/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
     default: 'apmmachine'
     required: false
+  gitops:
+    description: 'Whether to provide the GitOps metadata to the oblt-cli'
+    default: false
+    required: false
 runs:
   using: "composite"
   steps:
@@ -38,13 +42,29 @@ runs:
           [ -n '${{ inputs.elasticsearch-docker-image }}' ] \
             && echo -n '--elasticsearch-docker-image=${{ inputs.elasticsearch-docker-image }} '
         } > command
-        echo "COMMAND=$(cat command)" >> $GITHUB_ENV
+        echo "GITOPS=$(cat command)" >> $GITHUB_ENV
         rm command
+      shell: bash
+
+    - name: create oblt-cli command for gitops
+      run: |
+        if [ '${{ inputs.gitops }}' == "true" ] ; then
+          {
+            echo -n '--repo=${{ github.repository }} '
+            echo -n '--comment-id=${{ github.repository }} '
+            echo -n '--commit=${{ github.repository }} '
+            echo -n '--issue=${{ github.repository }} '
+            echo -n '--pull-request=${{ github.repository }} '
+          } > command
+        fi
+        touch command
+        echo "GITOPS=$(cat command)" >> $GITHUB_ENV
+        rm gitops
       shell: bash
 
     - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@feature/oblt-cli-create-ccs-action
       with:
-        command: 'cluster create ccs ${{ env.COMMAND }}'
+        command: 'cluster create ccs ${{ env.COMMAND }} ${{ env.GITOPS }}'
         slackChannel: ${{ inputs.slackChannel }}
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
## What does this PR do?

Automatically infers when the action is triggered by:
- GitHub issue
- GitHub comment

If a GitHub issue then:
* ❗ No support for GitHub comment ID, `--comment-id` flag
* ❗ No support for GitHub commit, `--commit` flag
* ❗ No support for GItHub pull Request, `--pull-request` flag
* 💚  Support for GItHub repo, `--repo` flag
* 💚  Support for GItHub issue, `--issue` flag

If a GitHub Pull Request then:
* 💚  Support for GitHub comment ID, `--comment-id` flag
* 💚  Support for GitHub commit, `--commit` flag
* 💚  Support for GItHub pull Request, `--pull-request` flag
* ❗ No support for GItHub repo, `--repo` flag
* ❗ No support for GItHub issue, `--issue` flag

## Why is it important?

Leverage the `oblt-cli-create-ccs` to support GitOps, so consumers can get notified accordingly.