### PR TITLE
Fix/issues with artifacts api 

### DIFF
--- a/.ci/generate-releases.sh
+++ b/.ci/generate-releases.sh
@@ -78,6 +78,7 @@ function next() {
   retry 3 curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" 2> /dev/null > $file
   jq -r --arg version "$version" '[.versions[]
     | select(contains("SNAPSHOT")|not)
+    | select(contains("+build")|not)
     | select(startswith($version))]
     | sort_by(.| split(".") | map(tonumber))
     | .[-1]' $file

--- a/.ci/generate-snapshots.sh
+++ b/.ci/generate-snapshots.sh
@@ -30,7 +30,7 @@ NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 
 
 echo ">> Query versions in ${URL}"
-QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT")) | select(contains("+build")|not)')
 for version in ${QUERY_OUTPUT}; do
   LATEST_OUTPUT=$(curl -s "${URL}/versions/${version}/builds/latest?${NO_KPI_URL_PARAM}" | jq 'del(.build.projects,.manifests) | . |= .build')
   BRANCH=$(echo "$LATEST_OUTPUT" | jq -r .branch)

--- a/resources/scripts/artifacts-api-latest-release-versions.sh
+++ b/resources/scripts/artifacts-api-latest-release-versions.sh
@@ -33,7 +33,7 @@ NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 OUTPUT=latest-release-versions.json
 
 curl -s "${URL}/versions?${NO_KPI_URL_PARAM}" \
-    | jq -r '.versions[] | select(contains("SNAPSHOT")|not)' \
+    | jq -r '.versions[] | select(contains("SNAPSHOT")|not) | select(contains("+build")|not)' \
     | jq -R . \
     | jq -s '. | sort_by(.| split(".") | map(tonumber))' \
     | tee ${OUTPUT}

--- a/resources/scripts/artifacts-api-latest-versions.sh
+++ b/resources/scripts/artifacts-api-latest-versions.sh
@@ -32,7 +32,7 @@ NO_KPI_URL_PARAM="x-elastic-no-kpi=true"
 TEMP_FILE=$(mktemp)
 OUTPUT=latest-versions.json
 
-QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT"))')
+QUERY_OUTPUT=$(curl -s "${URL}/versions?${NO_KPI_URL_PARAM}"| jq -r '.aliases[] | select(contains("SNAPSHOT")) | select(contains("+build")|not)')
 LENGTH=$(echo "$QUERY_OUTPUT" | wc -l)
 i=0
 echo "{" > "${TEMP_FILE}"


### PR DESCRIPTION
## What does this PR do?

`artifacts-api` introduced a regression and there are some non semver versions.

## Why is it important?

Partially solved in https://github.com/elastic/apm-pipeline-library/pull/2563

