### PR TITLE
mvnVersion: support for multiline

### DIFF
--- a/src/test/groovy/MvnVersionTests.groovy
+++ b/src/test/groovy/MvnVersionTests.groovy
@@ -57,4 +57,17 @@ class MvnVersionTests extends ApmBasePipelineTest {
     assertEquals("1.1.82", ret)
   }
 
+  @Test
+  void testVersionMultiline() throws Exception {
+    helper.registerAllowedMethod('sh', [Map.class], { return """
+Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
+Maven home: /Users/vmartinez/.m2/wrapper/dists/apache-maven-3.8.5-bin/5i5jha092a3i37g0paqnfr15e0/apache-maven-3.8.5
+Java version: 17.0.5, vendor: Eclipse Adoptium, runtime: /Users/vmartinez/.sdkman/candidates/java/17.0.5-tem
+Default locale: en_GB, platform encoding: UTF-8
+OS name: "mac os x", version: "13.3", arch: "x86_64", family: "mac"
+1.36.1-SNAPSHOT""" })
+    def ret = script.call()
+    assertEquals("1.36.1-SNAPSHOT", ret)
+  }
+
 }

--- a/vars/mvnVersion.groovy
+++ b/vars/mvnVersion.groovy
@@ -31,9 +31,10 @@ def call(Map args = [:]) {
         error "Error executing Maven. Check to ensure that you are in the project root and that `mvnw` and `pom.xml` are present."
         throw err
     }
+    def line = ver.split('\n').last()
     if (!showQualifiers){
-        return ver.replaceAll(/-.*$/, '')
+        return line.replaceAll(/-.*$/, '')
     } else {
-        return ver
+        return line
     }
 }


### PR DESCRIPTION
## What does this PR do?

Read the last line

## Why is it important?

Otherwise, when using `.mvn/maven.config` can cause some errors.

## Related issues
Closes https://github.com/elastic/apm-pipeline-library/issues/2186
