### PR TITLE
github-action: add label when deploy-my-kibana

### DIFF
--- a/.github/actions/deploy-my-kibana/README.md
+++ b/.github/actions/deploy-my-kibana/README.md
@@ -41,6 +41,7 @@ Following inputs can be used as `step.with` keys
 | `issue_url`       | String  | `${{ github.event.comment.issue_url }}`| The GitHub issue URL.  |
 | `comment_url`     | String  | `${{ github.event.comment.html_url }}` | The GitHub comment URL.  |
 | `comment_id`      | String  | `${{ github.event.comment.id }}`       | The GitHub comment ID.  |
+| `pr_label`        | String  | `ci:project-deploy-observability`      | The GitHub label to tag the PR.  |
 | `user`            | String  | `${{ github.triggering_actor }}`       | The GitHub user avatar           |
 | `repository`      | String  | `${{ github.repository }}`             | The GitHub repository, ORG/REPO. |
 | `serverless`      | Boolean | `false`                                | Whether to deploy a serverless deployment. |

--- a/.github/actions/deploy-my-kibana/action.yml
+++ b/.github/actions/deploy-my-kibana/action.yml
@@ -19,6 +19,9 @@ inputs:
   issue_url:
     description: 'The GitHub Issue URL'
     default: ${{ github.event.comment.issue_url }}
+  pr_label:
+    description: 'The GitHub label to be tagged'
+    default: "ci:project-deploy-observability"
   repository:
     description: 'The GitHub repository'
     default: ${{ github.repository }}
@@ -49,6 +52,20 @@ runs:
       with:
         username: ${{ inputs.user }}
         token: ${{ env.GITHUB_TOKEN }}
+
+    - name: Get PR given the issue_url (either edge-lite or release)
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: |-
+        PR=$(basename ${{ inputs.issue_url }})
+        echo "PR=${PR}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Add GitHub label
+      if: contains(steps.is_elastic_member.outputs.result, 'true')
+      run: gh pr edit ${PR} --add-label "${{ inputs.pr_label }}" --repo "${{ inputs.repository }}"
+      shell: bash
+      env:
+        GH_TOKEN: ${{ env.GITHUB_TOKEN }}
 
     - name: Get cluster given the target branch (either edge-lite or release)
       if: contains(steps.is_elastic_member.outputs.result, 'true')


### PR DESCRIPTION
## What does this PR do?

Initial attempt to integrate the Deploy My Kibana with the existing Kibana CI mechanism

## Why is it important?

Reuse what the Kibana CI generates
