### PR TITLE
fix: avoid unexpected versions for the time being

### DIFF
--- a/.ci/get-next-minor-version.sh
+++ b/.ci/get-next-minor-version.sh
@@ -25,8 +25,9 @@ set -eo pipefail
 URL="https://artifacts-api.elastic.co/v1"
 NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
+# 8.13.0+build202403222138 is unexpected let's exclude it
 curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" \
-    | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' \
+    | jq -r '.versions[] | select(contains("SNAPSHOT")|not) | select(contains("+build")|not)' \
     | jq -R . | jq -s '. | sort_by(.| split(".") | map(tonumber))' \
     | jq -r '.[]|select(. | startswith("8"))' \
     | tail -n1


### PR DESCRIPTION
## What does this PR do?

Filter a version from the list

## Why is it important?

It seems a bug has been introduced recently in the artifacts-api, so let's play safe and filter it