### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,9 @@ on:
   schedule:
     - cron: "31 17 * * 2"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just contents read.
Please checkout this branch and add the necessary permissions to the workflows.

Merging this PR as is might cause workflows that need more permissions to fail.
