### PR TITLE
Add outputs to `kibana-docker-image` action

### DIFF
--- a/.github/actions/kibana-docker-image/action.yml
+++ b/.github/actions/kibana-docker-image/action.yml
@@ -29,7 +29,7 @@ inputs:
 outputs:
   ref:
     description: |
-      Will be deprecated: Use 'kibana-docker-image' instead.
+      Will be deprecated. Use 'kibana-docker-image' instead.
       The reference of the Docker image that was built in the format image:tag.
     value: ${{ steps.vars.outputs.docker-reference }}
   kibana-docker-image:

--- a/.github/actions/kibana-docker-image/action.yml
+++ b/.github/actions/kibana-docker-image/action.yml
@@ -30,6 +30,9 @@ outputs:
   ref:
     description: The reference of the Docker image that was built in the format image:tag.
     value: ${{ steps.vars.outputs.docker-reference }}
+  git-commit-sha:
+    description: The git commit SHA of the image that was built.
+    value: ${{ steps.vars.outputs.kibana-commit-sha }}
 
 runs:
   using: composite

--- a/.github/actions/kibana-docker-image/action.yml
+++ b/.github/actions/kibana-docker-image/action.yml
@@ -40,7 +40,7 @@ outputs:
     value: ${{ steps.vars.outputs.kibana-commit-sha }}
   kibana-stack-version:
     description: The elastic stack version of Kibana that was built.
-    value: ${{ steps.vars.outputs.kibana-version }}
+    value: ${{ steps.vars.outputs.kibana-stack-version }}
 
 runs:
   using: composite

--- a/.github/actions/kibana-docker-image/action.yml
+++ b/.github/actions/kibana-docker-image/action.yml
@@ -28,12 +28,17 @@ inputs:
 
 outputs:
   ref:
+    description: |
+      Will be deprecated: Use 'kibana-docker-image' instead.
+      The reference of the Docker image that was built in the format image:tag.
+    value: ${{ steps.vars.outputs.docker-reference }}
+  kibana-docker-image:
     description: The reference of the Docker image that was built in the format image:tag.
     value: ${{ steps.vars.outputs.docker-reference }}
-  git-commit-sha:
+  kibana-commit-sha:
     description: The git commit SHA of the image that was built.
     value: ${{ steps.vars.outputs.kibana-commit-sha }}
-  stack-version:
+  kibana-stack-version:
     description: The elastic stack version of Kibana that was built.
     value: ${{ steps.vars.outputs.kibana-version }}
 

--- a/.github/actions/kibana-docker-image/action.yml
+++ b/.github/actions/kibana-docker-image/action.yml
@@ -33,6 +33,9 @@ outputs:
   git-commit-sha:
     description: The git commit SHA of the image that was built.
     value: ${{ steps.vars.outputs.kibana-commit-sha }}
+  stack-version:
+    description: The elastic stack version of Kibana that was built.
+    value: ${{ steps.vars.outputs.kibana-version }}
 
 runs:
   using: composite

--- a/.github/actions/kibana-docker-image/setup-vars.sh
+++ b/.github/actions/kibana-docker-image/setup-vars.sh
@@ -14,6 +14,7 @@ docker_reference="${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${docker_image}:${docke
 
 {
   echo "kibana-version=${kibana_version}"
+  echo "kibana-commit-sha=${kibana_commit_sha}"
   echo "docker-registry=${DOCKER_REGISTRY}"
   echo "docker-namespace=${DOCKER_NAMESPACE}"
   echo "docker-image=${docker_image}"

--- a/.github/actions/kibana-docker-image/setup-vars.sh
+++ b/.github/actions/kibana-docker-image/setup-vars.sh
@@ -11,7 +11,6 @@ kibana_commit_sha=$(git rev-parse HEAD)
 kibana_version="$(jq -r .version package.json)-SNAPSHOT"
 docker_tag="${kibana_version}-${kibana_commit_sha}"
 docker_reference="${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${docker_image}:${docker_tag}"
-
 {
   echo "kibana-version=${kibana_version}"
   echo "kibana-commit-sha=${kibana_commit_sha}"

--- a/.github/actions/kibana-docker-image/setup-vars.sh
+++ b/.github/actions/kibana-docker-image/setup-vars.sh
@@ -8,11 +8,11 @@ if [[ "${SERVERLESS}" == "true" ]]; then
 fi
 
 kibana_commit_sha=$(git rev-parse HEAD)
-kibana_version="$(jq -r .version package.json)-SNAPSHOT"
-docker_tag="${kibana_version}-${kibana_commit_sha}"
+kibana_stack_version="$(jq -r .version package.json)-SNAPSHOT"
+docker_tag="${kibana_stack_version}-${kibana_commit_sha}"
 docker_reference="${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${docker_image}:${docker_tag}"
 {
-  echo "kibana-version=${kibana_version}"
+  echo "kibana-stack-version=${kibana_stack_version}"
   echo "kibana-commit-sha=${kibana_commit_sha}"
   echo "docker-registry=${DOCKER_REGISTRY}"
   echo "docker-namespace=${DOCKER_NAMESPACE}"

--- a/.github/workflows/test-kibana-docker-image-action.yml
+++ b/.github/workflows/test-kibana-docker-image-action.yml
@@ -30,10 +30,12 @@ jobs:
         id: kibana-docker-image
       - name: Verify
         run: |
+          echo "${GIT_COMMIT_SHA:?}"
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
           DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
+          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:
@@ -59,10 +61,12 @@ jobs:
           serverless: true
       - name: Verify
         run: |
+          echo "${GIT_COMMIT_SHA:?}"
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
           DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
+          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:

--- a/.github/workflows/test-kibana-docker-image-action.yml
+++ b/.github/workflows/test-kibana-docker-image-action.yml
@@ -35,9 +35,9 @@ jobs:
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
-          DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
-          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
-          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.stack-version }}
+          DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.kibana-docker-image }}
+          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.kibana-commit-sha }}
+          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.kibana-stack-version }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:
@@ -68,9 +68,9 @@ jobs:
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
-          DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
-          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
-          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.stack-version }}
+          DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.kibana-docker-image }}
+          GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.kibana-commit-sha }}
+          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.kibana-stack-version }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:

--- a/.github/workflows/test-kibana-docker-image-action.yml
+++ b/.github/workflows/test-kibana-docker-image-action.yml
@@ -30,12 +30,14 @@ jobs:
         id: kibana-docker-image
       - name: Verify
         run: |
+          echo "${STACK_VERSION:?}"
           echo "${GIT_COMMIT_SHA:?}"
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
           DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
           GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
+          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.stack-version }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:
@@ -61,12 +63,14 @@ jobs:
           serverless: true
       - name: Verify
         run: |
+          echo "${STACK_VERSION:?}"
           echo "${GIT_COMMIT_SHA:?}"
           echo "${DOCKER_IMAGE_REF:?}"
           docker pull "${DOCKER_IMAGE_REF}"
         env:
           DOCKER_IMAGE_REF: ${{ steps.kibana-docker-image.outputs.ref }}
           GIT_COMMIT_SHA: ${{ steps.kibana-docker-image.outputs.git-commit-sha }}
+          STACK_VERSION: ${{ steps.kibana-docker-image.outputs.stack-version }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@main
         with:


### PR DESCRIPTION
## What does this PR do?


Adds the output `git-commit-sha` and `stack-version` to the `kibana-docker-image` action.
<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

This output can be used in further steps. 
E.g. 
- creating a commit status
- using the stack version for oblt-cli

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
