### PR TITLE
github-action: configure username for destroy cluster

### DIFF
--- a/.github/actions/oblt-cli-destroy-cluster/README.md
+++ b/.github/actions/oblt-cli-destroy-cluster/README.md
@@ -51,3 +51,4 @@ Following inputs can be used as `step.with` keys
 | `cluster-name `             | String  | Optional                    | The cluster name                                  |
 | `cluster-info-file `        | String  | Optional                    | The cluster info file (absolute path)             |
 | `github-token`              | String  | Mandatory                   | The GitHub token with permissions fetch releases. |
+| `username`                  | String  | `obltmachine`               | Username to show in the deployments with oblt-cli, format: [a-z0-9]. |

--- a/.github/actions/oblt-cli-destroy-cluster/action.yml
+++ b/.github/actions/oblt-cli-destroy-cluster/action.yml
@@ -10,6 +10,10 @@ inputs:
   github-token:
     description: 'The GitHub access token.'
     required: true
+  username:
+    description: 'Username to show in the deployments with oblt-cli, format: [a-z0-9]'
+    default: 'obltmachine'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -23,3 +27,4 @@ runs:
       with:
         command: cluster destroy --cluster-name "${{ steps.validation.outputs.cluster-name }}" --force
         token: ${{ inputs.github-token }}
+        username: ${{ inputs.username }}


### PR DESCRIPTION
## What does this PR do?

Configure username for destroy cluster

## Why is it important?

This will help consumers access their specific deployments

## Related issues
Closes #ISSUE
