### PR TITLE
remove obsoleted branches from the files with the list of branches from the unified release

### DIFF
--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -79,6 +79,6 @@ if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
   ## manipulate minorVersion to get the -1
   newMinorVersion=$(echo "$minorVersion - 1" | bc)
   export removeBranch="${majorVersion}.${newMinorVersion}"
-  jq -r ".branches | map(select(. != env.removeBranch))" branches.json > branches.json.tmp
+  jq -r 'del(.branches[] | select(test(env.removeBranch)))' branches.json > branches.json.tmp
   mv branches.json.tmp branches.json
 fi

--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# It queries the artifacts-api entry point to fetch the next release
+# version for the 8.x line.
+#
+set -eo pipefail
+
+## we avoid surprises by uploading the unexpected credentials json file
+mkdir snapshots
+cd snapshots
+URL="https://artifacts-api.elastic.co/v1"
+NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
+
+QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+for version in ${QUERY_OUTPUT}; do
+  LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
+  BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
+  echo "${LATEST_OUTPUT}" | tee "$BRANCH.json"
+done
+## support main branch
+cp master.json main.json || true
+
+## generate a manifest with the current active snapshot branches (it also includes main).
+## Aka those with artifacts that have been generated in the last 30 days.
+BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g')
+{
+  echo "{"
+  echo "\"branches\":"
+  echo "${BRANCHES}"
+  echo "}"
+} > branches.json
+
+## Remove branches that have not been created yet, for such it queries the GitHub repositories
+for branch in $(jq -r '.branches | .[]' branches.json); do
+  if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" ; then
+    echo "$branch"
+  else
+    ## fallback to kibana just in case
+    if git ls-remote --exit-code --heads https://github.com/elastic/kibana.git "$branch" ; then
+      echo "$branch"
+    else
+      echo "$branch does not exist"
+      {
+        echo "{"
+        echo "\"branches\":"
+        jq ".branches - [\"$branch\"]" branches.json
+        echo "}"
+      } > branches.json.tmp
+      mv branches.json.tmp branches.json
+    fi
+  fi
+done
+
+set -x
+## There are times when there are two minor versions at the same time and that's valid in some cases but
+## in other cases it's not required.
+searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
+searchVersion=$(jq -r '.version' "$searchLatestBranch.json" | sed 's#-SNAPSHOT##g')
+if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
+  ## Remove 8.x-1
+  majorVersion=$(cut -d '.' -f 1 <<< "$searchLatestBranch")
+  minorVersion=$(cut -d '.' -f 2 <<< "$searchLatestBranch")
+  ## manipulate minorVersion to get the -1
+  newMinorVersion=$(echo "$minorVersion - 1" | bc)
+  export removeBranch="${majorVersion}.${newMinorVersion}"
+  jq -r ".branches | map(select(. != env.removeBranch))" branches.json > branches.json.tmp
+  mv branches.json.tmp branches.json
+fi

--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-## we avoid surprises by uploading the unexpected credentials json file
+## We avoid surprises by uploading the unexpected credentials json file
 mkdir snapshots
 cd snapshots
 URL="https://artifacts-api.elastic.co/v1"
@@ -68,7 +68,6 @@ for branch in $(jq -r '.branches | .[]' branches.json); do
   fi
 done
 
-set -x
 ## There are times when there are two minor versions at the same time and that's valid in some cases but
 ## in other cases it's not required.
 searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -40,7 +40,7 @@ jobs:
             echo "}"
           } > branches.json
 
-          ## Remove branches that have not been created yet, for such it queries the GitHub repositoreis
+          ## Remove branches that have not been created yet, for such it queries the GitHub repositories
           for branch in $(jq -r '.branches | .[]' branches.json); do
             if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" ; then
               echo $branch
@@ -60,6 +60,21 @@ jobs:
               fi
             fi
           done
