### PR TITLE
Add setup-oblt-cli action

### DIFF
--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -18,23 +18,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: download oblt-cli
-      run: |
-        gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-      shell: bash
-
-    - name: configure oblt-cli
-      run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli configure --git-http-mode --username='${{ inputs.username }}' --slack-channel='${{ inputs.slackChannel }}'
-      env:
-        ELASTIC_APM_ENVIRONMENT: ci
-      shell: bash
-
+    - name: Setup oblt-cli
+      uses: elastic/apm-pipeline-library/.github/actions/setup-oblt-cli@current
+      with:
+        github-token: ${{ inputs.token }}
+        slack-channel: ${{ inputs.slackChannel }}
+        username: ${{ inputs.username }}
     - name: run oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose
-      env:
-        ELASTIC_APM_ENVIRONMENT: ci
+        GITHUB_TOKEN=${{ inputs.token }} oblt-cli ${{ inputs.command }} --verbose
       shell: bash

--- a/.github/actions/setup-oblt-cli/README.md
+++ b/.github/actions/setup-oblt-cli/README.md
@@ -1,0 +1,52 @@
+## About
+
+GitHub Action to set up oblt-cli
+
+## Usage
+
+### Configuration
+
+Given the CI GitHub action:
+
+```yaml
+---
+name: List clusters using oblt-cli
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-oblt-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        with:
+          username: ${{ env.GIT_USER }}
+          email: ${{ env.GIT_EMAIL }}
+          token: ${{ env.GITHUB_TOKEN }}
+      - uses: elastic/apm-pipeline-library/.github/actions/setup-oblt-cli@current
+        with:
+          slack-channel: '#observablt-bots' # default
+          username: 'apmmachine' # default
+          github-token: ${{ env.GITHUB_TOKEN }}
+
+      - run: oblt-cli cluster list
+```
+
+
+## Customizing
+
+### inputs
+
+Following inputs can be used as `step.with` keys
+
+| Name            | Type    | Default                     | Description                                                          |
+|-----------------|---------|-----------------------------|----------------------------------------------------------------------|
+| `slack-channel` | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli.                  |
+| `github-token`  | String  |                             | The GitHub token with permissions fetch releases.                    |
+| `username`      | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/setup-oblt-cli/action.yml
+++ b/.github/actions/setup-oblt-cli/action.yml
@@ -34,3 +34,6 @@ runs:
         OBLT_CLI_USERNAME: ${{ inputs.username }}
         OBLT_CLI_SLACK_CHANNEL: ${{ inputs.slack-channel }}
       shell: bash
+    - name: Export env
+      run: echo "ELASTIC_APM_ENVIRONMENT=ci" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-oblt-cli/action.yml
+++ b/.github/actions/setup-oblt-cli/action.yml
@@ -17,13 +17,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download oblt-cli
+    - name: Download oblt-cli and append to PATH
       run: ${{ github.action_path }}/download.sh
       env:
         GH_TOKEN: ${{ inputs.github-token }}
-      shell: bash
-    - name: Append oblt-cli to PATH
-      run: echo "${HOME}/oblt-cli" >> "${GITHUB_PATH}"
       shell: bash
     - name: Configure oblt-cli
       run: >

--- a/.github/actions/setup-oblt-cli/action.yml
+++ b/.github/actions/setup-oblt-cli/action.yml
@@ -1,0 +1,39 @@
+name: Setup oblt-cli
+
+description: Setup oblt-cli
+
+inputs:
+  github-token:
+    description: 'The GitHub access token.'
+    required: true
+  slack-channel:
+    description: 'The slack channel to notify the status.'
+    default: '#observablt-bots'
+    required: false
+  username:
+    description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
+    default: 'apmmachine'
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Download oblt-cli
+      run: ${{ github.action_path }}/download.sh
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      shell: bash
+    - name: Append oblt-cli to PATH
+      run: echo "${HOME}/oblt-cli" >> "${GITHUB_PATH}"
+      shell: bash
+    - name: Configure oblt-cli
+      run: >
+        oblt-cli configure
+        --git-http-mode
+        --username="${OBLT_CLI_USERNAME}"
+        --slack-channel="${OBLT_CLI_SLACK_CHANNEL}"
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        ELASTIC_APM_ENVIRONMENT: ci
+        OBLT_CLI_USERNAME: ${{ inputs.username }}
+        OBLT_CLI_SLACK_CHANNEL: ${{ inputs.slack-channel }}
+      shell: bash

--- a/.github/actions/setup-oblt-cli/download.sh
+++ b/.github/actions/setup-oblt-cli/download.sh
@@ -2,20 +2,22 @@
 
 set -euo pipefail
 
+BIN_DIR="$HOME/oblt-cli/bin"
+
 if [[ ${RUNNER_OS} == "Linux" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "$HOME"
+    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
   elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "$HOME"
+    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
   else
     echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
     exit 1
   fi
 elif [[ ${RUNNER_OS} == "macOS" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "$HOME"
+      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
     elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "$HOME"
+      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
     else
       echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
       exit 1
@@ -24,3 +26,5 @@ else
   echo "Unsupported OS: ${RUNNER_OS}"
   exit 1
 fi
+
+echo "${BIN_DIR}" >> "${GITHUB_PATH}"

--- a/.github/actions/setup-oblt-cli/download.sh
+++ b/.github/actions/setup-oblt-cli/download.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ${RUNNER_OS} == "Linux" ]]; then
+  if [[ ${RUNNER_ARCH} == "X64" ]]; then
+    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "$HOME"
+  elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
+    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "$HOME"
+  else
+    echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
+    exit 1
+  fi
+elif [[ ${RUNNER_OS} == "macOS" ]]; then
+  if [[ ${RUNNER_ARCH} == "X64" ]]; then
+      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "$HOME"
+    elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
+      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "$HOME"
+    else
+      echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
+      exit 1
+    fi
+else
+  echo "Unsupported OS: ${RUNNER_OS}"
+  exit 1
+fi

--- a/.github/actions/setup-oblt-cli/download.sh
+++ b/.github/actions/setup-oblt-cli/download.sh
@@ -4,20 +4,22 @@ set -euo pipefail
 
 BIN_DIR="$HOME/oblt-cli/bin"
 
+mkdir -p "${BIN_DIR}"
+
 if [[ ${RUNNER_OS} == "Linux" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
+    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
   elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
+    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
   else
     echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
     exit 1
   fi
 elif [[ ${RUNNER_OS} == "macOS" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
+      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
     elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}}"
+      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
     else
       echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
       exit 1


### PR DESCRIPTION
## What does this PR do?

Add an action that sets up `oblt-cli`

## Why is it important?

In a new workflow that is currently in the works, I have a shell script that uses `oblt-cli`. 
I need this action to make oblt-cli available in the `PATH`.

## Related issues
Closes #ISSUE
