### PR TITLE
action: is-pr-author-member-elastic-org

### DIFF
--- a/.github/actions/is-pr-author-member-elastic-org/README.md
+++ b/.github/actions/is-pr-author-member-elastic-org/README.md
@@ -1,0 +1,55 @@
+## About
+
+GitHub Action to check if the PR author is member of the GitHub organization.
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+  * [outputs](#outputs)
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```yaml
+---
+name: Is PR Author member Example
+on:
+  issues:
+    types: [opened]
+jobs:
+  run-if-member:
+    name: Welcome
+    runs-on: ubuntu-latest
+    steps:
+      - id: is_pr_author_elastic_member
+        uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@current
+        with:
+          pull-request: ${{ github.event.issue.number }}
+          repository: ${{ github.repository }}
+          token: ${{ secrets.PAT_TOKEN }}
+      - if: steps.is_pr_author_elastic_member.outputs.result == true
+        run: echo 'PR author of ${{ github.event.issue.number }} is Elastic member'
+```
+
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `pull-request`    | String  |                             | The GitHub Pull Request            |
+| `repository`      | String  |                             | The GitHub repository, format: ORG/REPO |
+| `token`           | String  |                             | The GitHub token                   |
+
+### outputs
+
+| Name              | Type    | Description                 |
+|-------------------|---------| ----------------------------|
+| `result`          | Boolean | Whether the PR author is member. |

--- a/.github/actions/is-pr-author-member-elastic-org/action.yml
+++ b/.github/actions/is-pr-author-member-elastic-org/action.yml
@@ -21,7 +21,7 @@ runs:
       name: Gather PR Owner
       run: |-
         PR_AUTHOR=$(gh pr view ${{ inputs.pull-request }} --repo ${{ inputs.repository }} --json author --jq .author.login)
-        echo result=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+        echo "result=${PR_AUTHOR}" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/is-pr-author-member-elastic-org/action.yml
+++ b/.github/actions/is-pr-author-member-elastic-org/action.yml
@@ -29,5 +29,5 @@ runs:
     - id: is_elastic_pr_author
       uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
       with:
-        username: ${{ steps.gh_api_pr_author.outputs.result }}"
+        username: ${{ steps.gh_api_pr_author.outputs.result }}
         token: ${{ inputs.token }}

--- a/.github/actions/is-pr-author-member-elastic-org/action.yml
+++ b/.github/actions/is-pr-author-member-elastic-org/action.yml
@@ -1,0 +1,33 @@
+name: 'Is PR author a member of Elastic org'
+description: 'Check if a Pull Request author is member of the GitHub organization.'
+inputs:
+  pull-request:
+    description: 'The GitHub Pull Request'
+    required: true
+  repository:
+    description: 'The GitHub repository (format: ORG/REPO)'
+    required: true
+  token:
+    description: 'The GitHub access token.'
+    required: true
+outputs:
+  result:
+    description: 'The result in either true or false'
+    value: ${{ steps.is_elastic_pr_author.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - id: gh_api_pr_author
+      name: Gather PR Owner
+      run: |-
+        PR_AUTHOR=$(gh pr view ${{ inputs.pull-request }} --repo ${{ inputs.repository }} --json author --jq .author.login)
+        echo result=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+
+    - id: is_elastic_pr_author
+      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+      with:
+        username: ${{ steps.gh_api_pr_author.outputs.result }}"
+        token: ${{ inputs.token }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -16,6 +16,7 @@ on:
       - pytest_otel-build-test
       - release-drafter
       - test-is-member-elastic-org
+      - test-is-pr-author-member-elastic-org
     types: [completed]
 
 jobs:

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -2,7 +2,6 @@
 name: test-is-pr-author-member-elastic-org
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -1,0 +1,46 @@
+---
+name: test-is-pr-author-member-elastic-org
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-with-non-elastic-author:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@feature/is-per-author-elastic-member
+        id: is_pr_author_elastic_member
+        with:
+          pull-request: 1129
+          repository: 'elastic/apm-pipeline-library'
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Assert is no member
+        run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "false"
+
+  test-with-elastic-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/is-per-author-elastic-member
+        id: is_pr_author_elastic_member
+        with:
+          pull-request: 2110
+          repository: 'elastic/apm-pipeline-library'
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Assert is member
+        run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "true"

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -15,7 +15,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@feature/is-per-author-elastic-member
+      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 1129
@@ -34,7 +34,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@feature/is-per-author-elastic-member
+      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 2110

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -35,7 +35,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@feature/is-per-author-elastic-member
+      - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@feature/is-per-author-elastic-member
         id: is_pr_author_elastic_member
         with:
           pull-request: 2110


### PR DESCRIPTION
## What does this PR do?

Given a PR id, and its repository then evaluate whether its author is an Elastic member.

## Why is it important?

An action helper functional for some other consumers


## Test

See https://github.com/elastic/apm-pipeline-library/actions/runs/4286615925/jobs/7466417811