### PR TITLE
github-action: use the correct email for obltmachine

### DIFF
--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -13,7 +13,7 @@ inputs:
   email:
     description: 'Git email.'
     required: false
-    default: 'obltmachine@users.noreply.github.com'
+    default: '150269514+obltmachine@users.noreply.github.com'
   trace:
     description: 'Enable git trace.'
     required: false


### PR DESCRIPTION
## What does this PR do?

Use the right email