### PR TITLE
action: run hourly

### DIFF
--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -4,7 +4,7 @@ name: generate-elastic-stack-snapshots
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1-5'
+    - cron: '0 */1 * * 1-5'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What does this PR do?

Run hourly

## Why is it important?

Unified release might take a few days to bump a new minor in `main` so running this daily when that happens might produce another 24 hours delay at most.

Let's avoid that by running more often
