### PR TITLE
updatecli: use GITHUB_RUN_ID for the branch name

### DIFF
--- a/.ci/bump-aliases.yml
+++ b/.ci/bump-aliases.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump aliases with the elastic stack versions
+pipelineid: 'updatecli-bump-aliases-{{ requiredEnv "GITHUB_RUN_ID" }}'
 
 actions:
   default:

--- a/.ci/bump-elastic-stack.yml
+++ b/.ci/bump-elastic-stack.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump elastic stack to latest version
+pipelineid: 'updatecli-bump-elastic-stack-{{ requiredEnv "GITHUB_RUN_ID" }}'
 
 actions:
   default:

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump golang-version to latest version
+pipelineid: 'updatecli-bump-golang-{{ requiredEnv "GITHUB_RUN_ID" }}'
 
 scms:
   githubConfig:


### PR DESCRIPTION
## What does this PR do?
updatecli: use GITHUB_RUN_ID for the branch name

## Why is it important?

Avoid reusing the same branch so PRs get created for each workflow execution, then no unrequired PRs are created.