+
+          ## There are times when there are two minor versions at the same time and that's valid in some cases but
+          ## in other cases it's not required.
+          searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
+          searchVersion=$(jq -r '.version' "$searchLatestBranch.json" | sed 's#-SNAPSHOT##g')
+          if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
+            ## Remove 8.x-1
+            majorVersion=$(cut -d '.' -f 1 <<< "$searchLatestBranch")
+            minorVersion=$(cut -d '.' -f 2 <<< "$searchLatestBranch")
+            ## manipulate minorVersion to get the -1
+            newMinorVersion=$(echo "$minorVersion - 1" | bc)
+            export removeBranch="${majorVersion}.${newMinorVersion}"
+            jq -r ".branches | map(select(. != env.removeBranch))" branches.json > branches.json.tmp
+            mv branches.json.tmp branches.json
+          fi
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.4.2

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -10,71 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  bump:
+  generate-snapshots:
     runs-on: ubuntu-latest
     steps:
-      - name: fetch snapshots
-        run: |-
-          ## we avoid surprises by uploading the unexpected credentials json file
-          mkdir snapshots
-          cd snapshots
-          URL="https://artifacts-api.elastic.co/v1"
-          NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
-
-          QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
-          for version in ${QUERY_OUTPUT}; do
-            LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
-            BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
-            echo "${LATEST_OUTPUT}" | tee "$BRANCH.json"
-          done
-          ## support main branch
-          cp master.json main.json || true
-
-          ## generate a manifest with the current active snapshot branches (it also includes main).
-          ## Aka those with artifacts that have been generated in the last 30 days.
-          BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g')
-          {
-            echo "{"
-            echo "\"branches\":"
-            echo "${BRANCHES}"
-            echo "}"
-          } > branches.json
-
-          ## Remove branches that have not been created yet, for such it queries the GitHub repositories
-          for branch in $(jq -r '.branches | .[]' branches.json); do
-            if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" ; then
-              echo $branch
-            else
-              ## fallback to kibana just in case
-              if git ls-remote --exit-code --heads https://github.com/elastic/kibana.git "$branch" ; then
-                echo $branch
-              else
-                echo "$branch does not exist"
-                {
-                  echo "{"
-                  echo "\"branches\":"
-                  jq ".branches - [\"$branch\"]" branches.json
-                  echo "}"
-                } > branches.json.tmp
-                mv branches.json.tmp branches.json
-              fi
-            fi
-          done
-
-          ## There are times when there are two minor versions at the same time and that's valid in some cases but
-          ## in other cases it's not required.
-          searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
-          searchVersion=$(jq -r '.version' "$searchLatestBranch.json" | sed 's#-SNAPSHOT##g')
-          if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
-            ## Remove 8.x-1
-            majorVersion=$(cut -d '.' -f 1 <<< "$searchLatestBranch")
-            minorVersion=$(cut -d '.' -f 2 <<< "$searchLatestBranch")
-            ## manipulate minorVersion to get the -1
-            newMinorVersion=$(echo "$minorVersion - 1" | bc)
-            export removeBranch="${majorVersion}.${newMinorVersion}"
-            jq -r ".branches | map(select(. != env.removeBranch))" branches.json > branches.json.tmp
-            mv branches.json.tmp branches.json
-          fi
+      - uses: actions/checkout@v3
+      - run: .ci/generate-snapshots.sh
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.4.2

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ wiremock-standalone.jar
 
 # For github actions
 node_modules/
+
+snapshots/


### PR DESCRIPTION
## What does this PR do?

Remove obsoleted branches from the source of truth.

## Why is it important?

The `artifacts-api` is the one providing the details, but release brnaches that are obsoleted need to be removed, for such I used the below algorithm:

- Given the `branches.json` then get the latest branch (after removing `main`)
- Gets its version and if its patch is different than `0` then
- Remove the minor-1.

For instance, given

```json
{
  "branches": [
    "7.17",
    "8.6",
    "8.7",
    "main"
  ]
}
```

And `8.7` is the latest release branch with the version `8.7.1-SNAPSHOT` 
Since its patch is `1` rather than `0`
Then `8.6` will be removed from the above json file

## Related issues
Closes #ISSUE
