### PR TITLE
Add ability to set notification status explicitly

### DIFF
--- a/.github/actions/check-dependent-jobs/README.md
+++ b/.github/actions/check-dependent-jobs/README.md
@@ -62,3 +62,4 @@ Following inputs can be used as `step.with` keys
 | Name        | Type    | Description                        |
 |-------------|---------|------------------------------------|
 | `isSuccess` | Boolean | If all jobs are successful or not. |
+| `status`    | String  | `success` or `failure`             |

--- a/.github/actions/check-dependent-jobs/action.yml
+++ b/.github/actions/check-dependent-jobs/action.yml
@@ -9,8 +9,11 @@ inputs:
     description: needs context as JSON string
 outputs:
   isSuccess:
-    description: the evaluated result of all provided jobs in the needs context.
+    description: The evaluated result of all provided jobs in the needs context.
     value: ${{ steps.test.outputs.isSuccess }}
+  status:
+    description: One of success or failure.
+    value: ${{ steps.test.outputs.status }}
 runs:
   using: composite
   steps:

--- a/.github/actions/check-dependent-jobs/action.yml
+++ b/.github/actions/check-dependent-jobs/action.yml
@@ -18,4 +18,10 @@ runs:
       run: |
         RESULT=$(echo '${{ inputs.needs }}' | jq -s 'map(.[].result) | all(.=="success")')
         echo "isSuccess=${RESULT}" >> $GITHUB_OUTPUT
+        if [[ $RESULT == true ]]; then
+          STATUS=success
+        else
+          STATUS=failure
+        fi
+        echo "status=${STATUS}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -81,7 +81,7 @@ jobs:
         with: ${{ toJSON(needs) }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
-          status: "${{ steps.check.outputs.isSuccess ? 'success' : 'failure' }}"
+          status: "${{ steps.check.outputs.isSuccess && 'success' || 'failure' }}"
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -79,7 +79,6 @@ jobs:
       - id: check
         uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
         with: ${{ toJSON(needs) }}
-      - run: ${{ steps.check.outputs.isSuccess }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           status: "${{ steps.check.outputs.isSuccess ? 'success' : 'failure' }}"

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -82,6 +82,7 @@ jobs:
       - run: ${{ steps.check.outputs.isSuccess }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
+          status: "${{ steps.check.outputs.isSuccess ? 'success' : 'failure' }}"
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -81,7 +81,7 @@ jobs:
         with: ${{ toJSON(needs) }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
-          status: "${{ steps.check.outputs.isSuccess && 'success' || 'failure' }}"
+          status: "${{ steps.check.outputs.isSuccess == 'true' && 'success' || 'failure' }}"
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -78,10 +78,11 @@ jobs:
     steps:
       - id: check
         uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
-        with: ${{ toJSON(needs) }}
+        with:
+          needs: ${{ toJSON(needs) }}
       - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
-          status: "${{ steps.check.outputs.isSuccess == 'true' && 'success' || 'failure' }}"
+          status: ${{ steps.check.outputs.status }}
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/actions/notify-build-status/README.md
+++ b/.github/actions/notify-build-status/README.md
@@ -95,10 +95,11 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name            | Type     | Required | Description                                                   |
-|-----------------|----------|----------|---------------------------------------------------------------|
-| `vaultRoleId`   | String   | yes      | The Vault role id.                                            |
-| `vaultSecretId` | String   | yes      | The Vault secret id.                                          |
-| `vaultUrl`      | String   | yes      | The Vault URL to connect to.                                  |
-| `slackChannel`  | String   | no       | Slack channel id, channel name, or user id to post message.   |
-| `message`       | String   | no       | Add additional message to the notification.                   |
+| Name            | Type     | Required | Description                                                 |
+|-----------------|----------|----------|-------------------------------------------------------------|
+| `vaultRoleId`   | String   | yes      | The Vault role id.                                          |
+| `vaultSecretId` | String   | yes      | The Vault secret id.                                        |
+| `vaultUrl`      | String   | yes      | The Vault URL to connect to.                                |
+| `slackChannel`  | String   | no       | Slack channel id, channel name, or user id to post message. |
+| `message`       | String   | no       | Add additional message to the notification.                 |
+| `status`        | String   | no       | One of success, failure, cancelled, auto. Default: auto     |

--- a/.github/actions/notify-build-status/action.yml
+++ b/.github/actions/notify-build-status/action.yml
@@ -17,6 +17,10 @@ inputs:
   message:
     description: Add additional message
     required: false
+  status:
+    description: Explicitly set status. One of success, failure, cancelled
+    required: false
+    default: auto
 
 runs:
   using: composite
@@ -25,7 +29,7 @@ runs:
       id: prepare
       shell: python
       env:
-        JOB_STATUS: "${{ job.status }}"
+        JOB_STATUS: "${{ inputs.status != 'auto' ? inputs.status : job.status }}"
         REPO_URL: "${{ github.server_url }}/${{ github.repository }}"
         PR_NUMBER: "${{ github.event.pull_request.number }}"
         PR_SHA: "${{ github.event.pull_request.head.sha }}"
@@ -81,7 +85,7 @@ runs:
                   {
                     "title": "Status",
                     "short": true,
-                    "value": "${{ job.status }}"
+                    "value": ""${{ inputs.status != 'auto' ? inputs.status : job.status }}""
                   },
                   {
                     "title": "Event",

--- a/.github/actions/notify-build-status/action.yml
+++ b/.github/actions/notify-build-status/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Add additional message
     required: false
   status:
-    description: Explicitly set status. One of success, failure, cancelled
+    description: "Explicitly set status. One of success, failure, cancelled, auto. Default: auto"
     required: false
     default: auto
 

--- a/.github/actions/notify-build-status/action.yml
+++ b/.github/actions/notify-build-status/action.yml
@@ -29,7 +29,7 @@ runs:
       id: prepare
       shell: python
       env:
-        JOB_STATUS: "${{ inputs.status != 'auto' ? inputs.status : job.status }}"
+        JOB_STATUS: "${{ inputs.status == 'auto' && job.status || inputs.status }}"
         REPO_URL: "${{ github.server_url }}/${{ github.repository }}"
         PR_NUMBER: "${{ github.event.pull_request.number }}"
         PR_SHA: "${{ github.event.pull_request.head.sha }}"
@@ -85,7 +85,7 @@ runs:
                   {
                     "title": "Status",
                     "short": true,
-                    "value": ""${{ inputs.status != 'auto' ? inputs.status : job.status }}""
+                    "value": "${{ inputs.status == 'auto' && job.status || inputs.status }}"
                   },
                   {
                     "title": "Event",


### PR DESCRIPTION
## What does this PR do?

Add ability to set notification status explicitly for the `notify-status-build` action.

this way it can be use in conjuction with `check-dependent-job-status`

Usage:

```yaml
steps:
      - id: check
        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
        with: ${{ toJSON(needs) }}
      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
        with:
          status: ${{ steps.check.outputs.status }}
          vaultUrl: ${{ secrets.VAULT_ADDR }}
          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
          slackChannel: "#some-channel"
```
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

- Send a notifcation regardless of the `job.status`
