### PR TITLE
oblt: support github command for serverless

### DIFF
--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -47,3 +47,9 @@ Following inputs can be used as `step.with` keys
 | `vaultRoleId`     | String  |                                        | The Vault role id. |
 | `vaultSecretId`   | String  |                                        | The Vault secret id. |
 | `vaultUrl`        | String  |                                        | The Vault URL to connect to. |
+
+### outputs
+
+| Name              | Type    | Description                               |
+|-------------------|---------| ------------------------------------------|
+| `issue`           | String  | The GitHub issue URL with the deployment. |

--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -43,6 +43,7 @@ Following inputs can be used as `step.with` keys
 | `comment_id`      | String  | `${{ github.event.comment.id }}`       | The GitHub comment ID.  |
 | `user`            | String  | `${{ github.triggering_actor }}`       | The GitHub user avatar           |
 | `repository`      | String  | `${{ github.repository }}`             | The GitHub repository, ORG/REPO. |
+| `serverless`      | Boolean | `false`                                | Whether to deploy a serverless deployment. |
 | `vaultRoleId`     | String  |                                        | The Vault role id. |
 | `vaultSecretId`   | String  |                                        | The Vault secret id. |
 | `vaultUrl`        | String  |                                        | The Vault URL to connect to. |

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -56,13 +56,21 @@ runs:
         PR=$(basename ${{ inputs.issue_url }})
         echo "PR=${PR}" >> $GITHUB_ENV
 
-        # If serverless
-        if [ "${{ inputs.serverless }}" == 'true' ] ; then
-          echo "CLUSTER=serverless-oblt" >> $GITHUB_ENV
-          exit 0
-        fi
         # issue_comment does not contain any references to github.base_ref
         TARGET_BRANCH=$(gh pr view ${PR} --repo ${{ inputs.repository }} --json baseRefName --jq .baseRefName)
+
+        # If serverless
+        if [ "${{ inputs.serverless }}" == 'true' ] ; then
+          if [ "${TARGET_BRANCH}" == 'main' ] ; then
+            # As long as serverless is not yet available we use stateless instead
+            #echo "CLUSTER=serverless-oblt" >> $GITHUB_ENV
+            echo "CLUSTER=stateless-oblt" >> $GITHUB_ENV
+            exit 0
+          fi
+          STATUS="#### You cannot deploy your PR when targeting a branch other than main :broken_heart:"
+          echo "${STATUS}" >> $GITHUB_STEP_SUMMARY
+          echo "::setFailed::${STATUS}"
+        fi
         if [ "${TARGET_BRANCH}" == 'main' ] ; then
           echo "CLUSTER=edge-lite-oblt" >> $GITHUB_ENV
         else

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -22,6 +22,9 @@ inputs:
   repository:
     description: 'The GitHub repository'
     default: ${{ github.repository }}
+  serverless:
+    description: 'Whether to deploy a serverless cluster'
+    default: false
   user:
     description: 'The GitHub user that triggered the workflow'
     default: ${{ github.triggering_actor }}
@@ -53,6 +56,11 @@ runs:
         PR=$(basename ${{ inputs.issue_url }})
         echo "PR=${PR}" >> $GITHUB_ENV
 
+        # If serverless
+        if [ "${{ inputs.serverless }}" == 'true' ] ; then
+          echo "CLUSTER=serverless-oblt" >> $GITHUB_ENV
+          exit 0
+        fi
         # issue_comment does not contain any references to github.base_ref
         TARGET_BRANCH=$(gh pr view ${PR} --repo ${{ inputs.repository }} --json baseRefName --jq .baseRefName)
         if [ "${TARGET_BRANCH}" == 'main' ] ; then

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -117,6 +117,7 @@ runs:
           --body-file .body-content \
           --repo elastic/observability-test-environments | tee .issue
         echo "ISSUE=$(cat .issue)" >> $GITHUB_ENV
+        echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ env.GITHUB_TOKEN }}
       shell: bash

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -67,9 +67,10 @@ runs:
             echo "CLUSTER=stateless-oblt" >> $GITHUB_ENV
             exit 0
           fi
-          STATUS="#### You cannot deploy your PR when targeting a branch other than main :broken_heart:"
-          echo "${STATUS}" >> $GITHUB_STEP_SUMMARY
-          echo "::setFailed::${STATUS}"
+          MESSAGE="You cannot deploy your PR when targeting a branch other than main"
+          echo "#### :broken_heart: ${MESSAGE}" >> $GITHUB_STEP_SUMMARY
+          echo "::error::${MESSAGE}"
+          exit 1
         fi
         if [ "${TARGET_BRANCH}" == 'main' ] ; then
           echo "CLUSTER=edge-lite-oblt" >> $GITHUB_ENV


### PR DESCRIPTION
## What does this PR do?

Deploy to a serverless cluster

## Related issues

Notifies https://github.com/elastic/kibana/pull/158237


## Test

If no `main` branch -> https://github.com/elastic/apm-pipeline-library/actions/runs/5055753199/jobs/9072363464

If `main` branch -> https://github.com/elastic/apm-pipeline-library/actions/runs/5055688365
