### PR TITLE
actions: use ephemeral GitHub tokens

### DIFF
--- a/.github/actions/github-token/action.yml
+++ b/.github/actions/github-token/action.yml
@@ -34,7 +34,7 @@ runs:
     #   id: get-token
     #   uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
     #   with:
-    #     app_id: ${{ env.APP_ID }}
+    #     app-id: ${{ env.APP_ID }}
     #     private_key: ${{ env.PRIVATE_KEY }}
     #     installation_id: ${{ env.INSTALLATION_ID }}
     #     permissions: >-

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -53,16 +53,17 @@ jobs:
         working-directory: ${{ matrix.working_directory || '.' }}
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repository }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           ref: ${{ matrix.branch }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@main

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -55,15 +55,15 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repository }}
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           ref: ${{ matrix.branch }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@main

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: ${{ matrix.repository }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-comment-reaction.yml
+++ b/.github/workflows/test-comment-reaction.yml
@@ -15,32 +15,34 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@main
         with:
           repository: ${{ github.repository }}
           commentId: ${{ github.event.comment.id }}
           emoji: hooray
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
 
   comment-reaction-if-comment:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/run-comment-reaction') }}
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@main
         with:
           repository: ${{ github.repository }}
           commentId: ${{ github.event.comment.id }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}

--- a/.github/workflows/test-comment-reaction.yml
+++ b/.github/workflows/test-comment-reaction.yml
@@ -17,17 +17,17 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@main
         with:
           repository: ${{ github.repository }}
           commentId: ${{ github.event.comment.id }}
           emoji: hooray
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
 
   comment-reaction-if-comment:
     runs-on: ubuntu-latest
@@ -36,13 +36,13 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/comment-reaction@main
         with:
           repository: ${{ github.repository }}
           commentId: ${{ github.event.comment.id }}
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/test-is-member-elastic-org.yml
+++ b/.github/workflows/test-is-member-elastic-org.yml
@@ -14,16 +14,16 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@main
         id: is_elastic_member
         with:
           username: mdelapenya
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Assert is no member
         run: test "${{steps.is_elastic_member.outputs.result}}" = "false"
@@ -33,16 +33,16 @@ jobs:
     steps:
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@main
         id: is_elastic_member
         with:
           username: apmmachine
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Assert is member
         run: test "${{steps.is_elastic_member.outputs.result}}" = "true"

--- a/.github/workflows/test-is-member-elastic-org.yml
+++ b/.github/workflows/test-is-member-elastic-org.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@main
         id: is_elastic_member
         with:
           username: mdelapenya
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
 
       - name: Assert is no member
         run: test "${{steps.is_elastic_member.outputs.result}}" = "false"
@@ -30,17 +31,18 @@ jobs:
   test-with-elastic-user:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@main
         id: is_elastic_member
         with:
           username: apmmachine
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
 
       - name: Assert is member
         run: test "${{steps.is_elastic_member.outputs.result}}" = "true"

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -12,18 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 1129
           repository: 'elastic/apm-pipeline-library'
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
 
       - name: Assert is no member
         run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "false"
@@ -31,18 +32,19 @@ jobs:
   test-with-elastic-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 2110
           repository: 'elastic/apm-pipeline-library'
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
 
       - name: Assert is member
         run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "true"

--- a/.github/workflows/test-is-pr-author-member-elastic-org.yml
+++ b/.github/workflows/test-is-pr-author-member-elastic-org.yml
@@ -14,17 +14,17 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 1129
           repository: 'elastic/apm-pipeline-library'
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Assert is no member
         run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "false"
@@ -34,17 +34,17 @@ jobs:
     steps:
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/is-pr-author-member-elastic-org@main
         id: is_pr_author_elastic_member
         with:
           pull-request: 2110
           repository: 'elastic/apm-pipeline-library'
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Assert is member
         run: test "${{steps.is_pr_author_elastic_member.outputs.result}}" = "true"

--- a/.github/workflows/test-oblt-cli-cluster-credentials.yml
+++ b/.github/workflows/test-oblt-cli-cluster-credentials.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-cluster-credentials@main
         with:

--- a/.github/workflows/test-oblt-cli-cluster-credentials.yml
+++ b/.github/workflows/test-oblt-cli-cluster-credentials.yml
@@ -17,15 +17,16 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-cluster-credentials@main
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.app_token }}
           cluster-name: 'dev-oblt'
           vault-url: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/test-oblt-cli-cluster-credentials.yml
+++ b/.github/workflows/test-oblt-cli-cluster-credentials.yml
@@ -19,14 +19,14 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-cluster-credentials@main
         with:
-          github-token: ${{ steps.get_token.outputs.app_token }}
+          github-token: ${{ steps.get_token.outputs.token }}
           cluster-name: 'dev-oblt'
           vault-url: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/test-oblt-cli-create-ccs.yml
