### PR TITLE
updatecli and mergify:  automate delete branches and when to reuse PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - base~=^update.*
+        - head~=^updatecli
     actions:
       delete_head_branch:
   - name: assign PRs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,14 +4,12 @@ queue_rules:
       - check-success=build
       - check-success=licenses
       - check-success=pre-commit
+      - check-success=CLA
 
 pull_request_rules:
   - name: Automatic squash and merge on approval with success checks and ready-to-merge label
     conditions:
       - "#approved-reviews-by>=2"
-      - check-success=apm-ci/pr-merge
-      - check-success=CLA
-      - check-success=Test
       - label=ready-to-merge
       - base=main
     actions:

--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -1,6 +1,6 @@
 ---
 name: Bump aliases with the elastic stack versions
-pipelineid: 'updatecli-bump-aliases-{{ requiredEnv "GITHUB_RUN_ID" }}'
+pipelineid: 'updatecli-bump-aliases'
 
 actions:
   default:

--- a/updatecli/updatecli.d/bump-elastic-stack.yml
+++ b/updatecli/updatecli.d/bump-elastic-stack.yml
@@ -9,6 +9,7 @@ actions:
     spec:
       labels:
         - dependencies
+        - automation
     scmid: default
 
 scms:

--- a/updatecli/updatecli.d/bump-golang.yml
+++ b/updatecli/updatecli.d/bump-golang.yml
@@ -1,6 +1,6 @@
 ---
 name: Bump golang-version to latest version
-pipelineid: 'updatecli-bump-golang-{{ requiredEnv "GITHUB_RUN_ID" }}'
+pipelineid: 'updatecli-bump-golang'
 
 actions:
   default:
@@ -10,6 +10,7 @@ actions:
       automerge: false
       labels:
         - dependencies
+        - automation
     scmid: default
 
 scms:


### PR DESCRIPTION
## What does this PR do?

Add labels so mergify can delete the branches when PRs are merged/closed
Reuse PRs when needed - golang and aliases don't need unique PRs since it's the same content, otherwise it will create duplicated PRs.


## Why is it important?

Automate some leftovers