### PR TITLE
await-maven-artifact check redirect

### DIFF
--- a/.github/actions/await-maven-artifact/action.yml
+++ b/.github/actions/await-maven-artifact/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         full_url="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=${{ inputs.groupid }}&a=${{ inputs.artifactid }}&v=${{ inputs.version }}"
-        until curl -fs "${full_url}" > /dev/null
+        until curl -fs -I -L "${full_url}" > /dev/null
         do
           echo "Artifact '${{ inputs.groupid }}:${{ inputs.artifactid }}:${{ inputs.version }}' not found on maven central. Sleeping 30 seconds, retrying afterwards"
           sleep 30s


### PR DESCRIPTION
## What does this PR do?

The publication on maven central may publish

This happened at least once during the following release execution: https://github.com/elastic/apm-agent-java/actions/runs/9266640000/attempts/1 where the AWS lambda layer could not be built as the artifact was missing.

However, in this case it seemed that the redirect may have worked as the `pom` was properly published (which I assume is used to properly redirect), but not the `.jar` file.

This PR does two things:
- use `-L` to follow the redirect link
- use `-I` to not download the artifact file but just print the HTTP response headers

## Why is it important?

This makes the release process more robust and actually checks that the artifact is accessible and can be downloaded, rather than assuming that it is when we get a non 404 response.
