### PR TITLE
fix: sort by semver

### DIFF
--- a/.ci/get-next-minor-version.sh
+++ b/.ci/get-next-minor-version.sh
@@ -25,4 +25,8 @@ set -eo pipefail
 URL="https://artifacts-api.elastic.co/v1"
 NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
-curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | jq -r '.[]|select(. | startswith("8"))' | tail -n1
+curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" \
+    | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' \
+    | jq -R . | jq -s '. | sort_by(.| split(".") | map(tonumber))' \
+    | jq -r '.[]|select(. | startswith("8"))' \
+    | tail -n1

--- a/resources/scripts/artifacts-api-latest-release-versions.sh
+++ b/resources/scripts/artifacts-api-latest-release-versions.sh
@@ -32,4 +32,8 @@ NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
 OUTPUT=latest-release-versions.json
 
-curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' | jq -R . | jq -s '. | sort' | tee ${OUTPUT}
+curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" \
+    | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' \
+    | jq -R . \
+    | jq -s '. | sort_by(.| split(".") | map(tonumber))' \
+    | tee ${OUTPUT}


### PR DESCRIPTION
## What does this PR do?

Sort by semver

## Why is it important?

Otherwise versions are not sorted correctly

## Related issues

Similarly done in https://github.com/elastic/apm-server/pull/12229
