### PR TITLE
feat(cluster-name): support oblt-cli with cluster-name flag

### DIFF
--- a/.github/actions/oblt-cli-create-ccs/README.md
+++ b/.github/actions/oblt-cli-create-ccs/README.md
@@ -39,6 +39,7 @@ Following inputs can be used as `step.with` keys
 | Name                        | Type    | Default                     | Description                        |
 |-----------------------------|---------|-----------------------------|------------------------------------|
 | `remote-cluster`            | String  | Mandatory                   | The Oblt cluster to use. |
+| `cluster-name`              | String  | Optional                    | The name of the cluster rather than a random one. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
 | `dry-run`                   | Boolean | `false`                     | Whether to dry-run the oblt-cli. |

--- a/.github/actions/oblt-cli-create-ccs/action.yml
+++ b/.github/actions/oblt-cli-create-ccs/action.yml
@@ -7,6 +7,9 @@ inputs:
   token:
     description: 'The GitHub access token.'
     required: true
+  cluster-name:
+    description: 'Name of the cluster if no a random one.'
+    required: false
   cluster-name-prefix:
     description: 'Prefix to be prepended to the randomised cluster name'
     required: false
@@ -40,6 +43,8 @@ runs:
       run: |
         {
           echo -n '--remote-cluster=${{ inputs.remote-cluster }} '
+          [ -n '${{ inputs.cluster-name }}' ] \
+            && echo -n '--cluster-name=${{ inputs.cluster-name }} '
           [ -n '${{ inputs.cluster-name-prefix }}' ] \
             && echo -n '--cluster-name-prefix=${{ inputs.cluster-name-prefix }} '
           [ -n '${{ inputs.cluster-name-suffix }}' ] \

--- a/.github/actions/oblt-cli-create-custom/README.md
+++ b/.github/actions/oblt-cli-create-custom/README.md
@@ -42,6 +42,7 @@ Following inputs can be used as `step.with` keys
 | `template`                  | String  | Mandatory                   | The Oblt cluster to use. |
 | `parameters`                | String  | Mandatory                   | Parameters values defined in JSON |
 | `token`                     | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
+| `cluster-name`              | String  | Optional                    | The name of the cluster rather than a random one. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
 | `skip-random-name`          | Boolean | `false`                      | Whether to skip the randomised cluster name |

--- a/.github/actions/oblt-cli-create-custom/action.yml
+++ b/.github/actions/oblt-cli-create-custom/action.yml
@@ -10,6 +10,9 @@ inputs:
   token:
     description: 'The GitHub access token.'
     required: true
+  cluster-name:
+    description: 'Name of the cluster if no a random one.'
+    required: false
   cluster-name-prefix:
     description: 'Prefix to be prepended to the randomised cluster name'
     required: false
@@ -72,6 +75,8 @@ runs:
       run: |
         {
           echo -n '--template=${{ inputs.template }} '
+          [ -n '${{ inputs.cluster-name }}' ] \
+            && echo -n '--cluster-name=${{ inputs.cluster-name }} '
           [ -n '${{ inputs.cluster-name-prefix }}' ] \
             && echo -n '--cluster-name-prefix=${{ inputs.cluster-name-prefix }} '
           [ -n '${{ inputs.cluster-name-suffix }}' ] \

--- a/.github/actions/oblt-cli-create-serverless/README.md
+++ b/.github/actions/oblt-cli-create-serverless/README.md
@@ -40,6 +40,7 @@ Following inputs can be used as `step.with` keys
 |-----------------------------|---------|-----------------------------|------------------------------------|
 | `target`                    | String  | `qa`                        | The target environment where to deploy the serverless cluster. |
 | `project-type`              | String  | `observability`             | The project type. |
+| `cluster-name`              | String  | Optional                    | The name of the cluster rather than a random one. |
 | `cluster-name-prefix`       | String  | Optional                    | Prefix to be prepended to the randomised cluster name |
 | `cluster-name-suffix`       | String  | Optional                    | Suffix to be appended to the randomised cluster name |
 | `dry-run`                   | Boolean | `false`                     | Whether to dry-run the oblt-cli. |

--- a/.github/actions/oblt-cli-create-serverless/action.yml
+++ b/.github/actions/oblt-cli-create-serverless/action.yml
@@ -1,6 +1,9 @@
 name: 'Oblt-cli create serverless'
 description: 'Run the oblt-cli wrapper to create a serverless cluster.'
 inputs:
+  cluster-name:
+    description: 'Name of the cluster if no a random one.'
+    required: false
   cluster-name-prefix:
     description: 'Prefix to be prepended to the randomised cluster name'
     required: false
@@ -49,6 +52,9 @@ runs:
           if (cluster_name_suffix != '') {
             core.exportVariable('CLUSTER_NAME_SUFFIX', `--cluster-name-suffix=${cluster_name_suffix}`)
           }
+          if (cluster_name != '') {
+            core.exportVariable('CLUSTER_NAME', `--cluster-name=${cluster_name}`)
+          }
           if (dry_run != 'false') {
             core.exportVariable('DRY_RUN', `--dry-run`)
           }
@@ -72,6 +78,7 @@ runs:
           console.log(`Create PARAMETERS env variable`)
           core.exportVariable('PARAMETERS', `--parameters='${(JSON.stringify(parameters))}'`)
       env:
+        cluster_name: ${{ inputs.cluster-name }}
         cluster_name_prefix: ${{ inputs.cluster-name-prefix }}
         cluster_name_suffix: ${{ inputs.cluster-name-suffix }}
         dry_run: ${{ inputs.dry-run }}
@@ -81,7 +88,7 @@ runs:
 
     - uses: elastic/apm-pipeline-library/.github/actions/oblt-cli@current
       with:
-        command: cluster create custom --template serverless ${{ env.DRY_RUN }} ${{ env.CLUSTER_NAME_PREFIX }} ${{ env.CLUSTER_NAME_SUFFIX }} ${{ env.PARAMETERS }}
+        command: cluster create custom --template serverless ${{ env.DRY_RUN }} ${{ env.CLUSTER_NAME_PREFIX }} ${{ env.CLUSTER_NAME_SUFFIX }} ${{ env.CLUSTER_NAME }} ${{ env.PARAMETERS }}
         slackChannel: ${{ inputs.slackChannel }}
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
## What does this PR do?

Add support for the `--cluster-name` when using the `oblt-cli`

## Why is it important?

Being able to fix the name of the ephemeral cluster, so the updates can work as expected.
