### PR TITLE
Allow buildkite action to download artifacts also when the build failed

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -87,7 +87,7 @@ runs:
 
       - id: download-artifacts
         name: Download artifacts
-        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != '' && steps.trigger-buildkite.outputs.build_state == 'passed'
+        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != ''
         run: |
           pip install globber==0.2.1
           python ${{ github.action_path }}/download_artifacts.py

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -87,7 +87,7 @@ runs:
 
       - id: download-artifacts
         name: Download artifacts
-        if: always() inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != ''
+        if: always() && inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != ''
         run: |
           pip install globber==0.2.1
           python ${{ github.action_path }}/download_artifacts.py

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -87,7 +87,7 @@ runs:
 
       - id: download-artifacts
         name: Download artifacts
-        if: inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != ''
+        if: always() inputs.waitFor && inputs.artifactName != '' && inputs.artifactPath != ''
         run: |
           pip install globber==0.2.1
           python ${{ github.action_path }}/download_artifacts.py
@@ -99,7 +99,7 @@ runs:
         shell: bash
 
       - uses: actions/upload-artifact@v3
-        if: steps.download-artifacts.outcome == 'success'
+        if: always() && steps.download-artifacts.outcome == 'success'
         with:
           name: ${{ inputs.artifactName }}
           path: ${{ inputs.artifactPath }}


### PR DESCRIPTION
## What does this PR do?

This will allow the buildkite action to download artifacts even if the buildkite job failed.


## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
