### PR TITLE
feat: ability to install a specific version of oblt-cli

### DIFF
--- a/.github/actions/setup-oblt-cli/README.md
+++ b/.github/actions/setup-oblt-cli/README.md
@@ -31,13 +31,12 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
       - uses: elastic/apm-pipeline-library/.github/actions/setup-oblt-cli@current
         with:
-          slack-channel: '#observablt-bots' # default
-          username: 'apmmachine' # default
+          slack-channel: "#observablt-bots" # default
+          username: "apmmachine" # default
           github-token: ${{ env.GITHUB_TOKEN }}
 
       - run: oblt-cli cluster list
 ```
-
 
 ## Customizing
 
@@ -45,8 +44,9 @@ jobs:
 
 Following inputs can be used as `step.with` keys
 
-| Name            | Type    | Default                     | Description                                                          |
-|-----------------|---------|-----------------------------|----------------------------------------------------------------------|
-| `slack-channel` | String  | `#observablt-bots`          | The slack channel to be configured in the oblt-cli.                  |
-| `github-token`  | String  |                             | The GitHub token with permissions fetch releases.                    |
-| `username`      | String  | `apmmachine`                | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |
+| Name            | Type   | Default            | Description                                                          |
+| --------------- | ------ | ------------------ | -------------------------------------------------------------------- |
+| `slack-channel` | String | `#observablt-bots` | The slack channel to be configured in the oblt-cli.                  |
+| `github-token`  | String |                    | The GitHub token with permissions fetch releases.                    |
+| `username`      | String | `apmmachine`       | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |
+| `version`       | String | `6.5.3`            | Install a specific version of oblt-cli                               |

--- a/.github/actions/setup-oblt-cli/action.yml
+++ b/.github/actions/setup-oblt-cli/action.yml
@@ -4,15 +4,19 @@ description: Setup oblt-cli
 
 inputs:
   github-token:
-    description: 'The GitHub access token.'
+    description: "The GitHub access token."
     required: true
   slack-channel:
-    description: 'The slack channel to notify the status.'
-    default: '#observablt-bots'
+    description: "The slack channel to notify the status."
+    default: "#observablt-bots"
     required: false
   username:
-    description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
-    default: 'apmmachine'
+    description: "Username to show in the deployments with oblt-cli, format: [a-z0-9]"
+    default: "apmmachine"
+    required: false
+  version:
+    description: "Install a specific version of oblt-cli"
+    default: "6.5.3"
     required: false
 runs:
   using: composite
@@ -21,6 +25,7 @@ runs:
       run: ${{ github.action_path }}/download.sh
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        OBLT_CLI_VERSION: ${{ inputs.version }}
       shell: bash
     - name: Configure oblt-cli
       run: >

--- a/.github/actions/setup-oblt-cli/download.sh
+++ b/.github/actions/setup-oblt-cli/download.sh
@@ -29,9 +29,12 @@ else
   exit 1
 fi
 
-echo "::warning::It will download the version 6.5.3. Latest version does not support Vault access anymore."
+if [ "${OBLT_CLI_VERSION}" == "6.5.3" ]; then
+  echo "::warning::It will download the version 6.5.3. Latest version does not support Vault access anymore."
+fi
+
 # TODO: use the latest available version.
-gh release download 6.5.3 \
+gh release download "${OBLT_CLI_VERSION}" \
   --repo elastic/observability-test-environments \
   -p "${PATTERN}" \
   --output - | tar -xz -C "${BIN_DIR}"


### PR DESCRIPTION
## What is the change being made?

- Add the ability to install a specific version of oblt-cli while defaulting to 6.5.3

## Why is the change being made?

- We need to be able to install the latest version of oblt-cli in gatekeeper.