### PR TITLE
docker: remove some docker image generation for ruby

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -247,30 +247,6 @@ images:
     test_script: "./run.sh --action test --registry 'elasticobservability'"
     push_script: "./run.sh --action push --registry 'elasticobservability'"
 
-  - <<: *apm-agent-ruby-docker-images
-    tag: "ruby-3.0"
-    build_opts: "--build-arg RUBY_IMAGE='ruby:3.0'"
-
-  - <<: *apm-agent-ruby-docker-images
-    tag: "ruby-2.7"
-    build_opts: "--build-arg RUBY_IMAGE='ruby:2.7'"
-
-  - <<: *apm-agent-ruby-docker-images
-    tag: "ruby-2.6"
-    build_opts: "--build-arg RUBY_IMAGE='ruby:2.6'"
-
-  - <<: *apm-agent-ruby-docker-images
-    tag: "ruby-2.5"
-    build_opts: "--build-arg RUBY_IMAGE='ruby:2.5'"
-
-  - <<: *apm-agent-ruby-docker-images
-    tag: "ruby-2.4"
-    build_opts: "--build-arg RUBY_IMAGE='ruby:2.4'"
-
-  - <<: *apm-agent-ruby-docker-images
-    tag: "jruby-9.2"
-    build_opts: "--build-arg RUBY_IMAGE='jruby:9.2'"
-
   # APM Agent RUM Docker images
 
   - <<: *apm-agent-rum-docker-images


### PR DESCRIPTION
## What does this PR do?

Those docker images are not consumed by the `apm-agent-ruby`.

## Why is it important?

The `apm-agent-ruby` build process already builds those docker images. Hence there is no need to build them again.

We could potentially change the `apm-agent-ruby` to consume them if they exist rather than building them again from scratch. But for the time being, I'd prefer we remove the logic in this repository