### PR TITLE
fix: update the serverless cluster reference

### DIFF
--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -62,7 +62,7 @@ runs:
         # If serverless
         if [ "${{ inputs.serverless }}" == 'true' ] ; then
           if [ "${TARGET_BRANCH}" == 'main' ] ; then
-            echo "CLUSTER=serverless-oblt" >> $GITHUB_ENV
+            echo "CLUSTER=serverless-qa-oblt" >> $GITHUB_ENV
             exit 0
           fi
           MESSAGE="You cannot deploy your PR when targeting a branch other than main"


### PR DESCRIPTION
serverless-oblt was replaced by serverless-qa-oblt

## What does this PR do?

fix: update the serverless cluster reference

## Why is it important?

The command /obl-deploy-serverless is failing. It requires a release of the library.