+++ b/.github/workflows/test-oblt-cli-create-ccs.yml
@@ -19,14 +19,14 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-ccs@main
         with:
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           remote-cluster: 'release-oblt'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli-create-ccs.yml
+++ b/.github/workflows/test-oblt-cli-create-ccs.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-ccs@main
         with:

--- a/.github/workflows/test-oblt-cli-create-ccs.yml
+++ b/.github/workflows/test-oblt-cli-create-ccs.yml
@@ -17,15 +17,16 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-ccs@main
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           remote-cluster: 'release-oblt'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-create-custom.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:
@@ -48,6 +49,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:

--- a/.github/workflows/test-oblt-cli-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-create-custom.yml
@@ -19,14 +19,14 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: true
@@ -44,14 +44,14 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: false

--- a/.github/workflows/test-oblt-cli-create-custom.yml
+++ b/.github/workflows/test-oblt-cli-create-custom.yml
@@ -17,15 +17,16 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: true
@@ -41,15 +42,16 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli-create-custom@main
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           template: 'deploy-kibana'
           cluster-name-prefix: 'testgithubaction'
           gitops: false

--- a/.github/workflows/test-oblt-cli-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-create-serverless.yml
@@ -22,15 +22,16 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: ./.github/actions/oblt-cli-create-serverless
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           target: 'qa'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-create-serverless.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: ./.github/actions/oblt-cli-create-serverless
         with:

--- a/.github/workflows/test-oblt-cli-create-serverless.yml
+++ b/.github/workflows/test-oblt-cli-create-serverless.yml
@@ -24,14 +24,14 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: ./.github/actions/oblt-cli-create-serverless
         with:
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           target: 'qa'
           cluster-name-prefix: 'testgithubaction'
           gitops: true

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -19,12 +19,12 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@main
         with:
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix testgithubaction'

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-test-environments"
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@main
         with:

--- a/.github/workflows/test-oblt-cli.yml
+++ b/.github/workflows/test-oblt-cli.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@main
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@main
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@main
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           command: 'cluster create ccs --remote-cluster=dev-oblt --cluster-name-prefix testgithubaction'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -14,11 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+      - name: Get token
+        id: get_token
+        uses: elastic/actions-app-token@master
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - name: Dump GitHub context
         run: echo '${{ toJSON(github) }}'
@@ -27,5 +28,5 @@ jobs:
         with:
           repository: "elastic/observability-robots-playground"
           type: my-event
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.app_token }}
           payload: '{ "ref": "${{ github.event.pull_request.head.sha }}", "repository": "${{ github.repository }}" }'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
           app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          repositories: "observability-robots-playground"
 
       - name: Dump GitHub context
         run: echo '${{ toJSON(github) }}'

--- a/.github/workflows/test-workflow-run.yml
+++ b/.github/workflows/test-workflow-run.yml
@@ -16,10 +16,10 @@ jobs:
 
       - name: Get token
         id: get_token
-        uses: elastic/actions-app-token@master
+        uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         with:
-          APP_PEM: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
-          APP_ID: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_PRIVATE_KEY }}
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
 
       - name: Dump GitHub context
         run: echo '${{ toJSON(github) }}'
@@ -28,5 +28,5 @@ jobs:
         with:
           repository: "elastic/observability-robots-playground"
           type: my-event
-          token: ${{ steps.get_token.outputs.app_token }}
+          token: ${{ steps.get_token.outputs.token }}
           payload: '{ "ref": "${{ github.event.pull_request.head.sha }}", "repository": "${{ github.repository }}" }'


### PR DESCRIPTION
## What does this PR do?

Use ephemeral GitHub tokens with https://github.com/elastic/actions-app-token in https://github.com/elastic/apm-pipeline-library/pull/2491/commits/12316d2005862790d19bfb3419e476c7fdf8432d or https://github.com/actions/create-github-app-token/tree/f04aa94d10cf56334d1c580e077ce2e3569e805d/ with the latest commits

## Why is it important?

* We can move away from service machine accounts.
* Ephemeral tokens are revoked
* Fine granular access to the given repository or list of repositories.

## Test

* [oblt-cli-credentials](https://github.com/elastic/apm-pipeline-library/actions/runs/7555666366/job/20571121758) was able to use the `oblt-cli` and gather the credentials.  ✅ 

* [publish-docker-images](https://github.com/elastic/apm-pipeline-library/actions/runs/7555654266/job/20571099384) was able to clone using the ephemeral token. ✅ 

* [oblt-cli](https://github.com/elastic/apm-pipeline-library/actions/runs/7555660853/job/20571105160#step:6:259) failed when writing to the GitHub repository. ⚠️ 

* [is-member](https://github.com/elastic/apm-pipeline-library/actions/runs/7555595302/job/20571019120) could not use the API to check whether it is a member or not. ⚠️ 