### PR TITLE
snapshots: remove majors if there are 3 versions

### DIFF
--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -28,17 +28,21 @@ cd snapshots
 URL="https://artifacts-api.elastic.co/v1"
 NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
+
+echo ">> Query versions in ${URL}"
 QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
 for version in ${QUERY_OUTPUT}; do
   LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
   BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)
   echo "${LATEST_OUTPUT}" | tee "$BRANCH.json"
 done
-## support main branch
+
+echo ">> Support master branch"
 cp master.json main.json || true
 
-## generate a manifest with the current active snapshot branches (it also includes main).
+## Generate a manifest with the current active snapshot branches (it also includes main).
 ## Aka those with artifacts that have been generated in the last 30 days.
+echo ">> Query branches in ${URL}"
 BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[] | select(test("SNAPSHOT$")|not)) | .aliases' | jq '. + [ "main" ]' | sed 's#-SNAPSHOT##g')
 {
   echo "{"
@@ -47,16 +51,17 @@ BRANCHES=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r 'del(.aliases[]
   echo "}"
 } > branches.json
 
+echo ">> Remove branches that have not been created yet"
 ## Remove branches that have not been created yet, for such it queries the GitHub repositories
 for branch in $(jq -r '.branches | .[]' branches.json); do
-  if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" ; then
-    echo "$branch"
+  if git ls-remote --exit-code --heads https://github.com/elastic/elasticsearch.git "$branch" > /dev/null ; then
+    echo ">>> $branch exists"
   else
     ## fallback to kibana just in case
-    if git ls-remote --exit-code --heads https://github.com/elastic/kibana.git "$branch" ; then
-      echo "$branch"
+    if git ls-remote --exit-code --heads https://github.com/elastic/kibana.git "$branch" > /dev/null ; then
+      echo ">>> $branch exists"
     else
-      echo "$branch does not exist"
+      echo ">>> $branch does not exist ... let's remove it"
       {
         echo "{"
         echo "\"branches\":"
@@ -68,6 +73,17 @@ for branch in $(jq -r '.branches | .[]' branches.json); do
   fi
 done
 
+echo ">> No more than 2 versions for the same minor is needed"
+if [ "$(jq -r '.branches | map(select(. | startswith("8."))) | length' branches.json)" == "3" ] ; then
+  echo ">>> Remove the first element"
+  removeFirstElement=$(jq -r '.branches | map(select(. | startswith("8."))) | .[0]' branches.json)
+  export removeFirstElement
+  echo ">>> $removeFirstElement"
+  jq -r 'del(.branches[] | select(test(env.removeFirstElement)))' branches.json > branches.json.tmp
+  mv branches.json.tmp branches.json
+fi
+
+echo ">> Can 2 versions for the same minor be available?"
 ## There are times when there are two minor versions at the same time and that's valid in some cases but
 ## in other cases it's not required.
 searchLatestBranch=$(jq -r '.branches | map(select(. != "main")) | .[-1]' branches.json)
@@ -81,12 +97,14 @@ fi
 
 searchVersion=$(jq -r '.version' "$searchLatestBranch.json" | sed 's#-SNAPSHOT##g')
 if [ "${searchVersion}" != "${searchLatestBranch}.0"  ] ; then
+  echo ">>> Remove <major>.x-1"
   ## Remove 8.x-1
   majorVersion=$(cut -d '.' -f 1 <<< "$searchLatestBranch")
   minorVersion=$(cut -d '.' -f 2 <<< "$searchLatestBranch")
   ## manipulate minorVersion to get the -1
   newMinorVersion=$(echo "$minorVersion - 1" | bc)
   export removeBranch="${majorVersion}.${newMinorVersion}"
+  echo ">>> $removeBranch"
   jq -r 'del(.branches[] | select(test(env.removeBranch)))' branches.json > branches.json.tmp
   mv branches.json.tmp branches.json
 fi


### PR DESCRIPTION
## What does this PR do?

Remove branches if for the same major version there are 3 elements

## Why is it important?

Artifacts API does not care about active release branches, hence it's required to delete the one is not supported.

https://github.com/elastic/apm-pipeline-library/pull/2176 was one case to care but there is also another one when an old branch is generated then it will be shown in the `artifacts-api`.

