### PR TITLE
Added action to wait for maven-central artifacts to be available

### DIFF
--- a/.github/actions/await-maven-artifact/action.yml
+++ b/.github/actions/await-maven-artifact/action.yml
@@ -1,0 +1,24 @@
+name: 'Wait for Maven Central Artifact'
+description: 'Waits for an artifact to be available on maven central'
+inputs:
+  groupid:  
+    description: 'Maven group-ID of the artifact'
+    required: true
+  artifactid:  
+    description: 'Maven artifact-ID of the artifact'
+    required: true
+  version:  
+    description: 'Version of the artifact to wait for'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Wait for artifact to be available on maven central
+      shell: bash
+      run: |
+        full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${{ inputs.groupid }}&a=${{ inputs.artifactid }}&v=${{ inputs.version }}"
+        until curl -fs "${full_url}" > /dev/null
+        do
+          echo "Artifact '${{ inputs.groupid }}:${{ inputs.artifactid }}:${{ inputs.version }}' not found on maven central. Sleeping 30 seconds, retrying afterwards"
+          sleep 30s
+        done

--- a/.github/actions/await-maven-artifact/action.yml
+++ b/.github/actions/await-maven-artifact/action.yml
@@ -1,13 +1,13 @@
 name: 'Wait for Maven Central Artifact'
 description: 'Waits for an artifact to be available on maven central'
 inputs:
-  groupid:  
+  groupid:
     description: 'Maven group-ID of the artifact'
     required: true
-  artifactid:  
+  artifactid:
     description: 'Maven artifact-ID of the artifact'
     required: true
-  version:  
+  version:
     description: 'Version of the artifact to wait for'
     required: true
 runs:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ release.properties
 target
 jenkins-cli.jar
 
+# Mac filesystem management files
+**/.DS_Store 
 
 # For the BATS testing
 bats-core/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ target
 jenkins-cli.jar
 
 # Mac filesystem management files
-**/.DS_Store 
+**/.DS_Store
 
 # For the BATS testing
 bats-core/


### PR DESCRIPTION
## What does this PR do?

Adds an action which allows to wait for a certain maven-central artifact to be available.

I've tested the action in a dummy-repo on my account.

## Why is it important?

When releasing artifacts to be maven central, the output of the release task is usually not useful: sometimes the output says failed, even though the artifact was published. Sometimes the release task is successfull, but the artifact wasn't published.

For this reason it is beneficial to just ignore the output of the release step and instead check the presence of the desired artifact on maven central, which is accomplished using this task.

In addition in the future we could enhance this task to provide the artifact as an output, so that we can for example publish it as artifact on the GH release.