### PR TITLE
Add slack notification to publish-docker-images workflow

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -119,3 +119,11 @@ jobs:
           else
             bash -c "${{ matrix.push_script }}"
           fi
+
+      - if: failure()
+        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#observablt-bots"


### PR DESCRIPTION
## What does this PR do?

Adds slack notificaiton to the publish-docker-images workflow

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
