### PR TITLE
action: bump updatecli to 0.44.2

### DIFF
--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -46,7 +46,7 @@ runs:
         secret: ${{ inputs.dockerVaultSecret }}
 
     - name: Install Updatecli in the runner
-      uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+      uses: updatecli/updatecli-action@e616220e571d67e7f98a3bd63f59ab0d8eb4e124
 
     - name: Run Updatecli
       run: updatecli ${{ inputs.command }} --config ${{ inputs.pipeline }}


### PR DESCRIPTION
uses https://github.com/updatecli/updatecli-action/releases/tag/v2.21.0

## What does this PR do?

Bump updatecli version

## Why is it important?

Golang crossbuild bumps dont' work while it works locally:

```
updatecli version  

VERSION

Application:	0.44.4
Golang     :	1.20.1 linux/amd64
Build Time :	2023-02-21T06:34:45Z

```

```bash
GO_MINOR=1.20 BRANCH=main GIT_USER=victormartinezrubio@gmail.com GIT_EMAIL=victormartinezrubio@gmail.com updatecli apply --config .ci/bump-golang.yml --debug


DEBUG: Attribute `content` detected
✔ Content of the file "go/Makefile.common" (line 5) is the same as the specified content.
✔ Condition on file [] passed
	 => expected condition result true, got true

✗ condition not met, skipping pipeline

=============================

REPORTS:


- Bump golang-version to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release (kind: githubrelease)
		✔ [minor] Get minor version (kind: shell)
	Condition:
		✔ [dockerTag] Is docker image golang:1.20.1 published (kind: dockerimage)
		✗ [is] Is version '1.20.1' not updated in 'go/Makefile.common'? (kind: file)
	Target:
		- [update-go-versions] Update go versions (kind: shell)


Run Summary

```

Although I used locally `0.44.4` and this bump is for `0.44.2`, I don't see any important changes in the release notes: https://github.com/updatecli/updatecli/compare/v0.44.2...v0.44.4