### PR TITLE
action: migrate to observability-ci

### DIFF
--- a/.github/actions/opentelemetry/README.md
+++ b/.github/actions/opentelemetry/README.md
@@ -74,4 +74,4 @@ Following inputs can be used as `step.with` keys
 | `vaultRoleId`     | String  |                             | The Vault role id. |
 | `vaultSecretId`   | String  |                             | The Vault secret id. |
 | `vaultUrl`        | String  |                             | The Vault URL to connect to. |
-| `secret`          | String  | `secret/observability-team/ci/jenkins-logs-robots` | The Vault secret. |
+| `secret`          | String  | `secret/observability-team/ci/observability-ci/apm-credentials` | The Vault secret. |

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   secret:
     description: 'Vault secret with the apmServerOtel and apmServerToken fields.'
-    default: secret/observability-team/ci/jenkins-logs-robots
+    default: secret/observability-team/ci/observability-ci/apm-credentials
     required: false
   githubToken:
     description: 'GitHub token (it uses github.token by default)'


### PR DESCRIPTION
## What does this PR do?

Use the new secret

## Why is it important?

Elastic cloud deployment will be renamed so this will help us with the renaming

Additionally, I created the vault folder `secret/observability-team/ci/observability-ci/` so the `apm-credentials` will only contain the relevant data
