### PR TITLE
fix: name of the serverless qa environment

### DIFF
--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -62,7 +62,7 @@ runs:
         # If serverless
         if [ "${{ inputs.serverless }}" == 'true' ] ; then
           if [ "${TARGET_BRANCH}" == 'main' ] ; then
-            echo "CLUSTER=serverless-qa-oblt" >> $GITHUB_ENV
+            echo "CLUSTER=keep_serverless-qa-oblt" >> $GITHUB_ENV
             exit 0
           fi
           MESSAGE="You cannot deploy your PR when targeting a branch other than main"


### PR DESCRIPTION
## What does this PR do?

Rename it

## Why is it important?

Otherwise it won't work

```
$ python3 .ci/scripts/find_cluster_config_by_name.py serverless-qa-oblt
```

while

```
$ python3 .ci/scripts/find_cluster_config_by_name.py keep_serverless-qa-oblt
.../environments/users/robots/keep_serverless-qa-oblt/config-cluster.yml
```
