### PR TITLE
docker: jenkins agent is not something we use nowadays

### DIFF
--- a/.ci/.docker-images.yml
+++ b/.ci/.docker-images.yml
@@ -144,15 +144,6 @@ images:
     test_script: "cd .. && make test-vmware-mock"
     working_directory: ".ci/docker/vmware-mock"
 
-  # APM Pipeline Library Extra Docker Images
-
-  - name: "jenkins-agent"
-    repository: "elastic/apm-pipeline-library"
-    working_directory: ".ci/docker"
-    build_script: "docker build --force-rm -t ${REGISTRY}/${PREFIX}/${NAME}:${TAG} ${NAME}"
-    push_script: "docker push ${REGISTRY}/${PREFIX}/${NAME}:${TAG}"
-    test_script: "make simple-test-${NAME}"
-
   # APM Agent Python Docker Images
 
   - name: "apm-agent-python-testing"


### PR DESCRIPTION
## What does this PR do?

Remove jenkins agent docker. generation

## Why is it important?

We don't need it anymore

## Related issues
Closes #ISSUE
