### PR TITLE
updatecli: use digits

### DIFF
--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -88,7 +88,7 @@ sources:
       key: .build_id
     transformers:
       - findsubmatch:
-          pattern: "([0-9].[0-9].[0-9])-(.*)"
+          pattern: "(\d+.\d+.\d+)-(.*)"
           captureindex: 1
 
 conditions:

--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -88,7 +88,7 @@ sources:
       key: .build_id
     transformers:
       - findsubmatch:
-          pattern: "(\d+.\d+.\d+)-(.*)"
+          pattern: '(\d+.\d+.\d+)-(.+)'
           captureindex: 1
 
 conditions:


### PR DESCRIPTION
## What does this PR do?

`[0-9]` is not supported but `\d` instead.

## Why is it important?

Otherwise it won't work