### PR TITLE
fix(buildkite): run cancelled step before tearing down the secret

### DIFF
--- a/.github/actions/buildkite/action.yml
+++ b/.github/actions/buildkite/action.yml
@@ -114,12 +114,6 @@ runs:
           path: ${{ inputs.artifactPath }}
           if-no-files-found: ${{ inputs.artifactIfNoFilesFound }}
 
-      - name: Reset environment
-        if: always()
-        shell: bash
-        run: |
-          echo "BUILDKITE_API_ACCESS_TOKEN=" >> $GITHUB_ENV
-
       - name: Cancel Buildkite pipeline
         if: cancelled() && inputs.waitFor && steps.trigger-buildkite.outputs.build_number
         run: |
@@ -129,3 +123,9 @@ runs:
             '${{ steps.trigger-buildkite.outputs.build_number }}' \
             '${{ env.BUILDKITE_API_ACCESS_TOKEN }}'
         shell: bash
+
+      - name: Reset environment
+        if: always()
+        shell: bash
+        run: |
+          echo "BUILDKITE_API_ACCESS_TOKEN=" >> $GITHUB_ENV


### PR DESCRIPTION
## What does this PR do?

Run cancel event before cleaning up the secrets

## Why is it important?

Otherwise, cancel won't work
