### PR TITLE
action: support flag to disable random cluster name

### DIFF
--- a/.github/actions/oblt-cli-create-custom/README.md
+++ b/.github/actions/oblt-cli-create-custom/README.md
@@ -44,6 +44,7 @@ Following inputs can be used as `step.with` keys
 | `token`                     | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
+| `random-seed`               | Boolean | `true`                      | Whether to skip the randomised cluster name |
 | `dry-run`                   | Boolean | `false`                     | Whether to dry-run the oblt-cli. |
 | `slackChannel`              | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `username`                  | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/oblt-cli-create-custom/README.md
+++ b/.github/actions/oblt-cli-create-custom/README.md
@@ -44,7 +44,7 @@ Following inputs can be used as `step.with` keys
 | `token`                     | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
-| `skip-random-name`               | Boolean | `false`                      | Whether to skip the randomised cluster name |
+| `skip-random-name`          | Boolean | `false`                      | Whether to skip the randomised cluster name |
 | `dry-run`                   | Boolean | `false`                     | Whether to dry-run the oblt-cli. |
 | `slackChannel`              | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `username`                  | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/oblt-cli-create-custom/README.md
+++ b/.github/actions/oblt-cli-create-custom/README.md
@@ -44,7 +44,7 @@ Following inputs can be used as `step.with` keys
 | `token`                     | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
-| `random-seed`               | Boolean | `true`                      | Whether to skip the randomised cluster name |
+| `skip-random-name`               | Boolean | `false`                      | Whether to skip the randomised cluster name |
 | `dry-run`                   | Boolean | `false`                     | Whether to dry-run the oblt-cli. |
 | `slackChannel`              | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli. |
 | `username`                  | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/oblt-cli-create-custom/action.yml
+++ b/.github/actions/oblt-cli-create-custom/action.yml
@@ -78,7 +78,8 @@ runs:
             && echo -n '--cluster-name-suffix=${{ inputs.cluster-name-suffix }} '
           [ '${{ inputs.dry-run }}' == 'true' ] \
             && echo -n '--dry-run '
-          echo -n '--skip-random-name=${{ inputs.skip-random-name }} '
+          [ '${{ inputs.skip-random-name }}' == 'true' ] \
+            && echo -n '--skip-random-name '
         } > .flags
         echo "COMMAND=$(cat .flags)" >> $GITHUB_ENV
         rm .flags

--- a/.github/actions/oblt-cli-create-custom/action.yml
+++ b/.github/actions/oblt-cli-create-custom/action.yml
@@ -32,7 +32,10 @@ inputs:
     description: 'Whether to dryRun'
     default: false
     required: false
-
+  random-seed:
+    description: 'Whether to deploy a cluster with a random name'
+    default: true
+    required: false
 runs:
   using: "composite"
   steps:
@@ -75,6 +78,7 @@ runs:
             && echo -n '--cluster-name-suffix=${{ inputs.cluster-name-suffix }} '
           [ '${{ inputs.dry-run }}' == 'true' ] \
             && echo -n '--dry-run '
+          echo -n '--random-seed=${{ inputs.random-seed }} '
         } > .flags
         echo "COMMAND=$(cat .flags)" >> $GITHUB_ENV
         rm .flags

--- a/.github/actions/oblt-cli-create-custom/action.yml
+++ b/.github/actions/oblt-cli-create-custom/action.yml
@@ -32,9 +32,9 @@ inputs:
     description: 'Whether to dryRun'
     default: false
     required: false
-  random-seed:
+  skip-random-name:
     description: 'Whether to deploy a cluster with a random name'
-    default: true
+    default: false
     required: false
 runs:
   using: "composite"
@@ -78,7 +78,7 @@ runs:
             && echo -n '--cluster-name-suffix=${{ inputs.cluster-name-suffix }} '
           [ '${{ inputs.dry-run }}' == 'true' ] \
             && echo -n '--dry-run '
-          echo -n '--random-seed=${{ inputs.random-seed }} '
+          echo -n '--skip-random-name=${{ inputs.skip-random-name }} '
         } > .flags
         echo "COMMAND=$(cat .flags)" >> $GITHUB_ENV
         rm .flags


### PR DESCRIPTION
## What does this PR do?

Enable the flag for the random cluster name.

## Why is it important?

We can support reusing cluster deployments.

## Related issues

Caused by https://github.com/elastic/observability-test-environments/pull/9314
