### PR TITLE
fix: create the arm64 Kibana Docker image for serverless

### DIFF
--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -48,7 +48,6 @@ time node scripts/build \
       --docker-namespace="${DOCKER_NAMESPACE}" \
       --docker-tag="${DOCKER_TAG}" \
       --docker-push \
-      --skip-archives \
       --skip-initialize \
       --skip-docker-contexts \
       --skip-docker-ubi \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -34,10 +34,13 @@ echo "::group::Build docker images"
 if [ "${SERVERLESS}" == "false" ] ; then
   skip_docker_flag="--skip-docker-serverless"
   docker_cross_compile=""
+  all_platforms=""
 else
   skip_docker_flag="--skip-docker-cloud"
   docker_cross_compile="--docker-cross-compile"
+  all_platforms="--all-platforms"
 fi
+
 time node scripts/build \
       --docker-images \
       --docker-namespace="${DOCKER_NAMESPACE}" \
@@ -51,5 +54,6 @@ time node scripts/build \
       --skip-generic-folders \
       --skip-platform-folders \
       "${skip_docker_flag}" \
-      "${docker_cross_compile}"
+      "${docker_cross_compile}" \
+      "${all_platforms}"
 echo "::endgroup::"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -51,7 +51,6 @@ time node scripts/build \
       --skip-docker-contexts \
       --skip-docker-ubi \
       --skip-docker-ubuntu \
-      --skip-generic-folders \
       --skip-platform-folders \
       "${skip_docker_flag}" \
       "${docker_cross_compile}" \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -49,7 +49,7 @@ else
   # enable Docker multiarch support
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   time node scripts/build \
-        --release
+        --release \
         --docker-cross-compile \
         --docker-images \
         --docker-namespace="${DOCKER_NAMESPACE}" \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -46,7 +46,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
         --skip-platform-folders \
         --skip-docker-serverless
 else
-  # enable Docker multiarch support
+  # enable Docker multiarch support
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   time node scripts/build \
         --release \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -34,7 +34,7 @@ echo "::group::Build docker images"
 if [ "${SERVERLESS}" == "false" ] ; then
   skip_docker_flag="--skip-docker-serverless"
 else
-  skip_docker_flag="--skip-docker-cloud"
+  skip_docker_flag="--skip-docker-cloud --docker-cross-compile"
 fi
 time node scripts/build \
       --docker-images \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -48,7 +48,6 @@ time node scripts/build \
       --docker-namespace="${DOCKER_NAMESPACE}" \
       --docker-tag="${DOCKER_TAG}" \
       --docker-push \
-      --skip-initialize \
       --skip-docker-contexts \
       --skip-docker-ubi \
       --skip-docker-ubuntu \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -38,7 +38,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
 else
   skip_docker_flag="--skip-docker-cloud"
   docker_cross_compile="--docker-cross-compile"
-  all_platforms="--all-platforms"
+  all_platforms="--release"
 fi
 
 time node scripts/build \
@@ -46,7 +46,6 @@ time node scripts/build \
       --docker-namespace="${DOCKER_NAMESPACE}" \
       --docker-tag="${DOCKER_TAG}" \
       --docker-push \
-      --skip-archives \
       --skip-initialize \
       --skip-docker-contexts \
       --skip-docker-ubi \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -46,12 +46,9 @@ time node scripts/build \
       --docker-namespace="${DOCKER_NAMESPACE}" \
       --docker-tag="${DOCKER_TAG}" \
       --docker-push \
-      --skip-initialize \
       --skip-docker-contexts \
       --skip-docker-ubi \
       --skip-docker-ubuntu \
-      --skip-generic-folders \
-      --skip-platform-folders \
       "${skip_docker_flag}" \
       "${docker_cross_compile}" \
       "${all_platforms}"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -37,7 +37,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
   all_platforms=""
 else
   skip_docker_flag="--skip-docker-cloud"
-  all_platforms="--release"
+  all_platforms=""
   # enable Docker multiarch support
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   docker_cross_compile="--docker-cross-compile"
@@ -48,9 +48,13 @@ time node scripts/build \
       --docker-namespace="${DOCKER_NAMESPACE}" \
       --docker-tag="${DOCKER_TAG}" \
       --docker-push \
