### PR TITLE
action: support messageIfFailure in the updatecli

### DIFF
--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'What slack channel to be used for notifying any failures while running the updatecli'
     default: '#observablt-bots'
     required: false
+  messageIfFailure:
+    description: 'What message to be sent if any failures while running the updatecli'
+    default: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -77,4 +81,4 @@ runs:
         roleId: ${{ inputs.vaultRoleId }}
         secretId: ${{ inputs.vaultSecretId }}
         channel: ${{ inputs.notifySlackChannel }}
-        message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+        message: ${{ inputs.messageIfFailure }}

--- a/.github/workflows/test-updatecli.yml
+++ b/.github/workflows/test-updatecli.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@main
+      - uses: ./.github/actions/updatecli
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/file-doesnt-exist-so-it-should-fail-and-notify-error
+          messageIfFailure: "my super duper-message"

--- a/.github/workflows/test-updatecli.yml
+++ b/.github/workflows/test-updatecli.yml
@@ -11,6 +11,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/updatecli
         with:

--- a/.github/workflows/test-updatecli.yml
+++ b/.github/workflows/test-updatecli.yml
@@ -8,7 +8,19 @@ permissions:
   contents: read
 
 jobs:
-  bump:
+  bump-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/updatecli
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/file-doesnt-exist-so-it-should-fail-and-notify-error
+
+  bump-override:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do?

Add `messageIfFailure` in the updatecli

## Why is it important?

Other teams can customise who should be notified and what message to be sent if any failure


## Test

https://github.com/elastic/apm-pipeline-library/actions/runs/6189566360 produced two messages

<img width="696" alt="image" src="https://github.com/elastic/apm-pipeline-library/assets/2871786/dffc0389-98ab-411f-a9de-3ee21b27d9d7">
