### PR TITLE
github-action(kibana-docker-image): skip CDN

### DIFF
--- a/.github/actions/kibana-docker-image/build-and-push.sh
+++ b/.github/actions/kibana-docker-image/build-and-push.sh
@@ -26,6 +26,7 @@ export KBN_NP_PLUGINS_BUILT=true
 time node scripts/build \
   --skip-os-packages \
   --skip-canvas-shareable-runtime \
+  --skip-cdn-assets \
   --skip-docker-contexts
 echo "::endgroup::"
 
@@ -39,6 +40,7 @@ if [ "${SERVERLESS}" == "false" ] ; then
         --docker-push \
         --skip-archives \
         --skip-initialize \
+        --skip-cdn-assets \
         --skip-docker-contexts \
         --skip-docker-ubi \
         --skip-docker-ubuntu \
@@ -55,6 +57,7 @@ else
         --docker-namespace="${DOCKER_NAMESPACE}" \
         --docker-tag="${DOCKER_TAG}" \
         --docker-push \
+        --skip-cdn-assets \
         --skip-docker-contexts \
         --skip-docker-ubi \
         --skip-docker-ubuntu \


### PR DESCRIPTION
## What does this PR do?

Disable the CDN thing for Kibana

## Why is it important?

Otherwise, serverless deployments use the CDN thing... 

## Related issues

Caused by https://github.com/elastic/kibana/pull/169707