+      --skip-archives \
+      --skip-initialize \
       --skip-docker-contexts \
       --skip-docker-ubi \
       --skip-docker-ubuntu \
+      --skip-generic-folders \
+      --skip-platform-folders \
       "${skip_docker_flag}" \
       "${docker_cross_compile}" \
       "${all_platforms}"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -37,8 +37,10 @@ if [ "${SERVERLESS}" == "false" ] ; then
   all_platforms=""
 else
   skip_docker_flag="--skip-docker-cloud"
-  docker_cross_compile="--docker-cross-compile"
   all_platforms="--release"
+  # enable Docker multiarch support
+  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  docker_cross_compile="--docker-cross-compile"
 fi
 
 time node scripts/build \

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -32,26 +32,32 @@ echo "::endgroup::"
 # https://github.com/elastic/kibana/blob/main/.buildkite/scripts/build_kibana.sh#L21-L34
 echo "::group::Build docker images"
 if [ "${SERVERLESS}" == "false" ] ; then
-  skip_docker_flag="--skip-docker-serverless"
-  docker_cross_compile=""
-  all_platforms=""
+  time node scripts/build \
+        --docker-images \
+        --docker-namespace="${DOCKER_NAMESPACE}" \
+        --docker-tag="${DOCKER_TAG}" \
+        --docker-push \
+        --skip-archives \
+        --skip-initialize \
+        --skip-docker-contexts \
+        --skip-docker-ubi \
+        --skip-docker-ubuntu \
+        --skip-generic-folders \
+        --skip-platform-folders \
+        --skip-docker-serverless
 else
-  skip_docker_flag="--skip-docker-cloud"
-  all_platforms="--release"
   # enable Docker multiarch support
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  docker_cross_compile="--docker-cross-compile"
+  time node scripts/build \
+        --release
+        --docker-cross-compile \
+        --docker-images \
+        --docker-namespace="${DOCKER_NAMESPACE}" \
+        --docker-tag="${DOCKER_TAG}" \
+        --docker-push \
+        --skip-docker-contexts \
+        --skip-docker-ubi \
+        --skip-docker-ubuntu \
+        --skip-docker-cloud
 fi
-
-time node scripts/build \
-      --docker-images \
-      --docker-namespace="${DOCKER_NAMESPACE}" \
-      --docker-tag="${DOCKER_TAG}" \
-      --docker-push \
-      --skip-docker-contexts \
-      --skip-docker-ubi \
-      --skip-docker-ubuntu \
-      "${skip_docker_flag}" \
-      "${docker_cross_compile}" \
-      "${all_platforms}"
 echo "::endgroup::"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -51,7 +51,6 @@ time node scripts/build \
       --skip-docker-contexts \
       --skip-docker-ubi \
       --skip-docker-ubuntu \
-      --skip-platform-folders \
       "${skip_docker_flag}" \
       "${docker_cross_compile}" \
       "${all_platforms}"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -33,8 +33,10 @@ echo "::endgroup::"
 echo "::group::Build docker images"
 if [ "${SERVERLESS}" == "false" ] ; then
   skip_docker_flag="--skip-docker-serverless"
+  docker_cross_compile=""
 else
-  skip_docker_flag="--skip-docker-cloud --docker-cross-compile"
+  skip_docker_flag="--skip-docker-cloud"
+  docker_cross_compile="--docker-cross-compile"
 fi
 time node scripts/build \
       --docker-images \
@@ -48,5 +50,6 @@ time node scripts/build \
       --skip-docker-ubuntu \
       --skip-generic-folders \
       --skip-platform-folders \
-      "${skip_docker_flag}"
+      "${skip_docker_flag}" \
+      "${docker_cross_compile}"
 echo "::endgroup::"

--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -37,7 +37,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
   all_platforms=""
 else
   skip_docker_flag="--skip-docker-cloud"
-  all_platforms=""
+  all_platforms="--release"
   # enable Docker multiarch support
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   docker_cross_compile="--docker-cross-compile"


### PR DESCRIPTION
## What does this PR do?

create the arm64 Kibana Docker image for serverless

## Why is it important?

The current implementation only generates amd64 Docker images that are no longer valid for serverless projects in QA. We split the command to better maintainability due to Kibana build flags can impact each other. We need to review if it is possible to skip something else in the serverless build because it takes longer than before.