### PR TITLE
releases: provide api with the google bucket

### DIFF
--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -183,5 +183,6 @@ fi
 EDGE_FOLDER=releases/edge
 mkdir -p $EDGE_FOLDER
 if [ "$(isAvailable "$edge_8")" = "true" ] ; then
-  echo "$edge_8" > "$EDGE_FOLDER/$(major "$edge_8")"
+  ## Edge always point to the main branch.
+  echo "$edge_8" > "$EDGE_FOLDER/main"
 fi

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -116,10 +116,10 @@ function isAvailable() {
 ### MAIN
 ###############
 
-## 0. Static versions
+## 0. Static versions
 current_6="6.8.23"
 
-## 1. Fetch the versions
+## 1. Fetch the versions
 current_7=$(latest v7)
 current_8=$(latest v8)
 next_7=$(incPatch "$current_7")
@@ -134,7 +134,7 @@ mkdir releases
 cd releases
 
 ### IMPORTANT:
-### This file might contain some versions that are not available yet.
+### This file might contain some versions that are not available yet.
 ### One way to solve this particular case will be by reading the current releases.properties
 ### and apply some validations with isAvailable, otherwise then fallback to the previous version.
 {

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -99,10 +99,16 @@ function majorminor() {
 # It uses docker images in the internal docker registry
 function isAvailable() {
   local version="$1"
-  if docker pull --quiet docker.elastic.co/elasticsearch/elasticsearch:"$version"-SNAPSHOT > /dev/null; then
+  # apm-server docker image is smaller.
+  if docker pull --quiet docker.elastic.co/apm/apm-server:"$version"-SNAPSHOT 2> /dev/null; then
     echo 'true'
   else
-    echo 'false'
+    # Fallback to use the elasticsearch - a quite  bigger docker image.
+    if docker pull --quiet docker.elastic.co/elasticsearch/elasticsearch:"$version"-SNAPSHOT 2> /dev/null; then
+      echo 'true'
+    else
+      echo 'false'
+    fi
   fi
 }
 

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -131,8 +131,12 @@ echo "$current_8" > "releases/current/$(majorminor "$current_8")"
 mkdir -p releases/next
 echo "$next7" > "releases/next/minor-$(major "$next7")"
 echo "$next8" > "releases/next/minor-$(major "$next8")"
+echo "$next7" > "releases/next/minor-$(majorminor "$next7")"
+echo "$next8" > "releases/next/minor-$(majorminor "$next8")"
 echo "$next7" > "releases/next/patch-$(major "$next7")"
 echo "$patch8" > "releases/next/patch-$(major "$patch8")"
+echo "$next7" > "releases/next/patch-$(majorminor "$next7")"
+echo "$patch8" > "releases/next/patch-$(majorminor "$patch8")"
 
 mkdir -p releases/edge
 echo "$edge_8" > "releases/edge/$(major "$edge_8")"

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# It produces the list of current releases, BCs or upcoming ones using the artifacts-api and GitHub API.
+# Then it does some manipulation to discard those releases that are not available. A bit opinionated.
+#
+set -eo pipefail
+
+# Get the latest github release for the given tag prefix.
+# Releases starts with v<major>, i.e: v8
+# It uses the gh cli in elastic/elasticsearch.
+# Owned by: release team
+function latest() {
+  local version="${1}"
+  gh api repos/elastic/elasticsearch/releases \
+    | jq -r --arg version "$version" '[.[].tag_name
+    | select(startswith($version))
+    | sub("v"; ""; "g")]
+    | sort_by(.| split(".") | map(tonumber))
+    | .[-1]'
+}
+
+# Get the next release for the given semver prefix.
+# Releases start with major.minor.patch.
+# It uses the artifacts-api.elastic.co entrypoint.
+# Owned by: release team
+function next() {
+  local version="${1}"
+  local URL="https://artifacts-api.elastic.co/v1"
+  local NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
+  curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" \
+    | jq -r --arg version "$version" '[.versions[]
+    | select(contains("SNAPSHOT")|not)
+    | select(startswith($version))]
+    | sort_by(.| split(".") | map(tonumber))
+    | .[-1]'
+}
+
+# Bump the patch version for the given version
+function incPatch() {
+  local version="$1"
+  version="${version#[vV]}"
+  major="${version%%\.*}"
+  minor="${version#*.}"
+  minor="${minor%.*}"
+  vpatch="${version##*.}"
+  echo "${major}.${minor}.$((vpatch + 1))"
+}
+
+# Get the latest version in the main branch.
+# It uses the https://storage.googleapis.com/artifacts-api.
+# Owned by: observability-robots
+function edge() {
+  curl -s https://storage.googleapis.com/artifacts-api/snapshots/main.json \
+  | jq -r .build_id \
+  | sed 's#-.*##g'
+}
+
+# Get the major version for the given semver
+function major() {
+  local version="$1"
+  version="${version#[vV]}"
+  major="${version%%\.*}"
+  echo "${major}"
+}
+
+# Get the major.minor version for the given semver
+function majorminor() {
+  local version="$1"
+  version="${version#[vV]}"
+  major="${version%%\.*}"
+  minor="${version#*.}"
+  minor="${minor%.*}"
+  echo "${major}.${minor}"
+}
+
+## Static versions
+current_6="6.8.23"
+
+## Fetch the versions
+current_7=$(latest v7)
+current_8=$(latest v8)
+next7=$(incPatch "$current_7")
+next8=$(next 8)
+patch8=$(incPatch "$current_8")
+edge_8=$(edge)
+
+## Validate if releases are available
+
+## Generate files
+
+### We avoid surprises by uploading the unexpected credentials json file
+mkdir releases
+cd releases
+
+{
+  echo "current_6=$current_6"
+  echo "current_7=$current_7"
+  echo "next_minor_7=$next7"
+  echo "next_patch_7=$next7"
+  echo "current_8=$current_8"
+  echo "next_minor_8=$next8"
+  echo "next_patch_8=$patch8"
+  echo "edge_8=$edge_8"
+} | tee releases.properties
+
+mkdir -p releases/current
+echo "$current_6" > "releases/current/$(major "$current_6")"
+echo "$current_7" > "releases/current/$(major "$current_7")"
+echo "$current_8" > "releases/current/$(major "$current_8")"
+echo "$current_6" > "releases/current/$(majorminor "$current_6")"
+echo "$current_7" > "releases/current/$(majorminor "$current_7")"
+echo "$current_8" > "releases/current/$(majorminor "$current_8")"
+
+mkdir -p releases/next
+echo "$next7" > "releases/next/minor-$(major "$next7")"
+echo "$next8" > "releases/next/minor-$(major "$next8")"
+echo "$next7" > "releases/next/patch-$(major "$next7")"
+echo "$patch8" > "releases/next/patch-$(major "$patch8")"
+
+mkdir -p releases/edge
+echo "$edge_8" > "releases/edge/$(major "$edge_8")"

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -183,6 +183,7 @@ fi
 EDGE_FOLDER=releases/edge
 mkdir -p $EDGE_FOLDER
 if [ "$(isAvailable "$edge_8")" = "true" ] ; then
-  ## Edge always point to the main branch.
+  echo "$edge_8" > "$EDGE_FOLDER/$(major "$edge_8")"
+  # NOTE: when 9.x happens then `main` will point to 9.
   echo "$edge_8" > "$EDGE_FOLDER/main"
 fi

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -23,7 +23,7 @@
 set -eo pipefail
 
 # Get the latest github release for the given tag prefix.
-# Releases starts with v<major>, i.e: v8
+# Releases starts with v<major>, i.e: v8
 # It uses the gh cli in elastic/elasticsearch.
 # Owned by: release team
 function latest() {

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -4,7 +4,7 @@ name: generate-elastic-stack-releases
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */1 * * 1-5'
+    - cron: '0 */6 * * 1-5'
 
 permissions:
   contents: read

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -1,0 +1,47 @@
+---
+name: generate-elastic-stack-snapshots
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */1 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: .ci/generate-releases.sh
+
+      - name: 'Get service account'
+        uses: hashicorp/vault-action@v2.7.4
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          method: approle
+          secrets: |
+            secret/observability-team/ci/artifacts-api-bucket service-account | SERVICE_ACCOUNT ;
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ env.SERVICE_ACCOUNT }}'
+
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
+        with:
+          path: releases
+          glob: "**/*.json"
+          destination: "artifacts-api"
+          parent: false
+          headers: |-
+            content-type: application/json
+            x-goog-meta-generator: generate-elastic-stack-releases.yml
+
+      - name: debug
+        run: echo "${{ steps.upload-file.outputs.uploaded }}"

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -1,5 +1,5 @@
 ---
