### PR TITLE
ci: use updatecli with github secrets

### DIFF
--- a/.github/workflows/bump-aliases.yml
+++ b/.github/workflows/bump-aliases.yml
@@ -16,10 +16,23 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@main
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
+
+      - name: Run Updatecli in Dry Run mode
+        run: updatecli diff
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
+      - name: Run Updatecli in Apply mode
+        run: updatecli apply --config updatecli/updatecli.d/bump-aliases.yml --values updatecli/values.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
+      - if: ${{ failure()  }}
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: ./updatecli/updatecli.d/bump-aliases.yml
-          values: ./updatecli/values.yml
+          channel-id: '#observablt-bots'
+          payload: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bump-aliases.yml
+++ b/.github/workflows/bump-aliases.yml
@@ -16,18 +16,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
-
-      - name: Run Updatecli in Apply mode
-        run: updatecli apply --config updatecli/updatecli.d/bump-aliases.yml --values updatecli/values.yml
+      - uses: elastic/oblt-actions/updatecli/run-and-notify@main
+        with:
+          command: apply --config updatecli/updatecli.d/bump-aliases.yml --values updatecli/values.yml
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: "#observablt-bots"
+          slack-message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+          slack-send-when: 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
-
-      - if: ${{ failure()  }}
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-        with:
-          channel-id: '#observablt-bots'
-          payload: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bump-aliases.yml
+++ b/.github/workflows/bump-aliases.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: elastic/oblt-actions/updatecli/run-and-notify@main
+      - uses: elastic/oblt-actions/updatecli/run-and-notify@v1
         with:
           command: apply --config updatecli/updatecli.d/bump-aliases.yml --values updatecli/values.yml
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bump-aliases.yml
+++ b/.github/workflows/bump-aliases.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
 
-      - name: Run Updatecli in Dry Run mode
-        run: updatecli diff
-        env:
-          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
-
       - name: Run Updatecli in Apply mode
         run: updatecli apply --config updatecli/updatecli.d/bump-aliases.yml --values updatecli/values.yml
         env:

--- a/updatecli/updatecli.d/bump-aliases.yml
+++ b/updatecli/updatecli.d/bump-aliases.yml
@@ -15,12 +15,11 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
 
 sources:
@@ -33,7 +32,7 @@ sources:
       owner: elastic
       repository: elasticsearch
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: regex
         pattern: v7\.17\.\d+$
@@ -47,7 +46,7 @@ sources:
       owner: elastic
       repository: elasticsearch
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: regex
         pattern: v8\.\d+\.\d+$


### PR DESCRIPTION
## What does this PR do?

Use GitHub secrets for the updatecli integration with Slack notifications.

Use https://github.com/elastic/oblt-actions/tree/main/updatecli/run-and-notify

## Why is it important?

Secure
