### PR TITLE
action: PRs don't have access to GH secrets

### DIFF
--- a/.github/workflows/test-notify-build-status.yml
+++ b/.github/workflows/test-notify-build-status.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - dependabot/*
+      - 'dependabot/**'
     paths:
       - '.github/actions/notify-build-status/**'
       - '.github/workflows/test-notify-build-status.yml'

--- a/.github/workflows/test-notify-build-status.yml
+++ b/.github/workflows/test-notify-build-status.yml
@@ -2,14 +2,11 @@
 name: test-notify-build-status
 
 on:
-  pull_request:
-    paths:
-      - '.github/actions/notify-build-status/**'
-      - '.github/workflows/test-notify-build-status.yml'
   workflow_dispatch:
   push:
     branches:
       - main
+      - dependabot/*
     paths:
       - '.github/actions/notify-build-status/**'
       - '.github/workflows/test-notify-build-status.yml'


### PR DESCRIPTION
## What does this PR do?

PRs don't have access to secrets let's use feature branches.

## Why is it important?

Fixes https://github.com/elastic/apm-pipeline-library/pull/2354 that failed when accessing the secrets
