### PR TITLE
oblt-cli: pin version 6.5.3

### DIFF
--- a/.github/actions/oblt-cli-cluster-credentials/action.yml
+++ b/.github/actions/oblt-cli-cluster-credentials/action.yml
@@ -13,12 +13,15 @@ inputs:
   vault-role-id:
     description: 'Vault role ID'
     required: true
+    deprecationMessage: "This field won't be needed once migrated to a different Secrets system."
   vault-secret-id:
     description: 'Vault secret ID'
     required: true
+    deprecationMessage: "This field won't be needed once migrated to a different Secrets system."
   vault-url:
     description: 'Vault URL'
     required: true
+    deprecationMessage: "This field won't be needed once migrated to a different Secrets system."
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-oblt-cli/download.sh
+++ b/.github/actions/setup-oblt-cli/download.sh
@@ -8,18 +8,18 @@ mkdir -p "${BIN_DIR}"
 
 if [[ ${RUNNER_OS} == "Linux" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
+    PATTERN='*linux_amd64.tar.gz'
   elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-    gh release download --repo elastic/observability-test-environments -p '*linux_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
+    PATTERN='*linux_arm64.tar.gz'
   else
     echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
     exit 1
   fi
 elif [[ ${RUNNER_OS} == "macOS" ]]; then
   if [[ ${RUNNER_ARCH} == "X64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_amd64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
+      PATTERN='*darwin_amd64.tar.gz'
     elif [[ ${RUNNER_ARCH} == "ARM64" ]]; then
-      gh release download --repo elastic/observability-test-environments -p '*darwin_arm64.tar.gz' --output - | tar -xz -C "${BIN_DIR}"
+      PATTERN='*darwin_arm64.tar.gz'
     else
       echo "Unsupported architecture for ${RUNNER_OS}: ${RUNNER_ARCH}"
       exit 1
@@ -28,5 +28,12 @@ else
   echo "Unsupported OS: ${RUNNER_OS}"
   exit 1
 fi
+
+echo "::warning::It will download the version 6.5.3. Latest version does not support Vault access anymore."
+# TODO: use the latest available version.
+gh release download 6.5.3 \
+  --repo elastic/observability-test-environments \
+  -p "${PATTERN}" \
+  --output - | tar -xz -C "${BIN_DIR}"
 
 echo "${BIN_DIR}" >> "${GITHUB_PATH}"


### PR DESCRIPTION
## What does this PR do?

PIn the version to `6.5.3`

## Why is it important?

Prepare for the secrets system migration so consumers don't get affected by the change.

## Follow-ups

Migrate to the new secret system store
