### PR TITLE
docker-images: update to reflect what we use these days

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -161,52 +161,6 @@ images:
     build_script: ./util.sh --action build
     push_script: ./util.sh --action push
 
-  # APM Agent Node.js Docker Images
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "17"
-    build_opts: "--build-arg NODE_VERSION=17"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "16"
-    build_opts: "--build-arg NODE_VERSION=16"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "16.0"
-    build_opts: "--build-arg NODE_VERSION=16.0"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "14"
-    build_opts: "--build-arg NODE_VERSION=14"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "14.0"
-    build_opts: "--build-arg NODE_VERSION=14.0"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "12"
-    build_opts: "--build-arg NODE_VERSION=12"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "12.0"
-    build_opts: "--build-arg NODE_VERSION=12.0"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "10"
-    build_opts: "--build-arg NODE_VERSION=10"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "10.0"
-    build_opts: "--build-arg NODE_VERSION=10.0"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "8"
-    build_opts: "--build-arg NODE_VERSION=8"
-
-  - <<: *apm-agent-nodejs-docker-images
-    tag: "8.6"
-    build_opts: "--build-arg NODE_VERSION=8.6"
-
   # APM Agent Ruby Docker images
   # dockerhub
   - <<: *apm-agent-ruby-docker-images

--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -176,4 +176,4 @@ images:
     name: "node-playwright"
     tag: "12"
     working_directory: ".ci/docker/node-playwright"
-    build_opts: "--build-arg NODEJS_VERSION='12'"
+    build_opts: "--build-arg NODEJS_VERSION='14'"


### PR DESCRIPTION
## What does this PR do?

Specialised docker images for the APM Agent Nodejs are not used anymore.
Playwright - node 14. https://github.com/elastic/apm-agent-rum-js/blob/7cd5f5ecbe02ee4ddc3e648927fa4ac0ce3dbb28/.ci/scripts/benchmarks.sh#L7

## Why is it important?

Build what's needed