-name: generate-elastic-stack-snapshots
+name: generate-elastic-stack-releases
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  generate-snapshots:
+  generate-releases:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -14,6 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: docker.elastic.co
+          secret: secret/observability-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - run: .ci/generate-releases.sh
 
       - name: 'Get service account'

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -9,6 +9,8 @@ on:
       - bump-golang
       - bump-elastic-stack
       - build-test
+      - generate-elastic-stack-releases
+      - generate-elastic-stack-snapshots
       - job-dsl
       - licenses
       - lint

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ wiremock-standalone.jar
 node_modules/
 
 snapshots/
+releases/


### PR DESCRIPTION
## What does this PR do?

Store the release properties file in the Google Bucket called https://storage.googleapis.com/artifacts-api/releases/

### Background

Back in the day, we enabled [releases.properties](https://github.com/elastic/apm-pipeline-library/blob/main/resources/versions/releases.properties) to provide the current releases or upcoming ones given the major/minor/patch versions.

https://github.com/elastic/apm-pipeline-library/pull/1197 is the original request.

Further details can be found in:
- https://github.com/elastic/apm-pipeline-library/pull/1641, so only when the release is available.
- https://github.com/elastic/apm-pipeline-library/pull/1645, to distinguish BCs/releases from main.

### Implementation details

It generates files that contain the version for the given aliases:

- next minor
- next patch
- current
- edge

The file's name will be the major version or the major.minor version, to help search for the latest release for the given branch or the upcoming release for the given branch.

As of today, it will produce something like the below folder structure:

```bash
releases
├── releases
│   ├── current
│   │   ├── 6
│   │   ├── 6.8
│   │   ├── 7
│   │   ├── 7.17
│   │   ├── 8
│   │   └── 8.11
│   ├── edge
│   │   ├── 8
│   │   └── main
│   └── next
│       ├── minor-7
│       ├── minor-7.17
│       ├── minor-8
│       ├── minor-8.12
│       ├── patch-7
│       ├── patch-7.17
│       ├── patch-8
│       └── patch-8.11
└── releases.properties
```

## Why is it important?

Eventually, we won't need to maintain the release.properties file in this repository but upload it to the given Google bucket for simplicity. 

## Related issues
Closes #ISSUE
