### PR TITLE
action: jenkins build

### DIFF
--- a/.github/actions/jenkins-build/README.md
+++ b/.github/actions/jenkins-build/README.md
@@ -1,0 +1,64 @@
+## About
+
+GitHub Action to run a Jenkins job using Vault
+
+___
+
+* [Usage](#usage)
+  * [Configuration](#configuration)
+* [Customizing](#customizing)
+  * [inputs](#inputs)
+
+## Usage
+
+### Configuration
+
+
+```yaml
+---
+name: Run In Jenkins
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types: [ completed ]
+
+jobs:
+  build-sign:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Run Jenkins job
+        uses: elastic/apm-pipeline-library/.github/actions/jenkins-build@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          jenkins-url: https://beats-ci.elastic.co
+          jenkins-job: observability-release-helm
+          build-params: |
+            param1=ACME
+            param2=BOB
+            something=my super duper variable
+
+```
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name              | Type    | Default                     | Description                        |
+|-------------------|---------|-----------------------------|------------------------------------|
+| `vaultRoleId`     | String  |                             | The Vault role id. |
+| `vaultSecretId`   | String  |                             | The Vault secret id. |
+| `vaultUrl`        | String  |                             | The Vault URL to connect to. |
+| `secret`          | String  | `secret/observability-team/ci/internal-ci-automation` | The Vault secret. |
+| `jenkins-url`     | String  |                             | The Jenkins base URL. |
+| `jenkins-job`     | String  |                             | The Jenkins job to interact with. |
+| `waitFor`         | boolean | `false`                     | Whether to wait for the build to finish. |
+| `printBuildLogs`  | boolean | `false`                     | Whether to print the build logs. |
+| `build-params`    | String  |                             | Specify the build parameters  in KEY=VALUE format. No double quoting or extra `=` |

--- a/.github/actions/jenkins-build/action.yml
+++ b/.github/actions/jenkins-build/action.yml
@@ -1,0 +1,57 @@
+---
+name: Jenkins job GitHub Action
+description: A GitHub Action for triggering a build on a Jenkins job.
+inputs:
+  vaultUrl:
+    description: 'Vault URL'
+    required: true
+  vaultRoleId:
+    description: 'Vault role ID'
+    required: true
+  vaultSecretId:
+    description: 'Vault secret ID'
+    required: true
+  secret:
+    description: 'Vault secret with the token field.'
+    default: secret/observability-team/ci/internal-ci-automation
+    required: false
+  jenkins-url:
+    description: 'Jenkins URL'
+    required: true
+  jenkins-job:
+    description: 'Jenkins Job'
+    required: true
+  waitFor:
+    description: 'Whether to wait for the build to finish.'
+    default: false
+    required: false
+  printBuildLogs:
+    description: 'Whether to print the build logs.'
+    default: false
+    required: false
+  build-params:
+    description: 'Specify the build parameters.'
+    required: false
+runs:
+  using: "composite"
+  steps:
+      - uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ inputs.vaultUrl }}
+          roleId: ${{ inputs.vaultRoleId }}
+          secretId: ${{ inputs.vaultSecretId }}
+          method: approle
+          secrets: |
+            ${{ inputs.secret }} user | JENKINS_USER ;
+            ${{ inputs.secret }} token | JENKINS_ACCESS_TOKEN
+
+      - name: Trigger Jenkins job
+        run: |
+          ${{ github.action_path }}/run.sh \
+            '${{ inputs.jenkins-url }}' \
+            '${{ inputs.jenkins-job }}' \
+            '${{ inputs.build-params }}' \
+            '${{ inputs.waitFor }}' \
+            '${{ inputs.printBuildLogs }}' \
+            '${{ env.JENKINS_USER }}:${{ env.JENKINS_ACCESS_TOKEN }}'
+        shell: bash

--- a/.github/actions/jenkins-build/run.sh
+++ b/.github/actions/jenkins-build/run.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Given some parameters it will trigger a build in Jenkins
+#
+# Parameters:
+#  $1 -> the Jenkins URL. Mandatory.
+#  $2 -> the Jenkins job. Mandatory.
+#  $3 -> the build params. Mandatory. "" if empty
+#  $4 -> whether to wait for. Mandatory.
+#  $5 -> whether to report logs. Mandatory
+#  $6 -> the Jenkins API token. Mandatory.
+#
+
+set -euo pipefail
+
+MSG="parameter missing."
+URL=${1:?$MSG}
+JOB=${2:?$MSG}
+BUILD_PARAMS=${3:-''}
+WAIT_FOR=${4:?$MSG}
+PRINT_BUILD=${5:?$MSG}
+JENKINS_TOKEN=${6:?$MSG}
+
+# Merge in the build environment variables, if they specified any
+BUILD_PARAMS_MANIPULATED=""
+if [[ -n "$BUILD_PARAMS" ]]; then
+  # Parse those env variables that are split in lines (VARIABLE=value)
+  while IFS= read -r line; do
+    if [ -n "$line" ] ; then
+      name=$(echo "$line" | cut -d= -f1)
+      value=$(echo "$line" | cut -d= -f2)
+      BUILD_PARAMS_MANIPULATED="${BUILD_PARAMS_MANIPULATED} -p $name=$value"
+    fi
+  done <<< "$BUILD_PARAMS"
+fi
+
+FLAGS=''
+if [ "$WAIT_FOR" == "true" ]; then
+  FLAGS="-s"
+  if [ "$PRINT_BUILD" == "true" ]; then
+    FLAGS="${FLAGS} -v"
+  fi
+fi
+
+echo "::group::Download Jenkins client"
+curl --no-progress-meter \
+  -s "${URL}/jnlpJars/jenkins-cli.jar" \
+  --output jenkins-cli.jar
+echo "::endgroup::"
+
+echo "::group::BuildLogs"
+java -jar \
+  jenkins-cli.jar \
+  -s "${URL}" \
+  -auth "${JENKINS_TOKEN}" \
+  -webSocket \
+  build \
+  "${JOB}" \
+  -w \
+  ${FLAGS} \
+  $BUILD_PARAMS_MANIPULATED
+echo "::endgroup::"

--- a/.github/actions/jenkins-build/run.sh
+++ b/.github/actions/jenkins-build/run.sh
@@ -49,6 +49,7 @@ curl --no-progress-meter \
 echo "::endgroup::"
 
 echo "::group::BuildLogs"
+# shellcheck disable=SC2086
 java -jar \
   jenkins-cli.jar \
   -s "${URL}" \


### PR DESCRIPTION
Support GitHub action to interact with Jenkins using the credentials in Vault.

## Why is it important?

Help with migrating our projects away from Jenkins even though they still need access to some of the existing Jenkins controllers.

As long as those services are not migrated yet, we can use this workaround.  So consumers will be able to migrate easily to a different CI by changing the contract.

Not ideal but at least we an move things forward in our end while working with the different system owners and stakeholders

