### PR TITLE
Add setup-npmrc action

### DIFF
--- a/.github/actions/setup-npmrc/README.md
+++ b/.github/actions/setup-npmrc/README.md
@@ -49,5 +49,5 @@ Following inputs can be used as `step.with` keys
 | `secret`        | String | `secret/apm-team/ci/elastic-observability-npmjs` | The Vault secret.                               |
 | `secretKey`     | String | `token`                                          | The Vault secret key.                           |
 | `registry`      | String | `registry.npmjs.org`                             | NPM Registry.                                   |
-| `npmrcfile`     | String | `.npmrc`                                         | Name of the file with the token.                |
+| `npmrcFile`     | String | `.npmrc`                                         | Name of the file with the token.                |
 | `path`          | String | `.`                                              | Folder where the `.npmrc` file will be created. |

--- a/.github/actions/setup-npmrc/README.md
+++ b/.github/actions/setup-npmrc/README.md
@@ -1,0 +1,55 @@
+## About
+
+Set up an .npmrc file for npm registry operations.
+
+* [Usage](#usage)
+    * [Configuration](#configuration)
+* [Customizing](#customizing)
+    * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+```yaml
+---
+name: Example
+
+on:
+  pull_request: ~
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - uses: elastic/apm-pipeline-library/.github/actions/setup-npmrc@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+```
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name            | Type   | Default                                          | Description                                     |
+|-----------------|--------|--------------------------------------------------|-------------------------------------------------|
+| `vaultRoleId`   | String |                                                  | The Vault role id.                              |
+| `vaultSecretId` | String |                                                  | The Vault secret id.                            |
+| `vaultUrl`      | String |                                                  | The Vault URL to connect to.                    |
+| `secret`        | String | `secret/apm-team/ci/elastic-observability-npmjs` | The Vault secret.                               |
+| `secretKey`     | String | `token`                                          | The Vault secret key.                           |
+| `registry`      | String | `registry.npmjs.org`                             | NPM Registry.                                   |
+| `npmrcfile`     | String | `.npmrc`                                         | Name of the file with the token.                |
+| `path`          | String | `.`                                              | Folder where the `.npmrc` file will be created. |

--- a/.github/actions/setup-npmrc/README.md
+++ b/.github/actions/setup-npmrc/README.md
@@ -32,9 +32,7 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish
+      - run: npm whoami
 ```
 
 ## Customizing

--- a/.github/actions/setup-npmrc/README.md
+++ b/.github/actions/setup-npmrc/README.md
@@ -29,9 +29,9 @@ jobs:
           node-version-file: .nvmrc
       - uses: elastic/apm-pipeline-library/.github/actions/setup-npmrc@current
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: npm whoami
 ```
 
@@ -43,11 +43,11 @@ Following inputs can be used as `step.with` keys
 
 | Name            | Type   | Default                                          | Description                                     |
 |-----------------|--------|--------------------------------------------------|-------------------------------------------------|
-| `vaultRoleId`   | String |                                                  | The Vault role id.                              |
-| `vaultSecretId` | String |                                                  | The Vault secret id.                            |
-| `vaultUrl`      | String |                                                  | The Vault URL to connect to.                    |
+| `vault-role-id`   | String |                                                  | The Vault role id.                              |
+| `vault-secret-id` | String |                                                  | The Vault secret id.                            |
+| `vault-url`      | String |                                                  | The Vault URL to connect to.                    |
 | `secret`        | String | `secret/apm-team/ci/elastic-observability-npmjs` | The Vault secret.                               |
-| `secretKey`     | String | `token`                                          | The Vault secret key.                           |
+| `secret-key`     | String | `token`                                          | The Vault secret key.                           |
 | `registry`      | String | `registry.npmjs.org`                             | NPM Registry.                                   |
-| `npmrcFile`     | String | `.npmrc`                                         | Name of the file with the token.                |
+| `npmrc-file`     | String | `.npmrc`                                         | Name of the file with the token.                |
 | `path`          | String | `.`                                              | Folder where the `.npmrc` file will be created. |

--- a/.github/actions/setup-npmrc/action.yml
+++ b/.github/actions/setup-npmrc/action.yml
@@ -3,20 +3,20 @@ name: setup-npmrc
 description: Creates an .npmrc file given a Vault secret.
 
 inputs:
-  vaultUrl:
+  vault-url:
     description: 'Vault URL'
     required: true
-  vaultRoleId:
+  vault-role-id:
     description: 'Vault role ID'
     required: true
-  vaultSecretId:
+  vault-secret-id:
     description: 'Vault secret ID'
     required: true
   secret:
     description: 'Vault secret with the token field. (Optional. Default: secret/apm-team/ci/elastic-observability-npmjs)'
     default: secret/apm-team/ci/elastic-observability-npmjs
     required: false
-  secretKey:
+  secret-key:
     description: 'Vault secret key. (Optional. Default: token)'
     default: token
     required: false
@@ -24,7 +24,7 @@ inputs:
     description: 'NPM registry. (Optional. Default: registry.npmjs.org)'
     default: registry.npmjs.org
     required: false
-  npmrcFile:
+  npmrc-file:
     description: 'Name of the file with the token. (Optional. Default: .npmrc)'
     default: .npmrc
     required: false
@@ -37,12 +37,12 @@ runs:
   steps:
     - uses: hashicorp/vault-action@v2.5.0
       with:
-        url: ${{ inputs.vaultUrl }}
-        roleId: ${{ inputs.vaultRoleId }}
-        secretId: ${{ inputs.vaultSecretId }}
+        url: ${{ inputs.vault-url }}
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
         method: approle
         secrets: |
-          ${{ inputs.secret }} ${{ inputs.secretKey }} | NPM_TOKEN
+          ${{ inputs.secret }} ${{ inputs.secret-key }} | NPM_TOKEN
     - run: |
-        echo "//${{ inputs.registry }}/:_authToken=${NPM_TOKEN}" > "${{ inputs.path }}/${{ inputs.npmrcFile }}"
+        echo "//${{ inputs.registry }}/:_authToken=${NPM_TOKEN}" > "${{ inputs.path }}/${{ inputs.npmrc-file }}"
       shell: bash

--- a/.github/actions/setup-npmrc/action.yml
+++ b/.github/actions/setup-npmrc/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'NPM registry. (Optional. Default: registry.npmjs.org)'
     default: registry.npmjs.org
     required: false
-  npmrcfile:
+  npmrcFile:
     description: 'Name of the file with the token. (Optional. Default: .npmrc)'
     default: .npmrc
     required: false
@@ -44,5 +44,5 @@ runs:
         secrets: |
           ${{ inputs.secret }} ${{ inputs.secretKey }} | NPM_TOKEN
     - run: |
-        echo "//${{ inputs.registry }}/:_authToken=${NPM_TOKEN}" > "${{ inputs.path }}/${{ inputs.npmrcfile }}"
+        echo "//${{ inputs.registry }}/:_authToken=${NPM_TOKEN}" > "${{ inputs.path }}/${{ inputs.npmrcFile }}"
       shell: bash

--- a/.github/actions/setup-npmrc/action.yml
+++ b/.github/actions/setup-npmrc/action.yml
@@ -1,0 +1,48 @@
+name: setup-npmrc
+
+description: Creates an .npmrc file given a Vault secret.
+
+inputs:
+  vaultUrl:
+    description: 'Vault URL'
+    required: true
+  vaultRoleId:
+    description: 'Vault role ID'
+    required: true
+  vaultSecretId:
+    description: 'Vault secret ID'
+    required: true
+  secret:
+    description: 'Vault secret with the token field. (Optional. Default: secret/apm-team/ci/elastic-observability-npmjs)'
+    default: secret/apm-team/ci/elastic-observability-npmjs
+    required: false
+  secretKey:
+    description: 'Vault secret key. (Optional. Default: token)'
+    default: token
+    required: false
+  registry:
+    description: 'NPM registry. (Optional. Default: registry.npmjs.org)'
+    default: registry.npmjs.org
+    required: false
+  npmrcfile:
+    description: 'Name of the file with the token. (Optional. Default: .npmrc)'
+    default: .npmrc
+    required: false
+  path:
+    description: 'Folder where the .npmrc file will be created. (Optional. Default: .)'
+    default: .
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ inputs.vaultUrl }}
+        roleId: ${{ inputs.vaultRoleId }}
+        secretId: ${{ inputs.vaultSecretId }}
+        method: approle
+        secrets: |
+          ${{ inputs.secret }} ${{ inputs.secretKey }} | NPM_TOKEN
+    - run: |
+        echo "//${{ inputs.registry }}/:_authToken=${NPM_TOKEN}" > "${{ inputs.path }}/${{ inputs.npmrcfile }}"
+      shell: bash


### PR DESCRIPTION
## What does this PR do?

- Creates a GH Action named `setup-npmrc`, similarly to `withNpmrc` Jenkins Global Variable.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

- Can be used in GH Actions workflows with npm registry operations like publishing, etc.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
