### PR TITLE
chore: set APM environment to CI

### DIFF
--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -28,9 +28,13 @@ runs:
     - name: configure oblt-cli
       run: |
         GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username='${{ inputs.username }}' --slack-channel='${{ inputs.slackChannel }}'
+      env:
+        ELASTIC_APM_ENVIRONMENT: CI
       shell: bash
 
     - name: run oblt-cli
       run: |
         GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose
+      env:
+        ELASTIC_APM_ENVIRONMENT: CI
       shell: bash

--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -29,12 +29,12 @@ runs:
       run: |
         GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username='${{ inputs.username }}' --slack-channel='${{ inputs.slackChannel }}'
       env:
-        ELASTIC_APM_ENVIRONMENT: CI
+        ELASTIC_APM_ENVIRONMENT: ci
       shell: bash
 
     - name: run oblt-cli
       run: |
         GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose
       env:
-        ELASTIC_APM_ENVIRONMENT: CI
+        ELASTIC_APM_ENVIRONMENT: ci
       shell: bash


### PR DESCRIPTION
## What does this PR do?

It adds the environment variable `ELASTIC_APM_ENVIRONMENT=CI` to the `oblt-cli` action to distinct CI operation from user operations.

## Why is it important?

We make a lot of calls to oblt-cli from CI we have to distinguish them from the user iterations, we are interested on the way users use `oblt-cli`, we know how the CI does it.
