### PR TITLE
Publish jruby images in dockerhub

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -279,13 +279,13 @@ images:
     build_opts: "--build-arg NODE_VERSION=8.6"
 
   # APM Agent Ruby Docker images
-
+  # dockerhub
   - <<: *apm-agent-ruby-docker-images
     name: "apm-agent-jruby"
     working_directory: ".ci/docker/jruby"
-    build_script: "./run.sh --action build --registry ${REGISTRY}/${PREFIX}"
-    test_script: "./run.sh --action test --registry ${REGISTRY}/${PREFIX}"
-    push_script: "./run.sh --action push --registry ${REGISTRY}/${PREFIX}"
+    build_script: "./run.sh --action build --registry 'elasticobservability'"
+    test_script: "./run.sh --action test --registry 'elasticobservability'"
+    push_script: "./run.sh --action push --registry 'elasticobservability'"
 
   - <<: *apm-agent-ruby-docker-images
     tag: "ruby-3.0"

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -73,6 +73,14 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: ""
+          secret: secret/observability-team/ci/elastic-observability-dockerhub
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - name: Setup Env
         run: |
           echo "NAME=${{ matrix.name }}" >> $GITHUB_ENV

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:
-          registry: ""
+          registry: docker.io
           secret: secret/observability-team/ci/elastic-observability-dockerhub
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## What does this PR do?

- Adds the ability to push to dockerhub
- Pushes jruby images to dockerhub instead

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

This is needed to be able to run PR tests in https://github.com/elastic/apm-agent-ruby/pull/1366 without the necessity of GH secrets.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
- Depends on https://github.com/elastic/apm-agent-ruby/pull/1367
- Needed in https://github.com/elastic/apm-agent-ruby/pull/1366
