### PR TITLE
Add ability to cancel BK build when workflow is cancelled

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -112,7 +112,7 @@ runs:
           echo "BUILDKITE_API_ACCESS_TOKEN=" >> $GITHUB_ENV
 
       - name: Cancel Buildkite pipeline
-        if: cancelled() inputs.waitFor && steps.trigger-buildkite.outputs.build_number
+        if: cancelled() && inputs.waitFor && steps.trigger-buildkite.outputs.build_number
         run: |
           ${{ github.action_path }}/cancel.sh \
             '${{ inputs.org }}' \

--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -110,3 +110,13 @@ runs:
         shell: bash
         run: |
           echo "BUILDKITE_API_ACCESS_TOKEN=" >> $GITHUB_ENV
+
+      - name: Cancel Buildkite pipeline
+        if: cancelled() inputs.waitFor && steps.trigger-buildkite.outputs.build_number
+        run: |
+          ${{ github.action_path }}/cancel.sh \
+            '${{ inputs.org }}' \
+            '${{ inputs.pipeline }}' \
+            '${{ steps.trigger-buildkite.outputs.build_number }}' \
+            '${{ env.BUILDKITE_API_ACCESS_TOKEN }}'
+        shell: bash

--- a/.github/actions/buildkite/cancel.sh
+++ b/.github/actions/buildkite/cancel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Cancel the running build
+#
+set -euo pipefail
+
+MSG="parameter missing."
+ORG=${1:?$MSG}
+PIPELINE=${2:?$MSG}
+NUMBER=${3:?$MSG}
+BK_TOKEN=${4:?$MSG}
+
+curl \
+  --no-progress-meter \
+  -H "Authorization: Bearer $BK_TOKEN" \
+  -X "PUT" \
+  "https://api.buildkite.com/v2/organizations/$ORG/pipelines/$PIPELINE/builds/$NUMBER/cancel"


### PR DESCRIPTION
## What does this PR do?

Add ability to cancel BK build when workflow is cancelled


## Why is it important?

When we have a long running BK build and `waitFor == true` and we want to cancel the workflow.

## Related issues
Closes #ISSUE
