### PR TITLE
action: release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
-
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@main
-        with:
-          registry: docker.elastic.co
-          secret: secret/observability-team/ci/docker-registry/prod
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
         with:
@@ -38,6 +26,19 @@ jobs:
           username: ${{ env.GIT_USER }}
           email: ${{ env.GIT_EMAIL }}
           token: ${{ env.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@main
+        with:
+          registry: docker.elastic.co
+          secret: secret/observability-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION

## What does this PR do?

Support releases using the service account

## Why is it important?

Branch protection does not allow to use the maven release out of the box. This should help us to use it while we move away from Jenkins.

## Related issues
similar to https://github.com/elastic/apm-agent-java/pull/3178
