### PR TITLE
action: deploy-my-kibana

### DIFF
--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -25,9 +25,6 @@ jobs:
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/deploy-my-kibana@current
         with:
-          githubEvent: ${{ github.event }}
-          user: ${{ github.triggering_actor }}
-          repository: ${{ github.repository }}
           vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
           vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
@@ -41,7 +38,7 @@ Following inputs can be used as `step.with` keys
 
 | Name              | Type    | Default                         | Description                        |
 |-------------------|---------|---------------------------------|------------------------------------|
-| `githubEvent`     | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
+| `event`           | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
 | `user`            | String  | `${{ github.triggering_actor }}`| The GitHub user avatar           |
 | `repository`      | String  | `${{ github.repository }}`      | The GitHub repository, ORG/REPO. |
 | `vaultRoleId`     | String  |                                 | The Vault role id. |

--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -1,0 +1,49 @@
+## About
+
+GitHub Action to deploy my kibana process
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```yaml
+---
+name: Create cluster using the oblt-cli
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  deploy-my-kibana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/deploy-my-kibana@current
+        with:
+          event: ${{ github.event }}
+          user: ${{ github.triggering_actor }}
+          repository: ${{ github.repository }}
+          vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+```
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                         | Description                        |
+|-------------------|---------|---------------------------------|------------------------------------|
+| `event`           | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
+| `user`            | String  | `${{ github.triggering_actor }}`| The GitHub user avatar           |
+| `repository`      | String  | `${{ github.repository }}`      | The GitHub repository, ORG/REPO. |
+| `vaultRoleId`     | String  |                                 | The Vault role id. |
+| `vaultSecretId`   | String  |                                 | The Vault secret id. |
+| `vaultUrl`        | String  |                                 | The Vault URL to connect to. |

--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/deploy-my-kibana@current
         with:
-          event: ${{ github.event }}
+          githubEvent: ${{ github.event }}
           user: ${{ github.triggering_actor }}
           repository: ${{ github.repository }}
           vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
@@ -41,7 +41,7 @@ Following inputs can be used as `step.with` keys
 
 | Name              | Type    | Default                         | Description                        |
 |-------------------|---------|---------------------------------|------------------------------------|
-| `event`           | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
+| `githubEvent`     | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
 | `user`            | String  | `${{ github.triggering_actor }}`| The GitHub user avatar           |
 | `repository`      | String  | `${{ github.repository }}`      | The GitHub repository, ORG/REPO. |
 | `vaultRoleId`     | String  |                                 | The Vault role id. |

--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -36,11 +36,13 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name              | Type    | Default                         | Description                        |
-|-------------------|---------|---------------------------------|------------------------------------|
-| `event`           | String  | `${{ github.event }}`           | The GitHub event payload. Json.  |
-| `user`            | String  | `${{ github.triggering_actor }}`| The GitHub user avatar           |
-| `repository`      | String  | `${{ github.repository }}`      | The GitHub repository, ORG/REPO. |
-| `vaultRoleId`     | String  |                                 | The Vault role id. |
-| `vaultSecretId`   | String  |                                 | The Vault secret id. |
-| `vaultUrl`        | String  |                                 | The Vault URL to connect to. |
+| Name              | Type    | Default                                | Description                        |
+|-------------------|---------|----------------------------------------|------------------------------------|
+| `issue_url`       | String  | `${{ github.event.comment.issue_url }}`| The GitHub issue URL.  |
+| `comment_url`     | String  | `${{ github.event.comment.html_url }}` | The GitHub comment URL.  |
+| `comment_id`      | String  | `${{ github.event.comment.id }}`       | The GitHub comment ID.  |
+| `user`            | String  | `${{ github.triggering_actor }}`       | The GitHub user avatar           |
+| `repository`      | String  | `${{ github.repository }}`             | The GitHub repository, ORG/REPO. |
+| `vaultRoleId`     | String  |                                        | The Vault role id. |
+| `vaultSecretId`   | String  |                                        | The Vault secret id. |
+| `vaultUrl`        | String  |                                        | The Vault URL to connect to. |

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -10,15 +10,15 @@ inputs:
   vaultSecretId:
     description: 'Vault secret ID'
     required: true
