### PR TITLE
updatecli: use groups

### DIFF
--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -88,7 +88,8 @@ sources:
       key: .build_id
     transformers:
       - findsubmatch:
-          pattern: "[0-9].[0-9].[0-9]"
+          pattern: "([0-9].[0-9].[0-9])-(.*)"
+          captureindex: 1
 
 conditions:
   docker_next7:


### PR DESCRIPTION
## What does this PR do?

Use groups to get the first one

## Why is it important?

Otherwise it will return something else

```
		✗ [docker_edge8] Is docker image elasticsearch:80852-SNAPSHOT available
```

See https://github.com/elastic/apm-pipeline-library/actions/runs/6509890106/job/17682399721
