### PR TITLE
ci: add exclude branches on elastic stack snapshot branches 

### DIFF
--- a/.github/actions/elastic-stack-snapshot-branches/action.yml
+++ b/.github/actions/elastic-stack-snapshot-branches/action.yml
@@ -1,6 +1,12 @@
 ---
 name: 'Elastic Stack Snapshot branches'
 description: 'Fetch the current list of active branches with snapshots in Elastic'
+inputs:
+  exclude-branches:
+    description: "Exclude branches comma separated"
+    required: false
+    type: string
+    default: ''
 outputs:
   matrix:
     description: "Processed matrix with the required tuples of version and framework"
@@ -8,19 +14,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
     - id: generator
-      shell: python
-      run: |
-        import json
-        import os
-        import requests
-        r = requests.get(url='https://storage.googleapis.com/artifacts-api/snapshots/branches.json')
-        matrix = {'include': []}
-        for branch in r.json()['branches']:
-          matrix['include'].append({"branch": branch})
-        with open(os.environ.get('GITHUB_OUTPUT'), "a") as f:
-          f.write("matrix={}\n".format(json.dumps(matrix)))
+      shell: bash
+      run: python ${{ github.action_path }}/script.py
+      env:
+        EXCLUDE_BRANCHES: ${{ inputs.exclude-branches }}
     - id: debug
       shell: bash
       run: |

--- a/.github/actions/elastic-stack-snapshot-branches/script.py
+++ b/.github/actions/elastic-stack-snapshot-branches/script.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import json
+import os
+import requests
+
+def fails(msg):
+    print(msg)
+    exit(1)
+
+req = requests.get(url='https://storage.googleapis.com/artifacts-api/snapshots/branches.json')
+if req.status_code != requests.codes.ok:
+    fails("Failed to fetch active branches")
+
+try:
+    payload = req.json()
+except requests.exceptions.JSONDecodeError:
+    fails("Failed to decode json payload")
+
+branches = payload.get('branches')
+if not branches:
+    fails("Failed to retrieve active branches")
+
+exclude_branches = os.environ.get('EXCLUDE_BRANCHES', '')
+exclude_branches = set(filter(lambda branch: len(branch) > 0, exclude_branches.split(',')))
+if exclude_branches:
+    branches = list(filter(lambda branch: branch not in exclude_branches, branches))
+
+branches = list(map(lambda branch: {"branch": branch}, branches))
+matrix = {'include': branches}
+
+with open(os.environ.get('GITHUB_OUTPUT'), "a") as file_descriptor:
+    file_descriptor.write(f"matrix={json.dumps(matrix)}\n")

--- a/.github/workflows/test-elastic-stack-snapshot-branches.yml
+++ b/.github/workflows/test-elastic-stack-snapshot-branches.yml
@@ -1,0 +1,20 @@
+---
+name: test-elastic-stack-snapshot-branches
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - id: generator
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@main
+
+  test-with-exclude-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - id: generator
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@main
+        with:
+          exclude-branches: '7.17,main'


### PR DESCRIPTION
## What does this PR do?

* Add exclude branches input on elastic stack snapshot branches action.
* Refactor the script in a separate file.

## Why is it important?

* Some use cases require excluding branches from the list of active branches.