-  event:
+  githubEvent:
     description: 'The GitHub event payload. JSON'
-    required: true
+    default: ${{ github.event }}
   user:
     description: 'The GitHub user that triggered the workflow'
-    required: true
+    default: ${{ github.triggering_actor }}
   repository:
     description: 'The GitHub repository'
-    required: true
+    default: ${{ github.repository }}
 runs:
   using: "composite"
   steps:
@@ -31,7 +31,7 @@ runs:
     - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.event.comment.id }}
+        commentId: ${{ inputs.githubEvent.comment.id }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Is an Elastician comment?
@@ -46,7 +46,7 @@ runs:
       run: |-
         # issue_comment does not contain any references to the original PR so it's requires
         # to parse github.event.comment.issue_url
-        PR=$(basename ${{ inputs.event.comment.issue_url }})
+        PR=$(basename ${{ inputs.githubEvent.comment.issue_url }})
         echo "PR=${PR}" >> $GITHUB_ENV
 
         # issue_comment does not contain any references to github.base_ref
@@ -82,7 +82,7 @@ runs:
 
         ### Further details
 
-        Caused by @${{ inputs.user }} in ${{ inputs.event.comment.html_url }}
+        Caused by @${{ inputs.user }} in ${{ inputs.githubEvent.comment.html_url }}
         EOT
       shell: bash
 
@@ -106,6 +106,6 @@ runs:
       if: contains(steps.is_elastic_member.outputs.result, 'false')
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.event.comment.id }}
+        commentId: ${{ inputs.githubEvent.comment.id }}
         emoji: '-1'
         token: ${{ env.GITHUB_TOKEN }}

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -34,8 +34,16 @@ runs:
         commentId: ${{ event.comment.id }}
         token: ${{ env.GITHUB_TOKEN }}
 
+    - name: Is an Elastician comment?
+      id: is_elastic_member
+      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
+      with:
+        username: ${{ github.event.issue.user.login }}
+        token: ${{ env.GITHUB_TOKEN }}
+
     ### TODO: From cluster need to know the version based on the target branch
     - name: Create github issue body
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |-
         cat <<EOT >> .body-content
         ### From cluster
@@ -52,7 +60,7 @@ runs:
 
         ### Oblt-cli user (Optional)
 
-        deploykibana
+        ${{ github.event.issue.user.login }}
 
         ### further details
 
@@ -62,6 +70,7 @@ runs:
 
     ### TODO: gather the http url so it can be reported back to the GitHub comment
     - name: Create github issue for the deploy-my-kibana
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |
         gh issue \
           create \
@@ -73,3 +82,12 @@ runs:
       env:
         GH_TOKEN: ${{ env.GITHUB_TOKEN }}
       shell: bash
+
+    - name: Notify with a reaction if a non-elastician comment
+      uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
+      if: contains(steps.is_elastic_member.outputs.result, 'false')
+      with:
+        repository: ${{ inputs.repository }}
+        commentId: ${{ event.comment.id }}
+        emoji: '-1'
+        token: ${{ env.GITHUB_TOKEN }}

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -71,9 +71,9 @@ runs:
 
         ${{ github.event.issue.user.login }}
 
-        ### further details
+        ### Further details
 
-        Created by a GitHub command in the project https://github.com/${{ inputs.repository }}/pulls/${{ event.pull_request.number }}
+        Caused by @${{ github.event.issue.user.login }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
         EOT
       shell: bash
 

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -81,6 +81,8 @@ runs:
     - name: Create github issue for the deploy-my-kibana
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |
+        cat .body-content
+        exit 0
         gh issue \
           create \
           --label 'deploy-custom-kibana' \

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -31,14 +31,14 @@ runs:
     - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ event.comment.id }}
