### PR TITLE
Pytest otel fix teardown bug

### DIFF
--- a/resources/scripts/pytest_otel/src/pytest_otel/__init__.py
+++ b/resources/scripts/pytest_otel/src/pytest_otel/__init__.py
@@ -354,7 +354,7 @@ def pytest_runtest_logreport(report):
     test_name = report.nodeid.split("::")[0]
 
     if report.failed and report.when == "teardown":
-        span = spans[test_name]
+        span = spans[session_name]
         span.set_attribute("tests.systemerr", report.capstderr)
         span.set_attribute("tests.systemout", report.capstdout)
         span.set_attribute("tests.duration", getattr(report, "duration", 0.0))

--- a/resources/scripts/pytest_otel/tests/test_pytest_otel.py
+++ b/resources/scripts/pytest_otel/tests/test_pytest_otel.py
@@ -103,7 +103,7 @@ def test_failure_teardown_plugin(pytester):
 @pytest.fixture(autouse=True)
 def bad_teardown():
     yield
-    raise RuntimeError("Bad teardown")
+    raise RuntimeError("Bad fixture teardown")
 
 def test_failure_teardown():
     pass

--- a/resources/scripts/pytest_otel/tests/test_pytest_otel.py
+++ b/resources/scripts/pytest_otel/tests/test_pytest_otel.py
@@ -95,6 +95,22 @@ def test_failure_code():
     assertTest(pytester, "test_failure_code", "failed", "ERROR", "failed", "ERROR")
 
 
+def test_failure_teardown_plugin(pytester):
+    """test a test with an exception during teardown"""
+    pytester.makepyfile(
+        common_code
+        + """
+@pytest.fixture(autouse=True)
+def bad_teardown():
+    yield
+    raise RuntimeError("Bad teardown")
+
+def test_failure_teardown():
+    pass
+""")
+    assertTest(pytester, "test_failure_teardown", "failed", "ERROR", None, "OK")
+
+
 def test_skip_plugin(pytester):
     """test a skipped test"""
     pytester.makepyfile(


### PR DESCRIPTION
## What does this PR do?

Before this patch the pytest-otel plugin would encounter INTERNALERROR if there was a bug during test teardown instead of outputting the proper error. It seems that the 'span[test_name]' expression cannot actually be valid looking at the rest of init.py

I also added a test that previously failed and now passes, though I didn't understand why all the tests seem to be duplicated in separate files in the tests/it/ directory. The make target 'make it-test' failed for me due to not having docker-compose.

Testing: 'make test'

## Why is it important?

Without the change test failures during teardown are not properly reported.

## Related issues
Closes #ISSUE
