### PR TITLE
update golang bump to listen for new releases

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -37,7 +37,7 @@ sources:
       username: '{{ requiredEnv "GIT_USER" }}'
       versionfilter:
         kind: regex
-        pattern: go1\.18\.(\d*)$
+        pattern: go1\.(\d*)\.(\d*)$
 
 conditions:
   dockerTag:


### PR DESCRIPTION
1.18 is dead, and we can use 1.20, consumers are teh ones defining what version to be used, so we can enforce to use the latest one by default