### PR TITLE
snapshots: when release branch is not yet available in the Unified Release

### DIFF
--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -71,6 +71,14 @@ done
 ## There are times when there are two minor versions at the same time and that's valid in some cases but
 ## in other cases it's not required.
 searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
+
+## If branch is not available yet, likely it's related with a new release is created from the main branch
+## then the unified release likely has not been triggered yet. Then let's fall back to create the file
+## matching the main.json (this will avoid issues with the consumers)
+if [ ! -e  "$searchLatestBranch.json" ] ; then
+  cp main.json "$searchLatestBranch.json"
+fi
+
 searchVersion=$(jq -r '.version' "$searchLatestBranch.json" | sed 's#-SNAPSHOT##g')
 if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
   ## Remove 8.x-1

--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -72,7 +72,7 @@ done
 ## in other cases it's not required.
 searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
 
-## If branch is not available yet, likely it's related with a new release is created from the main branch
+## If branch is not available yet, likely it's related when a new release is created from the main branch
 ## then the unified release likely has not been triggered yet. Then let's fall back to create the file
 ## matching the main.json (this will avoid issues with the consumers)
 if [ ! -e  "$searchLatestBranch.json" ] ; then


### PR DESCRIPTION
## What does this PR do?

Create a `<branch>.json` when the `<branch>` is created from the `main` branch but the Unified Release has not been executed yet. 

## Why is it important?

Fixes

```
d13bda82c47f75988b87ca1422ebcddad994f6f5	refs/heads/7.17
7.17
8b8607111451b5b32c0f264f69142b26a696574d	refs/heads/8.6
8.6
d917f5648890b6dcbd23e623f1f1bf8f82ce5523	refs/heads/8.7
8.7
c90baf5e77ea3a932e06de126e30c95377b331e8	refs/heads/8.8
8.8
4e69fa102ffe583a224b11c36[49](https://github.com/elastic/apm-pipeline-library/actions/runs/4814611121/jobs/8587535969#step:3:50)c82784dd91a3e	refs/heads/main
main
jq: error: Could not open file 8.8.json: No such file or directory
Error: Process completed with exit code 2.
```

And

```
latestVersion
-------------
ERROR: ✗ file "https://storage.googleapis.com/artifacts-api/snapshots/8.8.json" does not exist
Pipeline "Bump elastic-stack to latest snapshot version" failed
Skipping due to:
	sources stage:	"file \"[https://storage.googleapis.com/artifacts-api/snapshots/8.8.json\](https://storage.googleapis.com/artifacts-api/snapshots/8.8.json/)" does not exist"
```

See https://github.com/elastic/apm-server/actions/runs/4821320150/jobs/8587046280

See https://github.com/elastic/apm-pipeline-library/actions/runs/4814611121/jobs/8587535969