### PR TITLE
build(github-actions): upgrade to github-script 6.4.x

### DIFF
--- a/.github/actions/publish-report/action.yml
+++ b/.github/actions/publish-report/action.yml
@@ -34,11 +34,10 @@ runs:
   using: "composite"
   steps:
     - name: 'Download artifact'
-      ## TODO: forced to use v3.1.0 but I don't recall why, let's keep it for now
-      uses: actions/github-script@v3.1.0
+      uses: actions/github-script@v6.4.1
       with:
         script: |
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
              run_id: ${{ github.event.workflow_run.id }},
@@ -46,7 +45,7 @@ runs:
           var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "${{ inputs.artifact }}"
           })[0];
-          var download = await github.actions.downloadArtifact({
+          var download = await github.rest.actions.downloadArtifact({
              owner: context.repo.owner,
              repo: context.repo.repo,
              artifact_id: matchArtifact.id,
@@ -61,7 +60,7 @@ runs:
 
     - name: 'Get the PR id'
       id: 'get-pr'
-      uses: actions/github-script@v6.4.0
+      uses: actions/github-script@v6.4.1
       with:
         github-token: ${{ inputs.token }}
         script: |
@@ -100,7 +99,7 @@ runs:
         body-includes: '<!-- automated report -->'
 
     - name: 'Update PR'
-      uses: actions/github-script@v6.4.0
+      uses: actions/github-script@v6.4.1
       if: ${{ steps.fc.outputs.comment-id != '' }}
       with:
         github-token: ${{ inputs.token }}
@@ -115,7 +114,7 @@ runs:
         BODY_CONTENT: '<!-- automated report -->\n:rocket: [Report](https://storage.cloud.google.com/${{ inputs.bucket }}/prs/${{ steps.get-pr.outputs.result }}/${{ inputs.index }})'
 
     - name: 'Comment on PR'
-      uses: actions/github-script@v6.4.0
+      uses: actions/github-script@v6.4.1
       if: ${{ steps.fc.outputs.comment-id == ''}}
       with:
         github-token: ${{ inputs.token }}


### PR DESCRIPTION
## What does this PR do?

* Upgrade github-script dependency to 6.4.1.

## Why is it important?

* Use the latest bug fixes.
* Unblock [dependabot](https://github.com/elastic/apm-pipeline-library/pull/2183) PRs.

## Related issues
Closes #2183 
