### PR TITLE
ci: add e2e tests to check dist for is-pr-approved

### DIFF
--- a/.github/workflows/test-is-pr-approved.yml
+++ b/.github/workflows/test-is-pr-approved.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
     paths:
       - '.github/actions/is-pr-approved/**'
+      - '.github/workflows/test-is-pr-approved.yml'
   push:
-    branches: main
+    branches:
+      - main
     paths:
       - '.github/actions/is-pr-approved/**'
+      - '.github/workflows/test-is-pr-approved.yml'
 
 jobs:
   test-is-pr-approved:
@@ -29,3 +32,22 @@ jobs:
         run: npm run all
       - name: Check nothing changes
         run: npm run check
+
+  test-is-pr-approved-dist:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./.github/actions/is-pr-approved
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          # Must be kept in sync with node version in action.yml
+          node-version: '16'
+      - name: Validate dist package
+        run: |
+          set +e
+          logs="$(node dist/index.js)"
+          status="${?}"
+          set -e
+          [ "${status}" != "0" ] && [ ! -z "${logs}" ]


### PR DESCRIPTION
## What is the change being made?

* Add E2E test to ensure the GitHub Actions is doing something.

## Why is the change being made?

* The ncc package could create an invalid `dist` due to misconfiguration.
* We can end up with a `dist` that does nothing and exit with success.

## How has this been tested?

* https://github.com/elastic/apm-pipeline-library/actions/runs/5313343370/jobs/9619105337?pr=2259
