### PR TITLE
github-action: use the right contract for destroying PRs

### DIFF
--- a/.github/actions/undeploy-my-kibana/action.yml
+++ b/.github/actions/undeploy-my-kibana/action.yml
@@ -28,7 +28,7 @@ runs:
       if: contains(steps.is_elastic_member.outputs.result, 'true')
       run: |-
         cat <<EOT >> .body-content
-        ### Kibana branch
+        ### Kibana pull request
 
         ${{ env.PR }}
 


### PR DESCRIPTION
## What does this PR do?

Fixes the name of the header

## Why is it important?
Otherwise the automation won't work
## Related issues
Closes #ISSUE
