### PR TITLE
ignore: generated credentials

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,2 @@
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ node_modules/
 
 snapshots/
 releases/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
## What does this PR do?

Create file to avoid generated credentials to be published accidentally

## Why is it important?

Fixes 

> The "process_gcloudignore" option is true, but no .gcloudignore file was found. If you do not intend to process a gcloudignore file, set "process_gcloudignore" to false

See https://github.com/elastic/apm-pipeline-library/actions/runs/7335622889

