### PR TITLE
docker: azure-vm-utils is not something belong to us

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -38,13 +38,6 @@ images:
     build_script: "docker build --force-rm -t ${REGISTRY}/${PREFIX}/${NAME}:${TAG} ${NAME}"
     push_script: "docker push ${REGISTRY}/${PREFIX}/${NAME}:${TAG}"
 
-  - name: "azure-vm-tools"
-    repository: "elastic/azure-vm-extension"
-    build_script: "make prepare"
-    # The full image name is defined here: https://github.com/elastic/azure-vm-extension/blob/82862124bbbc9bc7ab50184375d3b9743c42b2b7/.ci/Makefile#L5
-    push_script: "docker push ${REGISTRY}/${PREFIX}/${NAME}:${TAG}"
-    working_directory: ".ci"
-
   # observability-robots Docker Images
 
   - name: "picklesdoc"


### PR DESCRIPTION
## What does this PR do?

Remove unused docker image

## Why is it important?

Migrated to Buildktie https://github.com/elastic/azure-vm-extension/pull/93 or will be migrated shortly