### PR TITLE
Update nodeJSDefaultVersion.groovy to 18.17.1

### DIFF
--- a/vars/nodeJSDefaultVersion.groovy
+++ b/vars/nodeJSDefaultVersion.groovy
@@ -30,5 +30,5 @@ def call(Map args = [:]) {
 }
 
 def defaultVersion(){
-  return '14.17.5'
+  return '18.17.1'
 }


### PR DESCRIPTION
## What does this PR do?

Upgrades the node version to the latest LTS version, this was breaking synthetics tests that depend on node 14 features.
I'm not sure if other Jenkins stuff would have an issue with this version.

## Why is it important?

Unblocks development of heartbeat

## Related issues

https://github.com/elastic/beats/pull/36147/