### PR TITLE
jenkins: disable send telemetry data by default

### DIFF
--- a/.github/workflows/pytest_otel.yml
+++ b/.github/workflows/pytest_otel.yml
@@ -36,7 +36,7 @@ jobs:
         run: make -C resources/scripts/pytest_otel test
       - name: it-test
         run: make -C resources/scripts/pytest_otel it-test
-      - uses: actions/upload-artifact@v2  # upload test results
+      - uses: actions/upload-artifact@v4  # upload test results
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results

--- a/src/test/groovy/NotifyBuildResultStepTests.groovy
+++ b/src/test/groovy/NotifyBuildResultStepTests.groovy
@@ -64,7 +64,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
   @Test
   void testPullRequest() throws Exception {
     env.CHANGE_ID = "123"
-    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
+    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString(), sendTelemetry: true)
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
     assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 2))
@@ -85,7 +85,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     binding.getVariable('currentBuild').result = "SUCCESS"
     binding.getVariable('currentBuild').currentResult = "SUCCESS"
 
-    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
+    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString(), sendTelemetry: true)
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
     assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 2))
@@ -98,13 +98,12 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     script.call()
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
-    assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 2))
     assertFalse(assertMethodCallContainsPattern('log', 'notifyBuildResult: Notifying results by email.'))
   }
 
   @Test
   void testWithoutSecret() throws Exception {
-    script.call(es: EXAMPLE_URL)
+    script.call(es: EXAMPLE_URL, sendTelemetry: true)
     printCallStack()
     assertTrue(assertMethodCallOccurrences('getBuildInfoJsonFiles', 1))
     assertTrue(assertMethodCallOccurrences('sendDataToElasticsearch', 2))
@@ -121,7 +120,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     binding.getVariable('currentBuild').result = "SUCCESS"
     binding.getVariable('currentBuild').currentResult = "SUCCESS"
 
-    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
+    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString(), sendTelemetry: true)
     printCallStack()
 
     // Then senddata to ElasticSearch happens
@@ -336,7 +335,7 @@ class NotifyBuildResultStepTests extends ApmBasePipelineTest {
     // When PR and there is a builk file
     helper.registerAllowedMethod('isPR', { return true })
 
-    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString())
+    script.call(es: EXAMPLE_URL, secret: VaultSecret.SECRET_NAME.toString(), sendTelemetry: true)
     printCallStack()
 
     // Then sendDataToElasticsearch happens three times

--- a/vars/notifyBuildResult.txt
+++ b/vars/notifyBuildResult.txt
@@ -45,3 +45,4 @@ emails on Failed builds that are not pull request.
 * githubAssignees: What GitHub assignees to be added in the GitHub issue. Default value uses ``.
 * githubLabels: What GitHub labels to be added in the GitHub issue in addition to `automation,ci-reported`. Optional
 * githubTitle: What GitHub title to be added in the GitHub issue. Default: `Build ${env.BUILD_NUMBER} for ${env.BRANCH_NAME} with status '${buildStatus}'`.
+* sendTelemetry: Whether to ingest the CI data to Elasticsearch. Default value `false`


### PR DESCRIPTION
## What does this PR do?

Disable sending telemetry dta

## Why is it important?
Jenkins sunset, so we can decommission the infrastructure

## Related issues
Closes #ISSUE
