### PR TITLE
chore: upgrade github action vault

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -49,7 +49,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-      - uses: hashicorp/vault-action@v2.4.2
+      - uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ inputs.vaultUrl }}
           roleId: ${{ inputs.vaultRoleId }}

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -23,7 +23,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: hashicorp/vault-action@v2.4.2
+    - uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ inputs.url }}
         roleId: ${{ inputs.roleId }}

--- a/.github/actions/github-token/action.yml
+++ b/.github/actions/github-token/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     # FIXME we need a GitHub APP with enough permissions.
-    # - uses: hashicorp/vault-action@v2.4.2
+    # - uses: hashicorp/vault-action@v2.5.0
     #   with:
     #     url: ${{ inputs.url }}
     #     roleId: ${{ inputs.roleId }}
@@ -50,7 +50,7 @@ runs:
     #       echo "GIT_USER=apmmachine" >> $GITHUB_ENV
     #       echo "GIT_EMAIL=apmmachine@users.noreply.github.com" >> $GITHUB_ENV
 
-    - uses: hashicorp/vault-action@v2.4.2
+    - uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ inputs.url }}
         roleId: ${{ inputs.roleId }}

--- a/.github/actions/opentelemetry/action.yml
+++ b/.github/actions/opentelemetry/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: hashicorp/vault-action@v2.4.2
+    - uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ inputs.vaultUrl }}
         roleId: ${{ inputs.vaultRoleId }}

--- a/.github/actions/publish-report/action.yml
+++ b/.github/actions/publish-report/action.yml
@@ -70,7 +70,7 @@ runs:
         result-encoding: string
 
     - name: 'Get service account'
-      uses: hashicorp/vault-action@v2.4.2
+      uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ inputs.vaultUrl }}
         roleId: ${{ inputs.vaultRoleId }}

--- a/.github/actions/setup-vault-cli/action.yml
+++ b/.github/actions/setup-vault-cli/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - uses: hashicorp/vault-action@v2.4.2
+      - uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ inputs.url }}
           roleId: ${{ inputs.roleId }}

--- a/.github/actions/slack-message/action.yml
+++ b/.github/actions/slack-message/action.yml
@@ -44,7 +44,7 @@ runs:
   using: "composite"
   steps:
     - name: Get the Slack token from Vault
-      uses: hashicorp/vault-action@v2.4.2
+      uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ inputs.url }}
         roleId: ${{ inputs.roleId }}


### PR DESCRIPTION
## What does this PR do?

* Update github action vault version to 2.5.0

## Why is it important?

* Version prior 2.4.3 use deprecated [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) command. 

