### PR TITLE
Revert "chore(deps): bump updatecli/updatecli-action from 2.43.0 to 2.44.0 in /.github/actions/updatecli (#2393)"

### DIFF
--- a/.github/actions/updatecli/action.yml
+++ b/.github/actions/updatecli/action.yml
@@ -61,7 +61,7 @@ runs:
         secret: ${{ inputs.dockerVaultSecret }}
 
     - name: Install Updatecli in the runner
-      uses: updatecli/updatecli-action@1fecc22224650fad964be9e12c1b26fdf46ecbd3
+      uses: updatecli/updatecli-action@a72a5270f196ed415badcad0056b4c9886da28c5
 
     - name: Run Updatecli
       run: |-


### PR DESCRIPTION


This reverts commit 0b62c6cd998b84715d12932c3863eab40dc968e4.

See https://github.com/updatecli/updatecli/issues/1706