### PR TITLE
fix: parameters when using ccs

### DIFF
--- a/.github/actions/oblt-cli-create-ccs/action.yml
+++ b/.github/actions/oblt-cli-create-ccs/action.yml
@@ -79,7 +79,7 @@ runs:
 
     - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@current
       with:
-        command: cluster create ccs ${{ env.COMMAND }} ${{ env.GITOPS }} --parameters='{"EphemeralCluster":"true"}'
+        command: cluster create ccs ${{ env.COMMAND }} ${{ env.GITOPS }}
         slackChannel: ${{ inputs.slackChannel }}
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
## What does this PR do?

remove parameters when using `cluster create ccs`

since it's not supported