### PR TITLE
docker: remove apm-integration-testing docker image generation

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -89,17 +89,6 @@ images:
     name: "apm-proxy-be"
     working_directory: "tools/apm_proxy/backend"
 
-  # APM ITs Docker Images are built daily.
-
-  - name: "apm-integration-testing"
-    repository: "elastic/apm-integration-testing"
-    tag: "daily"
-
-  - name: "apm-integration-testing-all"
-    repository: "elastic/apm-integration-testing"
-    build_script: "make -C docker all-tests"
-    push_script: "make -C docker all-push"
-
   # Opbeans Docker Images
 
   - <<: *opbeans-docker-images


### PR DESCRIPTION
## What does this PR do?

Remove apm-integration-testing docker image generation

## Why is it important?

We don't use apm-integration-testing these days.