### PR TITLE
Create env variable

### DIFF
--- a/.github/actions/setup-git/README.md
+++ b/.github/actions/setup-git/README.md
@@ -43,3 +43,5 @@ Following inputs can be used as `step.with` keys
 | `secretId`     | String  | `150269514+obltmachine@users.noreply.github.com`| Git email.         |
 | `trace`        | Boolean | `false`                               | Enable git trace.  |
 | `token`        | String  | `github.token`                        | GitHub token.      |
+
+`GITHUB_TOKEN` env variable is created on the fly.

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -43,3 +43,7 @@ runs:
         GIT_USER: "${{ inputs.username }}"
         GIT_EMAIL: "${{ inputs.email }}"
         GIT_TRACE: "${{ inputs.trace }}"
+
+    - name: Debug gh status
+      shell: bash
+      run: gh auth status

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -25,18 +25,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - if: ${{ inputs.token }}
+      shell: bash
+      run: echo 'GITHUB_TOKEN=${{ inputs.token }}' >> $GITHUB_ENV
+
     - name: Setup git
       shell: bash
       run: |
         git config --global user.name "${GIT_USER}"
         git config --global user.email "${GIT_EMAIL}"
         gh auth setup-git
-
-        echo "GIT_USER=${GIT_USER}" >> $GITHUB_ENV
+        echo "GIT_USER=${GIT_USER}"   >> $GITHUB_ENV
         echo "GIT_EMAIL=${GIT_EMAIL}" >> $GITHUB_ENV
-
       env:
         GIT_USER: "${{ inputs.username }}"
         GIT_EMAIL: "${{ inputs.email }}"
         GIT_TRACE: "${{ inputs.trace }}"
-        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -27,7 +27,9 @@ runs:
   steps:
     - if: ${{ inputs.token }}
       shell: bash
-      run: echo 'GITHUB_TOKEN=${{ inputs.token }}' >> $GITHUB_ENV
+      run: echo 'GITHUB_TOKEN=${{ env.GITHUB_TOKEN }}' >> $GITHUB_ENV
+      env:
+        GITHUB_TOKEN: "${{ inputs.token }}"
 
     - name: Setup git
       shell: bash


### PR DESCRIPTION
## What does this PR do?

Set GITHUB_TOKEN.

## Why is it important?

While migrated to EPHEMERAL tokens we stopped using `github-token` and the `GITHUB_TOKEN` was not configured... and the login didn't work.

This is the way we can use `setup-git`