### PR TITLE
Update docs-preview link

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -17,7 +17,7 @@
 
 <!-- BUILD BADGES-->
 > _the below badges are clickable and redirect to their specific view in the CI or DOCS_
-[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL.replaceAll(' ','+')})<%}%><% if (statusSuccess && snapshoty) {%>[![Snapshots](https://img.shields.io/badge/snapshots-artifacts-blue)](${snapshotyUrl})<%}%>
+[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim() && !buildStatus?.equals('ABORTED')) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>  <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL.replaceAll(' ','+')})<%}%><% if (statusSuccess && snapshoty) {%>[![Snapshots](https://img.shields.io/badge/snapshots-artifacts-blue)](${snapshotyUrl})<%}%>
 
 <!-- BUILD SUMMARY-->
 <details><summary>Expand to view the summary</summary>

--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -17,7 +17,7 @@
 
 <!-- BUILD BADGES-->
 > _the below badges are clickable and redirect to their specific view in the CI or DOCS_
-[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(docsUrl?.trim() && !buildStatus?.equals('ABORTED')) {%>[![preview](https://img.shields.io/badge/docs-preview-yellowgreen)](${docsUrl})<%}%>  <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL.replaceAll(' ','+')})<%}%><% if (statusSuccess && snapshoty) {%>[![Snapshots](https://img.shields.io/badge/snapshots-artifacts-blue)](${snapshotyUrl})<%}%>
+[![Pipeline View](https://img.shields.io/badge/pipeline-pipeline%20-green)](${jobUrl}/pipeline) [![Test View](https://img.shields.io/badge/test-test-green)](${jobUrl}/tests) [![Changes](https://img.shields.io/badge/changes-changes-green)](${jobUrl}/changes) [![Artifacts](https://img.shields.io/badge/artifacts-artifacts-yellow)](${jobUrl}/artifacts) <% if(env?.OTEL_ELASTIC_URL != null && !env?.OTEL_ELASTIC_URL.equals('null')) {%>[![preview](https://img.shields.io/badge/elastic-observability-blue)](${env?.OTEL_ELASTIC_URL.replaceAll(' ','+')})<%}%><% if (statusSuccess && snapshoty) {%>[![Snapshots](https://img.shields.io/badge/snapshots-artifacts-blue)](${snapshotyUrl})<%}%>
 
 <!-- BUILD SUMMARY-->
 <details><summary>Expand to view the summary</summary>

--- a/vars/notifyBuildResult.groovy
+++ b/vars/notifyBuildResult.groovy
@@ -71,7 +71,7 @@ def call(Map args = [:]) {
       def jobName = args.get('jobName') ? args.jobName : ''
       catchError(message: 'There were some failures with the notifications', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
         def data = getBuildInfoJsonFiles(jobURL: env.JOB_URL, buildNumber: env.BUILD_NUMBER, returnData: true)
-        data['docsUrl'] = "http://${env?.REPO_NAME}_${env?.CHANGE_ID}.docs-preview.app.elstc.co/diff"
+        data['docsUrl'] = "http://${env?.REPO_NAME}_bk_${env?.CHANGE_ID}.docs-preview.app.elstc.co/diff"
         data['emailRecipients'] = to
         data['statsUrl'] = statsURL
         data['es'] = es


### PR DESCRIPTION
Following the migration from Jenkins to Buildkite, docs previews are now available at <repo>_bk_<PR>.

More context in https://github.com/elastic/docs/pull/2898

## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
