### PR TITLE
chore: Loosen up opentelemetry versions

### DIFF
--- a/resources/scripts/pytest_otel/requirements.txt
+++ b/resources/scripts/pytest_otel/requirements.txt
@@ -1,9 +1,9 @@
 coverage==7.0.5
-opentelemetry-api==1.15.0
-opentelemetry-exporter-otlp==1.15.0
-opentelemetry-sdk==1.15.0
+opentelemetry-api~=1.15
+opentelemetry-exporter-otlp~=1.15
+opentelemetry-sdk~=1.15
 psutil==5.9.3
-pytest==7.2.1
+pytest~=7.2
 pre-commit==2.21.0
 mypy==0.982
 pytest-docker==1.0.1

--- a/resources/scripts/pytest_otel/setup.cfg
+++ b/resources/scripts/pytest_otel/setup.cfg
@@ -33,10 +33,10 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    opentelemetry-api==1.15.0
-    opentelemetry-exporter-otlp==1.15.0
-    opentelemetry-sdk==1.15.0
-    pytest==7.2.1
+    opentelemetry-api~=1.15
+    opentelemetry-exporter-otlp~=1.15
+    opentelemetry-sdk~=1.15
+    pytest~=7.2
 python_requires = >=3.6
 include_package_data = True
 package_dir =


### PR DESCRIPTION

This make sures the downstream can consume this library without pinning otel's version to 1.15.0.
Otel's version is fairly stable so, everything >=1 and <2 should be safe.