### PR TITLE
action: notify when updatecli failed

### DIFF
--- a/.github/actions/updatecli/README.md
+++ b/.github/actions/updatecli/README.md
@@ -54,5 +54,7 @@ Following inputs can be used as `step.with` keys
 | `vaultSecretId`   | String  |                             | The Vault secret id. |
 | `vaultUrl`        | String  |                             | The Vault URL to connect to. |
 | `command`         | String  | `apply`                     | What updatecli command to run. |
-| `dockerRegistry`    | String  | `docker.elastic.co`         | The docker registry. |
+| `dockerRegistry`    | String  | `docker.elastic.co`       | The docker registry. |
 | `dockerVaultSecret` | String  | `secret/observability-team/ci/docker-registry/prod` | The Vault secret with the docker auth details. |
+| `notifyIfFailure`   | Boolean | `true`                    | Whether to notify if any failure while running the updatecli. |
+| `notifySlackChannel`| String  | `#observablt-bots`        | What slack channel to be used for notifying any failures while running the updatecli. |

--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: 'What updatecli command'
     default: 'apply'
     required: false
+  notifyIfFailure:
+    description: 'Whether to notify if any failure while running the updatecli'
+    default: true
+    required: false
+  notifySlackChannel:
+    description: 'What slack channel to be used for notifying any failures while running the updatecli'
+    default: '#observablt-bots'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -53,3 +61,13 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+    - if: ${{ failure() && contains(inputs.notifyIfFailure, 'true') }}
+      name: Report updatecli failure in slack
+      uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+      with:
+        url: ${{ inputs.vaultUrl }}
+        roleId: ${{ inputs.vaultRoleId }}
+        secretId: ${{ inputs.vaultSecretId }}
+        channel: ${{ inputs.notifySlackChannel }}
+        message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/test-updatecli.yml
+++ b/.github/workflows/test-updatecli.yml
@@ -1,0 +1,20 @@
+---
+name: test-updatecli1
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@main
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/file-doesnt-exist-so-it-should-fail-and-notify-error


### PR DESCRIPTION
## What does this PR do?

Notify if the `updatecli` failed with some customisation 

## Why is it important?

Proactive failure notification
