### PR TITLE
release: set GH_TOKEN, add debug traces and notify if failures

### DIFF
--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -215,3 +215,9 @@ if [ "$(isAvailable "$edge_8")" = "true" ] ; then
   # NOTE: when 9.x happens then `main` will point to 9.
   echo "$edge_8" > "$EDGE_FOLDER/main"
 fi
+
+## 3. debug
+if command -v tree ; then
+  echo "The below files have been generated"
+  tree .
+fi

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -22,6 +22,9 @@
 #
 set -eo pipefail
 
+if [ -n "$RUNNER_DEBUG" ] ; then
+  set -x
+fi
 
 ###############
 ### FUNCTIONS

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -66,17 +66,6 @@ function latest() {
   rm $file &> /dev/null || true
 }
 
-function debug_latest() {
-  local version="${1}"
-  local file=.releases
-  retry 3 gh api repos/elastic/elasticsearch/releases > $file
-  jq -r --arg version "$version" '[.[].tag_name
-    | select(startswith($version))
-    | sub("v"; ""; "g")]
-    | sort_by(.| split(".") | map(tonumber))' .releases
-  rm $file &> /dev/null || true
-}
-
 # Get the next release for the given semver prefix.
 # Releases start with major.minor.patch.
 # It uses the artifacts-api.elastic.co entrypoint.
@@ -165,10 +154,6 @@ next_7=$(incPatch "$current_7")
 next_minor_8=$(next 8)
 next_patch_8=$(incPatch "$current_8")
 edge_8=$(edge)
-
-## debug
-debug_latest v7
-debug_latest v8
 
 ## 2. Generate files
 

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -66,6 +66,17 @@ function latest() {
   rm $file &> /dev/null || true
 }
 
+function debug_latest() {
+  local version="${1}"
+  local file=.releases
+  retry 3 gh api repos/elastic/elasticsearch/releases > $file
+  jq -r --arg version "$version" '[.[].tag_name
+    | select(startswith($version))
+    | sub("v"; ""; "g")]
+    | sort_by(.| split(".") | map(tonumber))' .releases
+  rm $file &> /dev/null || true
+}
+
 # Get the next release for the given semver prefix.
 # Releases start with major.minor.patch.
 # It uses the artifacts-api.elastic.co entrypoint.
@@ -154,6 +165,10 @@ next_7=$(incPatch "$current_7")
 next_minor_8=$(next 8)
 next_patch_8=$(incPatch "$current_8")
 edge_8=$(edge)
+
+## debug
+debug_latest v7
+debug_latest v8
 
 ## 2. Generate files
 

--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -175,7 +175,7 @@ cd releases
   echo "next_patch_8=$next_patch_8"
   echo "edge_8=$edge_8"
   echo "generated=https://github.com/elastic/apm-pipeline-library/actions/workflows/generate-elastic-stack-releases.yml"
-} > releases.properties
+} | tee releases.properties
 
 ### Generate the files for the current releases
 CURRENT_FOLDER=releases/current

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -47,7 +47,6 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: releases
-          glob: "**/*.json"
           destination: "artifacts-api"
           parent: false
           headers: |-

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -55,3 +55,12 @@ jobs:
 
       - name: debug
         run: echo "${{ steps.upload-file.outputs.uploaded }}"
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: '#observablt-bots'
+          message: ":traffic_cone: generate-elastic-stack-releases failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -24,6 +24,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - run: .ci/generate-releases.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: 'Get service account'
         uses: hashicorp/vault-action@v2.7.4


### PR DESCRIPTION
## What does this PR do?

Set GH_TOKEN
Add debug traces
Notify if any failures

## Why is it important?

Otherwise, it fails when running on the CI with the error below:

> To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable