### PR TITLE
Revert "chore(deps): bump the github-actions group in /.github/actions/buildkite with 1 update"

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -107,7 +107,7 @@ runs:
           ARTIFACT_PATH: ${{ inputs.artifactPath }}
         shell: bash
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: always() && steps.download-artifacts.outcome == 'success'
         with:
           name: ${{ inputs.artifactName }}


### PR DESCRIPTION
Reverts elastic/apm-pipeline-library#2474

Otherwise, consumers need to use v4 and we have not done that yet