+        commentId: ${{ inputs.event.comment.id }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Is an Elastician comment?
       id: is_elastic_member
       uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
       with:
-        username: ${{ github.event.issue.user.login }}
+        username: ${{ inputs.event.issue.user.login }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Get cluster given the target branch (either edge-lite or release)
@@ -61,7 +61,7 @@ runs:
 
         ### Kibana branch
 
-        pr/${{ event.pull_request.number }}
+        pr/${{ inputs.event.pull_request.number }}
 
         ### Custom prefix (Optional)
 
@@ -69,11 +69,11 @@ runs:
 
         ### Oblt-cli user (Optional)
 
-        ${{ github.event.issue.user.login }}
+        ${{ inputs.event.issue.user.login }}
 
         ### Further details
 
-        Caused by @${{ github.event.issue.user.login }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
+        Caused by @${{ inputs.event.issue.user.login }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
         EOT
       shell: bash
 
@@ -99,6 +99,6 @@ runs:
       if: contains(steps.is_elastic_member.outputs.result, 'false')
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ event.comment.id }}
+        commentId: ${{ inputs.event.comment.id }}
         emoji: '-1'
         token: ${{ env.GITHUB_TOKEN }}

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -38,7 +38,7 @@ runs:
       id: is_elastic_member
       uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
       with:
-        username: ${{ inputs.event.issue.user.login }}
+        username: ${{ inputs.user }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Get cluster given the target branch (either edge-lite or release)
@@ -69,11 +69,11 @@ runs:
 
         ### Oblt-cli user (Optional)
 
-        ${{ inputs.event.issue.user.login }}
+        ${{ inputs.user }}
 
         ### Further details
 
-        Caused by @${{ inputs.event.issue.user.login }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
+        Caused by @${{ inputs.user }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
         EOT
       shell: bash
 

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -1,0 +1,75 @@
+name: 'Oblt-cli wrapper'
+description: 'Run the oblt-cli wrapper.'
+inputs:
+  vaultUrl:
+    description: 'Vault URL'
+    required: true
+  vaultRoleId:
+    description: 'Vault role ID'
+    required: true
+  vaultSecretId:
+    description: 'Vault secret ID'
+    required: true
+  event:
+    description: 'The GitHub event payload. JSON'
+    required: true
+  user:
+    description: 'The GitHub user that triggered the workflow'
+    required: true
+  repository:
+    description: 'The GitHub repository'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      with:
+        url: ${{ inputs.vaultUrl }}
+        roleId: ${{ inputs.vaultRoleId }}
+        secretId: ${{ inputs.vaultSecretId }}
+
+    - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
+      with:
+        repository: ${{ inputs.repository }}
+        commentId: ${{ event.comment.id }}
+        token: ${{ env.GITHUB_TOKEN }}
+
+    ### TODO: From cluster need to know the version based on the target branch
+    - name: Create github issue body
+      run: |-
+        cat <<EOT >> .body-content
+        ### From cluster
+
+        release-oblt
+
+        ### Kibana branch
+
+        pr/${{ event.pull_request.number}}
+
+        ### Custom prefix (Optional)
+
+        _No response_
+
+        ### Oblt-cli user (Optional)
+
+        deploykibana
+
+        ### further details
+
+        Created by a GitHub command in the project TBC
+        EOT
+      shell: bash
+
+    ### TODO: gather the http url so it can be reported back to the GitHub comment
+    - name: Create github issue for the deploy-my-kibana
+      run: |
+        gh issue \
+          create \
+          --label 'deploy-custom-kibana' \
+          --title "[Deploy Kibana]: for user ${{ inputs.user }}" \
+          --assignee ${{ inputs.user }} \
+          --body-file .body-content \
+          --repo elastic/observability-robots-automation
+      env:
+        GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+      shell: bash

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -41,18 +41,27 @@ runs:
         username: ${{ github.event.issue.user.login }}
         token: ${{ env.GITHUB_TOKEN }}
 
-    ### TODO: From cluster need to know the version based on the target branch
+    - name: Get cluster given the target branch (either edge-lite or release)
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: |-
+        if [ "${{ github.base_ref }}" == 'main' ] ; then
+          echo "CLUSTER=edge-lite-oblt" >> $GITHUB_ENV
+        else
+          echo "CLUSTER=release-oblt" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Create github issue body
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |-
         cat <<EOT >> .body-content
         ### From cluster
 
-        release-oblt
+        ${{ env.CLUSTER }}
 
         ### Kibana branch
 
-        pr/${{ event.pull_request.number}}
+        pr/${{ event.pull_request.number }}
 
         ### Custom prefix (Optional)
 
@@ -64,7 +73,7 @@ runs:
 
         ### further details
 
-        Created by a GitHub command in the project TBC
+        Created by a GitHub command in the project https://github.com/${{ inputs.repository }}/pulls/${{ event.pull_request.number }}
         EOT
       shell: bash
 

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -13,6 +13,15 @@ inputs:
   event:
     description: 'The GitHub event payload. JSON'
     default: ${{ github.event }}
+  issue_url:
+    description: 'The GitHub Issue URL'
+    required: true
+  comment_url:
+    description: 'The GitHub Comment URL'
+    required: true
+  comment_id:
+    description: 'The GitHub Comment ID'
+    required: true
   user:
     description: 'The GitHub user that triggered the workflow'
     default: ${{ github.triggering_actor }}
@@ -31,7 +40,7 @@ runs:
     - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.event.comment.id }}
+        commentId: ${{ inputs.comment_id }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Is an Elastician comment?
@@ -44,9 +53,7 @@ runs:
     - name: Get cluster given the target branch (either edge-lite or release)
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |-
-        # issue_comment does not contain any references to the original PR so it's requires
-        # to parse github.event.comment.issue_url
-        PR=$(basename ${{ inputs.event.comment.issue_url }})
+        PR=$(basename ${{ inputs.issue_url }})
         echo "PR=${PR}" >> $GITHUB_ENV
 
         # issue_comment does not contain any references to github.base_ref
@@ -82,7 +89,7 @@ runs:
 
         ### Further details
 
-        Caused by @${{ inputs.user }} in ${{ inputs.event.comment.html_url }}
+        Caused by @${{ inputs.user }} in ${{ inputs.comment_url }}
         EOT
       shell: bash
 
@@ -106,6 +113,6 @@ runs:
       if: contains(steps.is_elastic_member.outputs.result, 'false')
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.event.comment.id }}
+        commentId: ${{ inputs.comment_id }}
         emoji: '-1'
         token: ${{ env.GITHUB_TOKEN }}

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -1,5 +1,5 @@
-name: 'Oblt-cli wrapper'
-description: 'Run the oblt-cli wrapper.'
+name: 'Deploy My Kibana'
+description: 'GitHub Action to deploy my kibana given the Pull Request'
 inputs:
   vaultUrl:
     description: 'Vault URL'
@@ -44,12 +44,21 @@ runs:
     - name: Get cluster given the target branch (either edge-lite or release)
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |-
-        if [ "${{ github.base_ref }}" == 'main' ] ; then
+        # issue_comment does not contain any references to the original PR so it's requires
+        # to parse github.event.comment.issue_url
+        PR=$(basename ${{ inputs.event.comment.issue_url }})
+        echo "PR=${PR}" >> $GITHUB_ENV
+
+        # issue_comment does not contain any references to github.base_ref
+        TARGET_BRANCH=$(gh pr view ${PR} --repo ${{ inputs.repository }} --json baseRefName --jq .baseRefName)
+        if [ "${TARGET_BRANCH}" == 'main' ] ; then
           echo "CLUSTER=edge-lite-oblt" >> $GITHUB_ENV
         else
           echo "CLUSTER=release-oblt" >> $GITHUB_ENV
         fi
       shell: bash
+      env:
+        GH_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     - name: Create github issue body
       if: contains(steps.is_elastic_member.outputs.result, 'true')
@@ -61,7 +70,7 @@ runs:
 
         ### Kibana branch
 
-        pr/${{ inputs.event.pull_request.number }}
+        pr/${{ env.PR }}
 
         ### Custom prefix (Optional)
 
@@ -73,23 +82,21 @@ runs:
 
         ### Further details
 
-        Caused by @${{ inputs.user }} with the GitHub command `${{ inputs.event.comment.body }}` in ${{ inputs.event.comment.html_url }}
+        Caused by @${{ inputs.user }} in ${{ inputs.event.comment.html_url }}
         EOT
       shell: bash
 
-    ### TODO: gather the http url so it can be reported back to the GitHub comment
     - name: Create github issue for the deploy-my-kibana
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |
-        cat .body-content
-        exit 0
         gh issue \
           create \
           --label 'deploy-custom-kibana' \
           --title "[Deploy Kibana]: for user ${{ inputs.user }}" \
           --assignee ${{ inputs.user }} \
           --body-file .body-content \
-          --repo elastic/observability-robots-automation
+          --repo elastic/observability-test-environments | tee .issue
+        echo "ISSUE=$(cat .issue)" >> $GITHUB_ENV
       env:
         GH_TOKEN: ${{ env.GITHUB_TOKEN }}
       shell: bash

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -10,24 +10,21 @@ inputs:
   vaultSecretId:
     description: 'Vault secret ID'
     required: true
-  event:
-    description: 'The GitHub event payload. JSON'
-    default: ${{ github.event }}
-  issue_url:
-    description: 'The GitHub Issue URL'
-    required: true
   comment_url:
     description: 'The GitHub Comment URL'
-    required: true
+    default: ${{ github.event.comment.html_url }}
   comment_id:
     description: 'The GitHub Comment ID'
-    required: true
-  user:
-    description: 'The GitHub user that triggered the workflow'
-    default: ${{ github.triggering_actor }}
+    default: ${{ github.event.comment.id }}
+  issue_url:
+    description: 'The GitHub Issue URL'
+    default: ${{ github.event.comment.issue_url }}
   repository:
     description: 'The GitHub repository'
     default: ${{ github.repository }}
+  user:
+    description: 'The GitHub user that triggered the workflow'
+    default: ${{ github.triggering_actor }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -10,7 +10,7 @@ inputs:
   vaultSecretId:
     description: 'Vault secret ID'
     required: true
-  githubEvent:
+  event:
     description: 'The GitHub event payload. JSON'
     default: ${{ github.event }}
   user:
@@ -31,7 +31,7 @@ runs:
     - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@current
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.githubEvent.comment.id }}
+        commentId: ${{ inputs.event.comment.id }}
         token: ${{ env.GITHUB_TOKEN }}
 
     - name: Is an Elastician comment?
@@ -46,7 +46,7 @@ runs:
       run: |-
         # issue_comment does not contain any references to the original PR so it's requires
         # to parse github.event.comment.issue_url
-        PR=$(basename ${{ inputs.githubEvent.comment.issue_url }})
+        PR=$(basename ${{ inputs.event.comment.issue_url }})
         echo "PR=${PR}" >> $GITHUB_ENV
 
         # issue_comment does not contain any references to github.base_ref
@@ -82,7 +82,7 @@ runs:
 
         ### Further details
 
-        Caused by @${{ inputs.user }} in ${{ inputs.githubEvent.comment.html_url }}
+        Caused by @${{ inputs.user }} in ${{ inputs.event.comment.html_url }}
         EOT
       shell: bash
 
@@ -106,6 +106,6 @@ runs:
       if: contains(steps.is_elastic_member.outputs.result, 'false')
       with:
         repository: ${{ inputs.repository }}
-        commentId: ${{ inputs.githubEvent.comment.id }}
+        commentId: ${{ inputs.event.comment.id }}
         emoji: '-1'
         token: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Support the deploy-my-kibana composite action that can request a new deployment using the GitHub issues automation

## Why is it important?

Entrypoint for the consumers that use GitHub commands to deploy a particular Kibana instance using the Oblt Test environments

## Task

- [x] Detect PR number
- [x] Support for elastic members only
- [x] Use defaults
- [x] Get cluster template