### PR TITLE
Add notice annotation to summary when using the buildkite action

### DIFF
--- a/.github/actions/buildkite/run.sh
+++ b/.github/actions/buildkite/run.sh
@@ -76,6 +76,7 @@ echo "::endgroup::"
 
 URL=$(echo "$RESP" | jq -r ".url")
 WEB_URL=$(echo "$RESP" | jq -r ".web_url")
+echo "::notice title=Buildkite Build URL::${WEB_URL}"
 BUILD_NUMBER=$(echo "$RESP" | jq -r ".number")
 # shellcheck disable=SC2086
 echo "build=$WEB_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What does this PR do?

Adds a notice annotation to the github workflow summary when using the buildkite action.

Example screenshot:

![image](https://github.com/elastic/apm-pipeline-library/assets/16325797/a0ec4c1b-cb36-4ae6-955a-23ce036bc558)


## Why is it important?

Easier to find the downstream buildkite build url

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
