### PR TITLE
Add pipelineCommit and pipelineBranch inputs to buildkite action

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -33,10 +33,19 @@ inputs:
   buildEnvVars:
     description: 'Additional environment variables to set on the build.'
     required: false
+  pipelineBranch:
+    description: 'Branch the commit belongs to. This allows you to take advantage of your pipeline and step-level branch filtering rules.'
+    default: main
+    required: false
+  pipelineCommit:
+    description: 'Ref, SHA or tag to be built.'
+    default: HEAD
+    required: false
   pipelineVersion:
     description: 'The pipeline version to be used (e.g. git sha, tag, branch).'
     default: HEAD
     required: false
+    deprecationMessage: "Use pipelineCommit instead."
   triggerMessage:
     description: 'The BK build message to be shown in the UI.'
     default: Triggered automatically with GH actions
@@ -82,7 +91,8 @@ runs:
             '${{ inputs.printBuildLogs }}' \
             '${{ env.BUILDKITE_API_ACCESS_TOKEN }}' \
             '${{ inputs.triggerMessage }}' \
-            '${{ inputs.pipelineVersion }}'
+            '${{ inputs.pipelineCommit || inputs.pipelineVersion }}' \
+            '${{ inputs.pipelineBranch }}'
         shell: bash
 
       - id: download-artifacts

--- a/.github/actions/buildkite/run.sh
+++ b/.github/actions/buildkite/run.sh
@@ -27,11 +27,12 @@ PRINT_BUILD=${5:?$MSG}
 BK_TOKEN=${6:?$MSG}
 MESSAGE=${7:-"Triggered automatically with GH actions"}
 PIPELINE_VERSION=${8:-"HEAD"}
+PIPELINE_BRANCH=${9:-"main"}
 
 JSON=$(
 jq -c -n \
   --arg COMMIT "$PIPELINE_VERSION" \
-  --arg BRANCH "main" \
+  --arg BRANCH "${PIPELINE_BRANCH}" \
   --arg MESSAGE "$MESSAGE" \
   '{
     "commit": $COMMIT,


### PR DESCRIPTION
## What does this PR do?

- Add `pipelineCommit` and `pipelineBranch` inputs to buildkite action.
- deprecates `pipeline

This is in line with the [Buildkite Builds API](https://buildkite.com/docs/apis/rest-api/builds#create-a-build).

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

For testing purposes I was not able to trigger the pipeline from a specific branch, it would always checkout the main.

This gives us the ability to do so.

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
