### PR TITLE
Publish apm-agent-python docker images in dockerhub

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -17,7 +17,7 @@ templates:
     repository: "elastic/apm-agent-python"
     working_directory: "tests"
     build_script: docker build --build-arg PYTHON_IMAGE=${TAG/-/:} -t elasticobservability/apm-agent-python:${TAG} .
-    push_script: docker push elasticobservability/apm-agent-python:${TAG} .
+    push_script: docker push elasticobservability/apm-agent-python:${TAG}
 
   - &apm-agent-nodejs-docker-images
     name: "apm-agent-nodejs"

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -12,13 +12,6 @@ templates:
   - &opbeans-docker-images
     tag: "daily"
 
-  - &apm-agent-python-docker-images
-    name: "apm-agent-python"
-    repository: "elastic/apm-agent-python"
-    working_directory: "tests"
-    build_script: docker build --build-arg PYTHON_IMAGE=${TAG/-/:} -t elasticobservability/apm-agent-python:${TAG} .
-    push_script: docker push elasticobservability/apm-agent-python:${TAG}
-
   - &apm-agent-nodejs-docker-images
     name: "apm-agent-nodejs"
     repository: "elastic/apm-agent-nodejs"
@@ -209,25 +202,12 @@ images:
     test_script: "make simple-test-${NAME}"
 
   # APM Agent Python Docker Images
-  # Taken from https://github.com/elastic/apm-agent-python/blob/main/.ci/.matrix_python_full.yml
 
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.6"
-
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.7"
-
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.8"
-
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.9"
-
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.10"
-
-  - <<: *apm-agent-python-docker-images
-    tag: "python-3.11"
+  - name: "apm-agent-python-testing"
+    repository: "elastic/apm-agent-python"
+    working_directory: .ci/docker
+    build_script: ./util --action build
+    push_script: ./util --action push
 
   # APM Agent Node.js Docker Images
 

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -16,6 +16,8 @@ templates:
     name: "apm-agent-python"
     repository: "elastic/apm-agent-python"
     working_directory: "tests"
+    build_script: docker build --build-arg PYTHON_IMAGE=${TAG/-/:} -t elasticobservability/apm-agent-python:${TAG} .
+    push_script: docker push elasticobservability/apm-agent-python:${TAG} .
 
   - &apm-agent-nodejs-docker-images
     name: "apm-agent-nodejs"
@@ -207,30 +209,25 @@ images:
     test_script: "make simple-test-${NAME}"
 
   # APM Agent Python Docker Images
+  # Taken from https://github.com/elastic/apm-agent-python/blob/main/.ci/.matrix_python_full.yml
 
   - <<: *apm-agent-python-docker-images
     tag: "python-3.6"
-    build_opts: "--build-arg PYTHON_IMAGE=python:3.6"
 
   - <<: *apm-agent-python-docker-images
     tag: "python-3.7"
-    build_opts: "--build-arg PYTHON_IMAGE=python:3.7"
 
   - <<: *apm-agent-python-docker-images
     tag: "python-3.8"
-    build_opts: "--build-arg PYTHON_IMAGE=python:3.8"
 
   - <<: *apm-agent-python-docker-images
     tag: "python-3.9"
-    build_opts: "--build-arg PYTHON_IMAGE=python:3.9"
 
   - <<: *apm-agent-python-docker-images
-    tag: "python-3.10-rc"
-    build_opts: "--build-arg PYTHON_IMAGE=python:3.10-rc"
+    tag: "python-3.10"
 
   - <<: *apm-agent-python-docker-images
-    tag: "pypy-3"
-    build_opts: "--build-arg PYTHON_IMAGE=pypy:3"
+    tag: "python-3.11"
 
   # APM Agent Node.js Docker Images
 


### PR DESCRIPTION
## What does this PR do?

Publishes apm-agent-python docker images for testing in dockerhub so it can be accessed publicly in GH Actions workflows.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

Optimizes the test time

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related Issues
- depends on https://github.com/elastic/apm-agent-python/pull/1794
