### PR TITLE
fix: github API comment is different when modigying an existing one

### DIFF
--- a/vars/githubTraditionalPrComment.groovy
+++ b/vars/githubTraditionalPrComment.groovy
@@ -37,12 +37,13 @@ def call(Map args = [:]){
   def id = "${args.get('id', '')}"
   def message = args.containsKey('message') ? args.message : error('githubTraditionalPrComment: message parameter is required')
 
+  def commonUrl = "https://api.github.com/repos/${env.ORG_NAME}/${env.REPO_NAME}/issues"
   if (isPR()) {
     def token = getGithubToken()
-    def url = "https://api.github.com/repos/${env.ORG_NAME}/${env.REPO_NAME}/issues/${env.CHANGE_ID}/comments"
+    def url = "${commonUrl}/${env.CHANGE_ID}/comments"
     def method = 'POST'
     if(id.trim()) {
-       url = "${url}/${id}"
+       url = "${commonUrl}/comments/${id}"
        method = 'PATCH'
     }
     def comment = githubApiCall(token: token, url: url, data: [ "body": "${message}" ], method: method, noCache: true)


### PR DESCRIPTION
I've just discovered that `https://api.github.com/repos/elastic/beats/issues/37853/comments/1925884269` is not working but `https://api.github.com/repos/elastic/beats/issues/comments/1925884269` then the GitHub comment with the build results are not reused but create a new one every time a build happens.

https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#list-issue-comments-for-a-repository is the command to list all the comments for any given issues/pull-request

https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#update-an-issue-comment is the one for changing existing GitHub comments.

I cannot understand the reason for the previous implementation and whether it never surfaced since there was a fallback for using the GitHub app.. maybe the scope of the permission has changed recently...


### Further details

If you open https://github.com/elastic/beats/pull/37825
Then you will see a few comments like the below screenshot.

<img width="1045" alt="image" src="https://github.com/elastic/apm-pipeline-library/assets/2871786/ee2b7a6f-705a-4d03-9905-9ac8cc647ddb">

While I'd expect the first comment to be changed for each build in the CI.

