### PR TITLE
Add ability to transfer artifacts from Buildkite to GH in the buildkite action

### DIFF
--- a/.github/actions/buildkite/README.md
+++ b/.github/actions/buildkite/README.md
@@ -95,7 +95,7 @@ in the GH workflow and then uploaded to GH artifacts again with `actions/upload-
 
 When you specify `artifactsName` and `artifactsPath`, the files are not automatically uploaded
 in a Buildkite pipeline. You must make sure that these files are uploaded in the targeted
-Buildkite pipeline itself. This action onlyu downloads the files already uploaded in
+Buildkite pipeline itself. This action only downloads the files already uploaded in
 Buildkite and uploads them again in GitHub via actions/upload-artifact.
 
 Due to the functionality of the Buildkite Artifacts API, files are downloaded individually.

--- a/.github/actions/buildkite/README.md
+++ b/.github/actions/buildkite/README.md
@@ -62,23 +62,44 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name              | Type    | Default                     | Description                        |
-|-------------------|---------|-----------------------------|------------------------------------|
-| `vaultRoleId`     | String  |                             | The Vault role id. |
-| `vaultSecretId`   | String  |                             | The Vault secret id. |
-| `vaultUrl`        | String  |                             | The Vault URL to connect to. |
-| `secret`          | String  | `secret/observability-team/ci/buildkite-automation` | The Vault secret. |
-| `org`             | String  | `elastic`                   | The Buildkite org. |
-| `pipeline`        | String  |                             | The Buildkite pipeline to interact with. |
-| `pipelineVersion` | String  | `HEAD`                      | The Buildkite pipeline version to be used, git tag, commit or branch. |
-| `triggerMessage`  | String  | `Triggered automatically with GH actions` | The Buildkite build message to be shown in the UI. |
-| `waitFor`         | boolean | `false`                     | Whether to wait for the build to finish. |
-| `printBuildLogs`  | boolean | `false`                     | Whether to print the build logs. |
-| `buildEnvVars`    | String  |                             | Additional environment variables to set on the build, in KEY=VALUE format. No double quoting or extra `=` |
-
+| Name                        | Type    | Default                                             | Description                                                                                                       |
+|-----------------------------|---------|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `vaultRoleId`               | String  |                                                     | The Vault role id.                                                                                                |
+| `vaultSecretId`             | String  |                                                     | The Vault secret id.                                                                                              |
+| `vaultUrl`                  | String  |                                                     | The Vault URL to connect to.                                                                                      |
+| `secret`                    | String  | `secret/observability-team/ci/buildkite-automation` | The Vault secret.                                                                                                 |
+| `org`                       | String  | `elastic`                                           | The Buildkite org.                                                                                                |
+| `pipeline`                  | String  |                                                     | The Buildkite pipeline to interact with.                                                                          |
+| `pipelineVersion`           | String  | `HEAD`                                              | The Buildkite pipeline version to be used, git tag, commit or branch.                                             |
+| `triggerMessage`            | String  | `Triggered automatically with GH actions`           | The Buildkite build message to be shown in the UI.                                                                |
+| `waitFor`                   | boolean | `false`                                             | Whether to wait for the build to finish.                                                                          |
+| `printBuildLogs`            | boolean | `false`                                             | Whether to print the build logs.                                                                                  |
+| `buildEnvVars`              | String  |                                                     | Additional environment variables to set on the build, in KEY=VALUE format. No double quoting or extra `=`         |
+| `artifactName`              | String  |                                                     | Artifact name                                                                                                     |
+| `artifactPath`              | String  |                                                     | A file, directory or wildcard pattern that describes what to upload                                               |
+| `artifactIfNoFilesFound`    | String  |                                                     | Passed to actons/upload-artifact. Equivalent to https://github.com/actions/upload-artifact/blob/v3/action.yml#L11 |
 
 ### outputs
 
 | Name              | Type    | Description               |
 |-------------------|---------| --------------------------|
 | `build`           | String  |  The Buildkite build URL. |
+
+## Limitations
+
+### Transferring artifacts from Buildkite to GH Actions
+
+Artifacts are uploaded in Buildkite then downloaded through the
+[Buildkite Artifacts API](https://buildkite.com/docs/apis/rest-api/artifacts)
+in the GH workflow and then uploaded to GH artifacts again with `actions/upload-artifact`.
+
+When you specify `artifactsName` and `artifactsPath`, the files are not automatically uploaded
+in a Buildkite pipeline. You must make sure that these files are uploaded in the targeted
+Buildkite pipeline itself. This action onlyu downloads the files already uploaded in
+Buildkite and uploads them again in GitHub via actions/upload-artifact.
+
+Due to the functionality of the Buildkite Artifacts API, files are downloaded individually.
+This means that if you use a glob that corresponds to 1000 files, 1000 requests will be sent to Buildkite.
+To work around this problem, you can zip the files you want to transfer first and then upload the zip file.
+The same problem is described in the actions/upload-artifact action itself in
+https://github.com/actions/upload-artifact/tree/v3#too-many-uploads-resulting-in-429-responses.

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -87,7 +87,7 @@ runs:
 
       - id: download-artifacts
         name: Download artifacts
-        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != '' && steps.trigger-buildkite.outputs.build_state == "passed"
+        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != '' && steps.trigger-buildkite.outputs.build_state == 'passed'
         run: python ${{ github.action_path }}/download_artifacts.py
         env:
           ORG: ${{ inputs.org }}

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -49,7 +49,7 @@ inputs:
     required: false
   artifactIfNoFilesFound:
     description: |
-      Passed to actons/upload-artifact.
+      Passed to actions/upload-artifact.
       Equivalent to https://github.com/actions/upload-artifact/blob/v3/action.yml#L11
     default: warn
     required: false

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   secret:
     description: 'Vault secret with the token field.'
-    default: secret/observability-team/ci/buildkite-automation
+    default: secret/observability-team/ci/buildkite-automation-v2
     required: false
   org:
     description: 'BuildKite org to interact with.'
@@ -41,6 +41,19 @@ inputs:
     description: 'The BK build message to be shown in the UI.'
     default: Triggered automatically with GH actions
     required: false
+  artifactName:
+    description: Artifact name
+    required: false
+  artifactPath:
+    description: A file, directory or wildcard pattern that describes what to upload
+    required: false
+  artifactIfNoFilesFound:
+    description: |
+      Passed to actons/upload-artifact.
+      Equivalent to https://github.com/actions/upload-artifact/blob/v3/action.yml#L11
+    default: warn
+    required: false
+
 outputs:
   build:
     description: "The Buildkite build url"
@@ -71,3 +84,27 @@ runs:
             '${{ inputs.triggerMessage }}' \
             '${{ inputs.pipelineVersion }}'
         shell: bash
+
+      - id: download-artifacts
+        name: Download artifacts
+        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != '' && steps.trigger-buildkite.outputs.build_state == "passed"
+        run: python ${{ github.action_path }}/download_artifacts.py
+        env:
+          ORG: ${{ inputs.org }}
+          PIPELINE: ${{ inputs.pipeline }}
+          BUILD_NUMBER: ${{ steps.trigger-buildkite.outputs.build_number }}
+          ARTIFACT_PATH: ${{ inputs.artifactPath }}
+        shell: bash
+
+      - uses: actions/upload-artifact@v3
+        if: steps.download-artifacts.outcome == 'success'
+        with:
+          name: ${{ inputs.artifactName }}
+          path: ${{ inputs.artifactPath }}
+          if-no-files-found: ${{ inputs.artifactIfNoFilesFound }}
+
+      - name: Reset environment
+        if: always()
+        shell: bash
+        run: |
+          echo "BUILDKITE_API_ACCESS_TOKEN=" >> $GITHUB_ENV

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -88,7 +88,9 @@ runs:
       - id: download-artifacts
         name: Download artifacts
         if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != '' && steps.trigger-buildkite.outputs.build_state == 'passed'
-        run: python ${{ github.action_path }}/download_artifacts.py
+        run: |
+          pip install globber==0.2.1
+          python ${{ github.action_path }}/download_artifacts.py
         env:
           ORG: ${{ inputs.org }}
           PIPELINE: ${{ inputs.pipeline }}

--- a/.github/actions/buildkite/download_artifacts.py
+++ b/.github/actions/buildkite/download_artifacts.py
@@ -66,7 +66,7 @@ def download_artifacts(artifacts: list) -> None:
             f.write(download_response.content)
 
 
-def get_artifacts_to_download(pattern: str, request_url: str, artifacts=None) -> list:
+def get_artifacts_to_download(pattern: str, request_url: str, artifacts: list = None) -> list:
     """
     Recursively gets all artifacts match the given pattern from a paginated artifacts list request.
     See https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build

--- a/.github/actions/buildkite/download_artifacts.py
+++ b/.github/actions/buildkite/download_artifacts.py
@@ -9,7 +9,7 @@ HEADERS = {'Authorization': f'Bearer {BUILDKITE_API_ACCESS_TOKEN}'}
 
 
 @dataclass
-class ListArtifactsRequestBuilder:
+class ListArtifactsRequestURLBuilder:
     org: str
     pipeline: str
     build_number: str
@@ -98,7 +98,7 @@ def run() -> None:
     pipeline = os.environ["PIPELINE"]
     build_number = os.environ["BUILD_NUMBER"]
     artifact_path = os.environ["ARTIFACT_PATH"]
-    request = ListArtifactsRequestBuilder(org, pipeline, build_number)
+    request = ListArtifactsRequestURLBuilder(org, pipeline, build_number)
     artifacts_to_download = get_artifacts_to_download(
         artifact_path,
         request.get_url()

--- a/.github/actions/buildkite/download_artifacts.py
+++ b/.github/actions/buildkite/download_artifacts.py
@@ -1,8 +1,10 @@
 from typing import Optional
-from pathlib import PurePath
 from dataclasses import dataclass
+
+import globber
 import requests
 import os
+
 
 BUILDKITE_API_ACCESS_TOKEN = os.environ["BUILDKITE_API_ACCESS_TOKEN"]
 HEADERS = {'Authorization': f'Bearer {BUILDKITE_API_ACCESS_TOKEN}'}
@@ -33,7 +35,7 @@ def find_all_matching_artifacts(artifacts: list, pattern: str) -> list:
     :param pattern: glob path
     :return: list of artifacts
     """
-    return [artifact for artifact in artifacts if PurePath(artifact["path"]).match(pattern)]
+    return [artifact for artifact in artifacts if globber.match(pattern, artifact["path"])]
 
 
 def get_next_artifacts_url(artifacts_response) -> Optional[str]:

--- a/.github/actions/buildkite/download_artifacts.py
+++ b/.github/actions/buildkite/download_artifacts.py
@@ -1,0 +1,109 @@
+from typing import Optional
+from pathlib import PurePath
+from dataclasses import dataclass
+import requests
+import os
+
+BUILDKITE_API_ACCESS_TOKEN = os.environ["BUILDKITE_API_ACCESS_TOKEN"]
+HEADERS = {'Authorization': f'Bearer {BUILDKITE_API_ACCESS_TOKEN}'}
+
+
+@dataclass
+class ListArtifactsRequestBuilder:
+    org: str
+    pipeline: str
+    build_number: str
+    per_page = 100
+
+    def get_url(self) -> str:
+        return (
+            'https://api.buildkite.com/v2'
+            f'/organizations/{self.org}'
+            f'/pipelines/{self.pipeline}'
+            f'/builds/{self.build_number}'
+            '/artifacts'
+            f'?per_page={self.per_page}'
+        )
+
+
+def find_all_matching_artifacts(artifacts: list, pattern: str) -> list:
+    """
+    Finds all artifacts matching the given pattern.
+    :param artifacts: https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build
+    :param pattern: glob path
+    :return: list of artifacts
+    """
+    return [artifact for artifact in artifacts if PurePath(artifact["path"]).match(pattern)]
+
+
+def get_next_artifacts_url(artifacts_response) -> Optional[str]:
+    """
+    Gets the next artifacts list URL from an artifacts list response.
+    https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build
+    :param artifacts_response: Paginated list response (https://buildkite.com/docs/apis/rest-api#pagination)
+    :return: The next artifacts url or None
+    """
+    if "next" in artifacts_response.links:
+        return artifacts_response.links["next"]["url"]
+    else:
+        return None
+
+
+def download_artifacts(artifacts: list) -> None:
+    """
+    Downloads artifacts to the current directory and maintains the folder structure.
+    :param artifacts: https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build
+    """
+    for artifact in artifacts:
+        # https://buildkite.com/docs/apis/rest-api/artifacts#download-an-artifact
+        download_response = requests.get(
+            artifact["download_url"],
+            headers=HEADERS,
+            allow_redirects=True
+        )
+        os.makedirs(artifact["dirname"], exist_ok=True)
+        with open(artifact["path"], 'wb') as f:
+            f.write(download_response.content)
+
+
+def get_artifacts_to_download(pattern: str, request_url: str, artifacts=None) -> list:
+    """
+    Recursively gets all artifacts match the given pattern from a paginated artifacts list request.
+    See https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build
+    :param pattern: glob path
+    :param request_url: artifacts list request URL
+    :param artifacts: buildkite artifacts
+    :return:
+    """
+    if artifacts is None:
+        artifacts = []
+    response = requests.get(
+        request_url,
+        headers=HEADERS
+    )
+    matching_artifacts = find_all_matching_artifacts(
+        response.json(),
+        pattern
+    )
+    next_url = get_next_artifacts_url(response)
+    combined_artifacts = artifacts + matching_artifacts
+    if next_url is None:
+        return combined_artifacts
+    else:
+        return get_artifacts_to_download(pattern, next_url, combined_artifacts)
+
+
+def run() -> None:
+    org = os.environ["ORG"]
+    pipeline = os.environ["PIPELINE"]
+    build_number = os.environ["BUILD_NUMBER"]
+    artifact_path = os.environ["ARTIFACT_PATH"]
+    request = ListArtifactsRequestBuilder(org, pipeline, build_number)
+    artifacts_to_download = get_artifacts_to_download(
+        artifact_path,
+        request.get_url()
+    )
+    download_artifacts(artifacts_to_download)
+
+
+run()

--- a/.github/actions/buildkite/run.sh
+++ b/.github/actions/buildkite/run.sh
@@ -113,12 +113,11 @@ if [ "$PRINT_BUILD" == "true" ]; then
   echo "::endgroup::"
 fi
 
+echo "build_state=${STATE}" >> "$GITHUB_OUTPUT"
 if [ "$STATE" == "passed" ]; then
   echo "Build passed ($WEB_URL)"
-  echo "build_state=${STATE}" >> "$GITHUB_OUTPUT"
   exit 0
 else
   echo "Build did not pass, it's '$STATE'. Check the logs at $WEB_URL"
-  echo "build_state=${STATE}" >> "$GITHUB_OUTPUT"
   exit 1
 fi

--- a/.github/actions/buildkite/run.sh
+++ b/.github/actions/buildkite/run.sh
@@ -75,8 +75,10 @@ echo "::endgroup::"
 
 URL=$(echo "$RESP" | jq -r ".url")
 WEB_URL=$(echo "$RESP" | jq -r ".web_url")
+BUILD_NUMBER=$(echo "$RESP" | jq -r ".number")
 # shellcheck disable=SC2086
 echo "build=$WEB_URL" >> $GITHUB_OUTPUT
+echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
 if [ "$WAIT_FOR" != "true" ]; then
   echo "No wait for build $WEB_URL to run "
   exit 0
@@ -113,8 +115,10 @@ fi
 
 if [ "$STATE" == "passed" ]; then
   echo "Build passed ($WEB_URL)"
+  echo "build_state=${STATE}" >> "$GITHUB_OUTPUT"
   exit 0
 else
   echo "Build did not pass, it's '$STATE'. Check the logs at $WEB_URL"
+  echo "build_state=${STATE}" >> "$GITHUB_OUTPUT"
   exit 1
 fi


### PR DESCRIPTION
## What does this PR do?

Adds the ability to download artifacts from the targeted buildkite pipeline and upload it in GH actions artifacts.

Successful test run: https://github.com/elastic/apm-agent-java/actions/runs/5176206539/jobs/9324729641?pr=3158

## Why is it important?

Needed in apm-agent-java migration to transfer artifacts built and uploaded in buildkite to the GH Actions workflow.
