### PR TITLE
update-cli: workflow link is now supported natively

### DIFF
--- a/.github/workflows/bump-aliases.yml
+++ b/.github/workflows/bump-aliases.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
 jobs:
   bump:
     runs-on: ubuntu-latest

--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -10,8 +10,6 @@ actions:
     spec:
       labels:
         - automation
-      description: |
-        Generated automatically with {{ requiredEnv "JOB_URL" }}
 
 scms:
   default:


### PR DESCRIPTION
## What does this PR do?

Remove the workaround to support the auditing of what github workflow produced the PR with the updatecli changes

## Why is it important?

It's now supported in updatecli itself, see https://github.com/elastic/apm-server/pull/12044:

<img width="588" alt="image" src="https://github.com/elastic/apm-pipeline-library/assets/2871786/ed18e729-531c-4ec3-96cb-fbd30533a312">


## Related issues
Closes #ISSUE
