### PR TITLE
chore: disable banner when oblt-cli run on CI

### DIFF
--- a/.github/actions/oblt-cli/action.yml
+++ b/.github/actions/oblt-cli/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: run oblt-cli
       run: |
-        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose
+        GITHUB_TOKEN=${{ inputs.token }} ./oblt-cli ${{ inputs.command }} --verbose --disable-banner
       env:
         ELASTIC_APM_ENVIRONMENT: ci
       shell: bash


### PR DESCRIPTION
The banner add some time and contains info not interested for the CI users

## What does this PR do?

chore: disable banner when oblt-cli run on CI
