### PR TITLE
github-action: use phoenix-actions/test-reporting@v12

### DIFF
--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -68,9 +68,7 @@ runs:
   using: "composite"
   steps:
     - name: Report test results
-      # Wait for https://github.com/phoenix-actions/test-reporting/pull/33 and a new release
-      #uses: phoenix-actions/test-reporting@93ce19fa5882ebe3969ebdb9ee1024b3d29e776f
-      uses: Mpdreamz/test-reporting@fix/only-failed
+      uses: phoenix-actions/test-reporting@41efe7ebebe7ef156ef46f6b0acf50ec0f10315b
       with:
         artifact: ${{ inputs.artifact }}
         name: ${{ inputs.name }}


### PR DESCRIPTION
## What does this PR do?

Bump the version for `phoenix-actions/test-reporting@v12` that points to https://github.com/phoenix-actions/test-reporting/commit/41efe7ebebe7ef156ef46f6b0acf50ec0f10315b

## Why is it important?

The version contains already the fix

## Related issues
Closes #ISSUE
