### PR TITLE
Add slack notifications to generate-elastic-stack-* workflows

### DIFF
--- a/.github/workflows/generate-elastic-stack-releases.yml
+++ b/.github/workflows/generate-elastic-stack-releases.yml
@@ -57,10 +57,8 @@ jobs:
         run: echo "${{ steps.upload-file.outputs.uploaded }}"
 
       - if: ${{ failure() }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: '#observablt-bots'
-          message: ":traffic_cone: generate-elastic-stack-releases failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#observablt-bots"
+          message: ":traffic_cone: generate-elastic-stack-releases failed for `${{ github.repository }}@${{ github.ref_name }}`, <!subteam^S03HM5G8CH0> please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/generate-elastic-stack-snapshots.yml
+++ b/.github/workflows/generate-elastic-stack-snapshots.yml
@@ -44,3 +44,10 @@ jobs:
 
       - name: debug
         run: echo "${{ steps.upload-file.outputs.uploaded }}"
+
+      - if: ${{ failure() }}
+        uses: elastic/oblt-actions/slack/notify-result@v1
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#observablt-bots"
+          message: ":traffic_cone: generate-elastic-stack-snapshots failed for `${{ github.repository }}@${{ github.ref_name }}`, <!subteam^S03HM5G8CH0> please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"


### PR DESCRIPTION
## What does this PR do?

The following workflows have been failing for a week, and we did not get notified.

- https://github.com/elastic/apm-pipeline-library/actions/workflows/generate-elastic-stack-releases.yml
- https://github.com/elastic/apm-pipeline-library/actions/workflows/generate-elastic-stack-snapshots.yml

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

## Related issues
Closes #ISSUE
