### PR TITLE
snapshoty: change license to apache-2.0

### DIFF
--- a/.github/actions/snapshoty/package.json
+++ b/.github/actions/snapshoty/package.json
@@ -15,7 +15,7 @@
     "JavaScript"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.0.1"


### PR DESCRIPTION
## What does this PR do?

* Change snapshoty license to Apache-2.0

## Why is it important?

* The project is under Apache-2.0.
* Avoid mixed licenses.

## Related issues
Closes #2038
